### PR TITLE
Add html decoder for separator entities

### DIFF
--- a/composites/OnboardingWizard/components/Choice.js
+++ b/composites/OnboardingWizard/components/Choice.js
@@ -1,6 +1,7 @@
 import React from "react";
-import Input from '../../../forms/Input';
-import Label from '../../../forms/Label';
+import Input from "../../../forms/Input";
+import Label from "../../../forms/Label";
+import htmlDecoder from "../helpers/htmlDecoder";
 
 /**
  * Represents a choice interface, like a group of radio buttons or a select button. Initially it should render a
@@ -28,7 +29,7 @@ const Choice = ( props ) => {
 						<Input name={fieldName} type="radio" label={choice.label} onChange={props.onChange}
 						       value={choiceName} optionalAttributes={{ id, checked }}
 						/>
-						<Label for={id}>{choice.label}</Label>
+						<Label for={id}>{htmlDecoder(choice.label)}</Label>
 					</div>
 				);
 			} )}

--- a/composites/OnboardingWizard/config/production-config.js
+++ b/composites/OnboardingWizard/config/production-config.js
@@ -280,15 +280,15 @@ let configuration = {
 						"screenReaderText": "Left angle quotation mark",
 					},
 					"raquo": {
-						"label": "»",
+						"label": "&raquo;",
 						"screenReaderText": "Right angle quotation mark",
 					},
 					"lt": {
-						"label": "<",
+						"label": "&lt;",
 						"screenReaderText": "Less than sign",
 					},
 					"gt": {
-						"label": ">",
+						"label": "&gt;",
 						"screenReaderText": "Greater than sign",
 					},
 				},

--- a/composites/OnboardingWizard/helpers/htmlDecoder.js
+++ b/composites/OnboardingWizard/helpers/htmlDecoder.js
@@ -1,3 +1,9 @@
+/**
+ * @summary Converts HTML entities to the actual symbols.
+ *
+ * @param htmlText The HTML text.
+ * @returns {string} The string with converted HTML entities.
+ */
 let decodeHTML = ( htmlText ) => {
 	var txt = document.createElement( "textarea" );
 	txt.innerHTML = htmlText;

--- a/composites/OnboardingWizard/helpers/htmlDecoder.js
+++ b/composites/OnboardingWizard/helpers/htmlDecoder.js
@@ -1,6 +1,8 @@
 /**
  * @summary Converts HTML entities to the actual symbols.
  *
+ * Source: http://stackoverflow.com/questions/3700326/decode-amp-back-to-in-javascript
+ *
  * @param htmlText The HTML text.
  * @returns {string} The string with converted HTML entities.
  */

--- a/composites/OnboardingWizard/helpers/htmlDecoder.js
+++ b/composites/OnboardingWizard/helpers/htmlDecoder.js
@@ -1,0 +1,7 @@
+let decodeHTML = ( htmlText ) => {
+	var txt = document.createElement( "textarea" );
+	txt.innerHTML = htmlText;
+	return txt.value;
+};
+
+export default decodeHTML;


### PR DESCRIPTION
Separators are stored as html entities in the config. For this a HTML decoder is added. This translates the entities back to their symbols.