### PR TITLE
Added a missing peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
     "webpack": "^1.13.1",
     "webpack-dev-server": "^1.14.1"
   },
+  "peerDependencies": {
+    "react-tap-event-plugin": "^1.0.0"
+  },
   "browserify": {
     "transform": [
       "babelify"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "webpack-dev-server": "^1.14.1"
   },
   "peerDependencies": {
-    "react-tap-event-plugin": "^1.0.0"
+    "react-tap-event-plugin": "^1.0.0",
+    "material-ui": "^0.15.4"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
This ensures that any implementation of `yoast-components` won't be missing particular dependencies that need to be installed by the party implementing one (or more) of our components.