### PR TITLE
Convert html entities for choice and text area input fields

### DIFF
--- a/composites/OnboardingWizard/components/Choice.js
+++ b/composites/OnboardingWizard/components/Choice.js
@@ -39,7 +39,7 @@ const Choice = ( props ) => {
 
 	return (
 		<div className={props.className}>
-			<p className="yoast-wizard-field-description">{props.properties.label}</p>
+			<p className="yoast-wizard-field-description">{htmlDecoder(props.properties.label)}</p>
 			{fieldSet()}
 			<Explanation text={props.properties.explanation}/>
 		</div>

--- a/forms/Label.js
+++ b/forms/Label.js
@@ -1,4 +1,5 @@
 import React from "react";
+import htmlDecoder from "../composites/OnboardingWizard/helpers/htmlDecoder";
 
 /**
  * Represents the label HTML tag.
@@ -8,8 +9,27 @@ import React from "react";
  * @constructor
  */
 const Label = ( props ) => {
+
+	/**
+	 * Check if the label should contain a string or JSX.Elements
+	 * and converts the HTML entities if it is a string.
+	 *
+	 * @param children The children(inner elements) for the label.
+	 *
+	 * @returns {string|JSX.Elements} String with converted HTML entities
+	 *                                or the unconverted JSX.Element(s).
+	 */
+	let decodeText = function ( children ) {
+		if ( typeof children === "string" ) {
+			return htmlDecoder( children );
+		}
+		return children;
+	};
+
+	let innerElements = decodeText(props.children);
+
 	return (
-		<label htmlFor={props.for} {...props.optionalAttributes}>{props.children}</label>
+		<label htmlFor={props.for} {...props.optionalAttributes}>{innerElements}</label>
 	);
 };
 

--- a/forms/Label.js
+++ b/forms/Label.js
@@ -9,24 +9,22 @@ import htmlDecoder from "../composites/OnboardingWizard/helpers/htmlDecoder";
  * @constructor
  */
 const Label = ( props ) => {
-
 	/**
 	 * Check if the label should contain a string or JSX.Elements
 	 * and converts the HTML entities if it is a string.
 	 *
-	 * @param children The children(inner elements) for the label.
+	 * @param {string|JSX.Element} children The children(inner elements) for the label.
 	 *
-	 * @returns {string|JSX.Elements} String with converted HTML entities
+	 * @returns {string|JSX.Element} String with converted HTML entities
 	 *                                or the unconverted JSX.Element(s).
 	 */
-	let decodeText = function ( children ) {
+	let decodeText = function( children ) {
 		if ( typeof children === "string" ) {
 			return htmlDecoder( children );
 		}
 		return children;
 	};
-
-	let innerElements = decodeText(props.children);
+	let innerElements = decodeText( props.children );
 
 	return (
 		<label htmlFor={props.for} {...props.optionalAttributes}>{innerElements}</label>

--- a/forms/tests/labelTest.js
+++ b/forms/tests/labelTest.js
@@ -1,4 +1,5 @@
 jest.unmock("../Label");
+jest.unmock("../../composites/OnboardingWizard/helpers/htmlDecoder");
 
 import React from "react";
 import TestUtils from "react-addons-test-utils";


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
The labels for Choice input fields like radio buttons did not decode the HTML entities back to their original symbol.

## Relevant technical choices:
- Decoded the strings for the labels with the htmlDecoder helper.
- The generic component TextArea that is used for Input type fields in the wizard only decodes the HTML if a string is passed as children. Not if JSX.Elements are passed as children.

## Test instructions
1. Add a HTML entity to the label of a radio field. This can be done in the getFieldProps function in the Step component. The label for a Choice element is defined in the props.properties.label variable.
2. Check if the symbol is displayed as the label for the choice component and not the HTML entity.
This PR can be tested by following these steps:

Fixes https://github.com/Yoast/wordpress-seo/issues/5613