### PR TITLE
Fix keys not unique for input components.

### DIFF
--- a/composites/OnboardingWizard/Step.js
+++ b/composites/OnboardingWizard/Step.js
@@ -138,7 +138,8 @@ class Step extends React.Component {
 				return null;
 			}
 
-			let fieldProps = this.getFieldProps( currentField.componentName, key, name, currentField );
+			let fieldKey = `${this.state.currentStep}-${key}`;
+			let fieldProps = this.getFieldProps( currentField.componentName, fieldKey, name, currentField );
 
 			return React.createElement( this.components[ currentField.componentName ], fieldProps );
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "i18n-calypso": "^1.6.2",
     "material-ui": "^0.15.2",
-    "react": "15.3.0",
-    "react-dom": "15.3.0",
+    "react": "^15.3.1",
+    "react-dom": "^15.3.1",
     "react-tap-event-plugin": "^1.0.0",
     "whatwg-fetch": "^1.0.0"
   },


### PR DESCRIPTION
The input fields did not get unique keys in React. This caused some fields to get the value from another field when a step is re-rendered.

This also fixes the problem with the radio buttons from react 15.3.1, so the React version in the package is also set to 15.3.1.

Testing:
1. Start the wizard and go to step 4.
2. Fill in some text in the textfield.
3. Go to the next step and see if no input fields in that step have the value from the previous step.

Also test the radio buttons.