### PR TITLE
Navigation buttons behaviour and text update.

### DIFF
--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -209,7 +209,10 @@ class OnboardingWizard extends React.Component {
 		let hideButton = false;
 
 		if ( type === "next" && ! currentStep.next ) {
-			attributes.label = "Close"
+			attributes.label = "Close";
+			attributes.onClick = () => {
+				history.go(-1);
+			}
 		}
 		if ( type === "previous" && ! currentStep.previous ) {
 			hideButton = true;

--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -208,9 +208,10 @@ class OnboardingWizard extends React.Component {
 	getNavigationbutton(type, attributes, currentStep, className){
 		let hideButton = false;
 
-		if ( (type === "next" && ! currentStep.next) ||
-		     (type === "previous" && ! currentStep.previous)
-		) {
+		if ( type === "next" && ! currentStep.next ) {
+			attributes.label = "Close"
+		}
+		if ( type === "previous" && ! currentStep.previous ) {
 			hideButton = true;
 		}
 
@@ -234,7 +235,7 @@ class OnboardingWizard extends React.Component {
 		}, step, "yoast-wizard--button yoast-wizard--button__previous");
 
 		let nextButton = this.getNavigationbutton("next", {
-			label: "Next",
+			label: "Continue",
 			primary: true,
 			onClick: this.setNextStep.bind( this ),
 		}, step, "yoast-wizard--button yoast-wizard--button__next");


### PR DESCRIPTION
The label for the next button is renamed to ‘continue’ and on the last page to ‘close’. The close button redirects to the previous page.

Fixes https://github.com/Yoast/wordpress-seo/issues/5576