### PR TITLE
Add screen reader text for choice component

### DIFF
--- a/composites/OnboardingWizard/components/Choice.js
+++ b/composites/OnboardingWizard/components/Choice.js
@@ -30,7 +30,7 @@ const Choice = ( props ) => {
 						<Input name={fieldName} type="radio" label={choice.label} onChange={props.onChange}
 						       value={choiceName} optionalAttributes={{ id, checked }}
 						/>
-						<Label for={id}>{htmlDecoder(choice.label)}</Label>
+						<Label for={id} optionalAttributes={{"aria-label" : choice.screenReaderText}}>{htmlDecoder(choice.label)} </Label>
 					</div>
 				);
 			} )}

--- a/forms/Label.js
+++ b/forms/Label.js
@@ -8,7 +8,6 @@ import React from "react";
  * @constructor
  */
 const Label = ( props ) => {
-	console.log(props);
 	return (
 		<label htmlFor={props.for} {...props.optionalAttributes}>{props.children}</label>
 	);
@@ -22,7 +21,7 @@ const Label = ( props ) => {
 Label.propTypes = {
 	"for": React.PropTypes.string.isRequired,
 	optionalAttributes: React.PropTypes.shape( {
-		"aria-label" : React.PropTypes.string,
+		"aria-label": React.PropTypes.string,
 		onClick: React.PropTypes.func,
 		className: React.PropTypes.string,
 	} ),

--- a/forms/Label.js
+++ b/forms/Label.js
@@ -8,6 +8,7 @@ import React from "react";
  * @constructor
  */
 const Label = ( props ) => {
+	console.log(props);
 	return (
 		<label htmlFor={props.for} {...props.optionalAttributes}>{props.children}</label>
 	);
@@ -21,6 +22,7 @@ const Label = ( props ) => {
 Label.propTypes = {
 	"for": React.PropTypes.string.isRequired,
 	optionalAttributes: React.PropTypes.shape( {
+		"aria-label" : React.PropTypes.string,
 		onClick: React.PropTypes.func,
 		className: React.PropTypes.string,
 	} ),


### PR DESCRIPTION
## Summary
The title separators are choice components. The special thing about this is that they contain a symbol and not text for a choice. The screen reader does not always give a good description for these symbols.

A solution for this is needed.

This PR can be summarized in the following change-log entry:
- Add more descriptive screen reader texts for choosing title separators.

## Relevant technical choices:
Normally a label is sufficient for a screen reader, but now the labels contain symbols. The symbols are not always pronounced correctly. To override the default(visible) label content an aria-label is added. This replaces the symbol that the label contains with a more descriptive text for the screen reader. 
*

## Test instructions

This PR can be tested by following these steps:
- Go to step 9 'title separators' in the wizard.
- Inspect the separators and see if the labels have an 'aria-label' property.
- Enable the screen reader (CMD+F5) and see(or actually hear) if the screen reader reads the aria label instead of the actual label, it works correctly. You can test this with the vertical bar, by default 'vertical line' is read, but when the aria-label works 'vertical bar' is read.

*
Fixes https://github.com/Yoast/wordpress-seo/issues/5608