### PR TITLE
Set finish url to go to when wizard has been finished

### DIFF
--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -211,6 +211,12 @@ class OnboardingWizard extends React.Component {
 		if ( type === "next" && ! currentStep.next ) {
 			attributes.label = "Close";
 			attributes.onClick = () => {
+				if( this.props.finishUrl !== '' ) {
+					window.location.href = this.props.finishUrl;
+
+					return;
+				}
+
 				history.go(-1);
 			}
 		}
@@ -275,10 +281,12 @@ OnboardingWizard.propTypes = {
 	steps: React.PropTypes.object.isRequired,
 	fields: React.PropTypes.object.isRequired,
 	customComponents: React.PropTypes.object,
+	finishUrl: React.PropTypes.string,
 };
 
 OnboardingWizard.defaultProps = {
 	customComponents: {},
+	finishUrl: ''
 };
 
 export default OnboardingWizard;

--- a/composites/OnboardingWizard/config/production-config.js
+++ b/composites/OnboardingWizard/config/production-config.js
@@ -4,6 +4,7 @@ import PostTypeVisibility from "../components/custom_components/PostTypeVisibili
 import ConnectGoogleSearchConsole from "../components/custom_components/ConnectGoogleSearchConsole"
 
 let configuration = {
+	'finishUrl' : '',
 	"endpoint": "http://127.0.0.1:8882/onboarding?wp_nonce=nonce",
 	"customComponents": {
 		MailchimpSignup, PublishingEntity, PostTypeVisibility, ConnectGoogleSearchConsole,


### PR DESCRIPTION
Use a finish url in the config. When pressing the close button in the wizard, this url is used to navigate to.