### PR TITLE
Change conditionalTextField to conditionalInput

### DIFF
--- a/composites/OnboardingWizard/Step.js
+++ b/composites/OnboardingWizard/Step.js
@@ -181,7 +181,7 @@ class Step extends React.Component {
 			Object.assign( props, choiceFieldProperties );
 		}
 
-		if ( componentType === "ConditionalTextField" ) {
+		if ( componentType === "ConditionalInput" ) {
 			let fieldValues = this.state.fieldValues;
 			let requiredFieldValue = fieldValues[ this.props.currentStep ][ currentField.requires.field ];
 			Object.assign( props, {

--- a/composites/OnboardingWizard/config/production-config.js
+++ b/composites/OnboardingWizard/config/production-config.js
@@ -99,7 +99,7 @@ let configuration = {
 			"data": "",
 		},
 		"personPublishingEntity": {
-			"componentName": "ConditionalTextField",
+			"componentName": "ConditionalInput",
 			"properties": {
 				"label": "Your name:",
 				"pattern": "*",
@@ -110,7 +110,7 @@ let configuration = {
 			}
 		},
 		"businessPublishingEntity": {
-			"componentName": "ConditionalTextField",
+			"componentName": "ConditionalInput",
 			"properties": {
 				"label": "The company name:",
 				"pattern": "*",

--- a/forms/composites/ConditionalTextField.js
+++ b/forms/composites/ConditionalTextField.js
@@ -53,7 +53,7 @@ ConditionalTextfield.propTypes = {
 	requires: React.PropTypes.shape( {
 		field: React.PropTypes.string.required,
 		value: React.PropTypes.string.required,
-	} ),
+	} ).required,
 	requiredFieldValue: React.PropTypes.string,
 };
 


### PR DESCRIPTION
To make the conditional text field work with the WP back-end the conditionalTextField is renamed to conditionalInput.

Testing:
1. Start the application
2. Go to step 4 and see if the radio buttons load.
3. Click the radio buttons and see if the conditional fields render.