### PR TITLE
Add default props for Textfield

### DIFF
--- a/forms/composites/ConditionalTextField.js
+++ b/forms/composites/ConditionalTextField.js
@@ -50,10 +50,7 @@ class ConditionalTextfield extends TextField {
  * @type {{requires: {object}, requiredFieldValue: string}}
  */
 ConditionalTextfield.propTypes = {
-	requires: React.PropTypes.shape( {
-		field: React.PropTypes.string.required,
-		value: React.PropTypes.string.required,
-	} ).required,
+	requires: React.PropTypes.object,
 	requiredFieldValue: React.PropTypes.string,
 };
 

--- a/forms/composites/ConditionalTextField.js
+++ b/forms/composites/ConditionalTextField.js
@@ -50,10 +50,7 @@ class ConditionalTextfield extends TextField {
  * @type {{requires: {object}, requiredFieldValue: string}}
  */
 ConditionalTextfield.propTypes = {
-	requires: React.PropTypes.shape( {
-		field: React.PropTypes.string.required,
-		value: React.PropTypes.string.required,
-	} ).required,
+	requires: React.PropTypes.requires,
 	requiredFieldValue: React.PropTypes.string,
 };
 

--- a/forms/composites/ConditionalTextField.js
+++ b/forms/composites/ConditionalTextField.js
@@ -50,7 +50,10 @@ class ConditionalTextfield extends TextField {
  * @type {{requires: {object}, requiredFieldValue: string}}
  */
 ConditionalTextfield.propTypes = {
-	requires: React.PropTypes.requires,
+	requires: React.PropTypes.shape( {
+		field: React.PropTypes.string.required,
+		value: React.PropTypes.string.required,
+	} ).required,
 	requiredFieldValue: React.PropTypes.string,
 };
 

--- a/forms/composites/Textfield.js
+++ b/forms/composites/Textfield.js
@@ -99,9 +99,4 @@ Textfield.propTypes = {
 	multiline: React.PropTypes.bool,
 };
 
-TextField.defaultProps = {
-	optionalAttributes: {},
-	multiline: false,
-};
-
 export default Textfield;

--- a/forms/composites/Textfield.js
+++ b/forms/composites/Textfield.js
@@ -99,4 +99,9 @@ Textfield.propTypes = {
 	multiline: React.PropTypes.bool,
 };
 
+Textfield.defaultProps = {
+	optionalAttributes: {},
+	multiline: false,
+};
+
 export default Textfield;

--- a/forms/composites/Textfield.js
+++ b/forms/composites/Textfield.js
@@ -99,4 +99,9 @@ Textfield.propTypes = {
 	multiline: React.PropTypes.bool,
 };
 
+TextField.defaultProps = {
+	optionalAttributes: {},
+	multiline: false,
+};
+
 export default Textfield;


### PR DESCRIPTION
The component crashed when leaving out not required values. To prevent this, default values are set for the optional props.

Also using a shape for the requires prop type in the ConditionalTextField made the application throw wrong warnings. Changed this to a required object instead of shape.