### PR TITLE
CSS selector to target all the input text fields.

### DIFF
--- a/composites/OnboardingWizard/onboarding-wizard.scss
+++ b/composites/OnboardingWizard/onboarding-wizard.scss
@@ -221,7 +221,7 @@ a:focus {
       font-weight: bold;
     }
 
-    &-field {
+    [type="text"] {
       width: 100%;
       max-width: 450px;
       box-sizing: border-box;


### PR DESCRIPTION
Fixes #96 

Uses 
`.yoast-wizard-text-input [type="text"]`
instead of
`.yoast-wizard-text-input-field`

to target any text input field inside its container, regardless of the input CSS class.