### PR TITLE
Set text input max-width to 450px

### DIFF
--- a/composites/OnboardingWizard/onboarding-wizard.scss
+++ b/composites/OnboardingWizard/onboarding-wizard.scss
@@ -156,7 +156,7 @@ body {
 
     &-field {
       width: 100%;
-      max-width: 300px;
+      max-width: 450px;
       box-sizing: border-box;
     }
   }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
- Bigger max-width for text input fields.

## Relevant technical choices:
This change is done based on this issue: https://github.com/Yoast/wordpress-seo/issues/5565

## Test instructions

This PR can be tested by following these steps:
1. Start yoast-components from the release branch. 
2. Switch to the RW/bigger-textinput-width branch and build the css.
3. See if the text input is bigger.
4. Also switch to responsive mode and see if the input fields are shown correctly with smaller screens.

https://github.com/Yoast/wordpress-seo/issues/5565
