### PR TITLE
Step buttons a11y improvements

### DIFF
--- a/composites/OnboardingWizard/StepButton.js
+++ b/composites/OnboardingWizard/StepButton.js
@@ -15,7 +15,7 @@ import SvgIcon from 'material-ui/SvgIcon';
  */
 const StepButton = ( props ) => (
 	<IconButton className={props.className} onClick={props.onClick} tooltip={props.tooltip} touch={true}
-	            tooltipPosition="top-center">
+	            tooltipPosition="top-center" aria-label={props.ariaLabel}>
 		<SvgIcon color="rgb(114, 119, 124)">
 			<circle cx="12" cy="12" r="10"/>
 			<text x="12" y="16" textAnchor="middle" fontSize="12" fill="#fff">

--- a/composites/OnboardingWizard/StepButton.js
+++ b/composites/OnboardingWizard/StepButton.js
@@ -15,7 +15,7 @@ import SvgIcon from 'material-ui/SvgIcon';
  */
 const StepButton = ( props ) => (
 	<IconButton className={props.className} onClick={props.onClick} tooltip={props.tooltip} touch={true}
-	            tooltipPosition="top-center" aria-label={props.ariaLabel}>
+	            tooltipPosition="top-center" tooltipStyles={props.tooltipStyles} aria-label={props.ariaLabel}>
 		<SvgIcon color="rgb(114, 119, 124)">
 			<circle cx="12" cy="12" r="10"/>
 			<text x="12" y="16" textAnchor="middle" fontSize="12" fill="#fff">

--- a/composites/OnboardingWizard/StepIndicator.js
+++ b/composites/OnboardingWizard/StepIndicator.js
@@ -1,6 +1,7 @@
 import React from "react";
 import CustomStepButton from "./StepButton";
 import {Stepper, Step, StepButton} from 'material-ui/Stepper';
+import { localize } from "../../utils/i18n";
 
 /**
  * The step indicator displays a horizontal progress indicator.
@@ -41,11 +42,16 @@ class StepIndicator extends React.Component {
 
 		return keys.map( ( name, key ) => {
 			var currentField = this.props.steps[ name ];
+			let stepNumber = key.valueOf() + 1;
+			/* %1$d expands to the number of the step, %2$s expands to the name of the step */
+			let ariaLabel = this.props.translate( 'Step %1$d: %2$s' );
+			ariaLabel = ariaLabel.replace( '%1$d', stepNumber ).replace( '%2$s', currentField.title );
 
 			if ( key === this.state.stepIndex ) {
 				button = React.createElement( StepButton, {
 					key: "step-indicator-" + key,
 					className: "yoast-wizard--step yoast-wizard--step__active",
+					"aria-label": ariaLabel,
 				}, currentField.title );
 			}
 			// Return a custom step button, without a label for non-active steps.
@@ -53,8 +59,9 @@ class StepIndicator extends React.Component {
 				let className = this.getStepButtonClass( key, amountOfSteps );
 
 				button = new CustomStepButton( {
-					index: key.valueOf() + 1,
+					index: stepNumber,
 					tooltip: currentField.title,
+					ariaLabel: ariaLabel,
 					className,
 					onClick: () => {
 						this.props.onClick( name )
@@ -108,4 +115,4 @@ StepIndicator.defaultProps = {
 	stepIndex: 0,
 };
 
-export default StepIndicator;
+export default localize( StepIndicator );

--- a/composites/OnboardingWizard/StepIndicator.js
+++ b/composites/OnboardingWizard/StepIndicator.js
@@ -63,6 +63,10 @@ class StepIndicator extends React.Component {
 					tooltip: currentField.title,
 					ariaLabel: ariaLabel,
 					className,
+					// See github.com/Yoast/wordpress-seo/issues/5530.
+					tooltipStyles: {
+						userSelect: "auto",
+					},
 					onClick: () => {
 						this.props.onClick( name )
 					},


### PR DESCRIPTION
Fixes #77 

- adds an `aria-label` on the step buttons with a translatable string to announce, for example: `Step 4: Company or person`
- reset the `user-select: none` CSS property to `auto` on the inactive buttons tooltips since this causes a weird bug on Safari+VoiceOver, see https://github.com/Yoast/wordpress-seo/issues/5530

Screenshots using VoiceOver:

![screen shot 2016-09-15 at 15 04 24](https://cloud.githubusercontent.com/assets/1682452/18552744/161361f4-7b5e-11e6-95b4-654b99ee5424.png)

![screen shot 2016-09-15 at 15 04 29](https://cloud.githubusercontent.com/assets/1682452/18552743/15f9b9fc-7b5e-11e6-9a39-47cae414a75a.png)