### PR TITLE
Select added as an option to the Choice component + plus a little bugfix

### DIFF
--- a/composites/OnboardingWizard/Step.js
+++ b/composites/OnboardingWizard/Step.js
@@ -134,7 +134,7 @@ class Step extends React.Component {
 				return null;
 			}
 
-			let fieldKey = `${this.state.currentStep}-${key}`;
+			let fieldKey = `${this.state.currentStep}-${name}`;
 			let fieldProps = this.getFieldProps( currentField.componentName, fieldKey, name, currentField );
 
 			return React.createElement( this.components[ currentField.componentName ], fieldProps );

--- a/composites/OnboardingWizard/Step.js
+++ b/composites/OnboardingWizard/Step.js
@@ -125,7 +125,7 @@ class Step extends React.Component {
 
 		keys = this.filterConditonalFields( keys, fields );
 
-		return keys.map( ( name, key ) => {
+		return keys.map( ( name ) => {
 			let currentField = fields[ name ];
 
 			if ( typeof this.components[ currentField.componentName ] === "undefined" ||

--- a/composites/OnboardingWizard/components/Choice.js
+++ b/composites/OnboardingWizard/components/Choice.js
@@ -20,9 +20,10 @@ const Choice = ( props ) => {
 
 	let fieldSet = () => {
 		let choiceName;
+		let field;
 
 		if ( type === "select" ) {
-			return (
+			field =
 				<fieldset className={"yoast-wizard-input-select-" + fieldName}>
 					<select defaultValue={props.value} name={fieldName}
 					        className={props.optionClassName + " " + choiceName} onChange={props.onChange}>
@@ -37,11 +38,9 @@ const Choice = ( props ) => {
 						} )}
 					</select>
 				</fieldset>
-			);
-		}
-
-		if ( type === "radio" ) {
-			return (
+			;
+		} else {
+			field =
 				<fieldset className={"yoast-wizard-input-radio-" + fieldName}>
 					{fieldKeys.map( ( choiceName, index ) => {
 						let choice = choices[ choiceName ];
@@ -60,8 +59,10 @@ const Choice = ( props ) => {
 						);
 					} )}
 				</fieldset>
-			);
+			;
 		}
+
+		return field;
 	};
 
 	return (

--- a/composites/OnboardingWizard/components/Choice.js
+++ b/composites/OnboardingWizard/components/Choice.js
@@ -16,26 +16,54 @@ const Choice = ( props ) => {
 	let choices = props.properties.choices;
 	let fieldKeys = Object.keys( choices );
 	let fieldName = props.name;
+	let type = props.properties.type;
 
-	let fieldSet  = () => {
-		return <fieldset className={"yoast-wizard-input-radio-" + fieldName}>
-			{fieldKeys.map( ( choiceName, index ) => {
-				let choice = choices[ choiceName ];
-				let id = `${fieldName}-${index}`;
-				// If the value for the choice field equals the name for this choice, the choice is checked.
-				let checked = ( props.value === choiceName );
+    let fieldSet  = () => {
 
-				return (
-					<div className={props.optionClassName + " " + choiceName} key={index}>
-						<Input name={fieldName} type="radio" label={choice.label} onChange={props.onChange}
-						       value={choiceName} optionalAttributes={{ id, checked }}
-						/>
-						<Label for={id} optionalAttributes={{ "aria-label": choice.screenReaderText }}>{htmlDecoder( choice.label )} </Label>
-					</div>
-				);
-			} )}
-		</fieldset>;
-	};
+        let choiceName;
+        let index;
+
+        if ( type == "select" ) {
+
+            return (
+                <fieldset className={"yoast-wizard-input-select-" + fieldName}>
+                    <select defaultValue={props.value} name={fieldName} className={props.optionClassName + " " + choiceName} onChange={props.onChange}>
+                        {fieldKeys.map( ( choiceName, index ) => {
+                            let choice = choices[ choiceName ];
+                            let id = `${fieldName}-${index}`;
+
+                            return (
+                                <option value={choiceName} key={index} >
+                                    {htmlDecoder( choice.label )}
+                                </option>
+                            );
+                        } )}
+                    </select>
+                </fieldset>
+            );
+
+        } else {
+            return (
+                <fieldset className={"yoast-wizard-input-radio-" + fieldName}>
+                    {fieldKeys.map( ( choiceName, index ) => {
+                        let choice = choices[ choiceName ];
+                        let id = `${fieldName}-${index}`;
+                        // If the value for the choice field equals the name for this choice, the choice is checked.
+                        let checked = ( props.value === choiceName );
+
+                        return (
+                            <div className={props.optionClassName + " " + choiceName} key={index}>
+                                <Input name={fieldName} type="radio" label={choice.label} onChange={props.onChange}
+                                       value={choiceName} optionalAttributes={{ id, checked }}
+                                />
+                                <Label for={id} optionalAttributes={{ "aria-label": choice.screenReaderText }}>{htmlDecoder( choice.label )}</Label>
+                            </div>
+                        );
+                    } )}
+                </fieldset>
+            );
+        }
+    };
 
 	return (
 		<div className={props.className}>
@@ -48,6 +76,7 @@ const Choice = ( props ) => {
 
 Choice.propTypes = {
 	component: React.PropTypes.string,
+    type: React.PropTypes.string,
 	value: React.PropTypes.string,
 	properties: React.PropTypes.object,
 	"default": React.PropTypes.string,
@@ -59,6 +88,7 @@ Choice.propTypes = {
 
 Choice.defaultProps = {
 	component: "",
+    type: "radio",
 	value: "",
 	properties: {
 		label: "",

--- a/composites/OnboardingWizard/components/Choice.js
+++ b/composites/OnboardingWizard/components/Choice.js
@@ -5,8 +5,8 @@ import htmlDecoder from "../helpers/htmlDecoder";
 import Explanation from "./Explanation";
 
 /**
- * Represents a choice interface, like a group of radio buttons or a select button. Initially it should render a
- * group of radio buttons. We might add other representations later on.
+ * Represents a choice interface, like a group of radio buttons or a select button. It could render a
+ * group of radio buttons (default) or a selectbox
  *
  * @param {Object} props The properties.
  * @returns {JSX} The choice component.
@@ -18,52 +18,51 @@ const Choice = ( props ) => {
 	let fieldName = props.name;
 	let type = props.properties.type;
 
-    let fieldSet  = () => {
+	let fieldSet = () => {
+		let choiceName;
 
-        let choiceName;
-        let index;
+		if ( type === "select" ) {
+			return (
+				<fieldset className={"yoast-wizard-input-select-" + fieldName}>
+					<select defaultValue={props.value} name={fieldName}
+					        className={props.optionClassName + " " + choiceName} onChange={props.onChange}>
+						{fieldKeys.map( ( choiceName, index ) => {
+							let choice = choices[ choiceName ];
 
-        if ( type == "select" ) {
+							return (
+								<option value={choiceName} key={index}>
+									{htmlDecoder( choice.label )}
+								</option>
+							);
+						} )}
+					</select>
+				</fieldset>
+			);
+		}
 
-            return (
-                <fieldset className={"yoast-wizard-input-select-" + fieldName}>
-                    <select defaultValue={props.value} name={fieldName} className={props.optionClassName + " " + choiceName} onChange={props.onChange}>
-                        {fieldKeys.map( ( choiceName, index ) => {
-                            let choice = choices[ choiceName ];
-                            let id = `${fieldName}-${index}`;
+		if ( type === "radio" ) {
+			return (
+				<fieldset className={"yoast-wizard-input-radio-" + fieldName}>
+					{fieldKeys.map( ( choiceName, index ) => {
+						let choice = choices[ choiceName ];
+						let id = `${fieldName}-${index}`;
+						// If the value for the choice field equals the name for this choice, the choice is checked.
+						let checked = ( props.value === choiceName );
 
-                            return (
-                                <option value={choiceName} key={index} >
-                                    {htmlDecoder( choice.label )}
-                                </option>
-                            );
-                        } )}
-                    </select>
-                </fieldset>
-            );
-
-        } else {
-            return (
-                <fieldset className={"yoast-wizard-input-radio-" + fieldName}>
-                    {fieldKeys.map( ( choiceName, index ) => {
-                        let choice = choices[ choiceName ];
-                        let id = `${fieldName}-${index}`;
-                        // If the value for the choice field equals the name for this choice, the choice is checked.
-                        let checked = ( props.value === choiceName );
-
-                        return (
-                            <div className={props.optionClassName + " " + choiceName} key={index}>
-                                <Input name={fieldName} type="radio" label={choice.label} onChange={props.onChange}
-                                       value={choiceName} optionalAttributes={{ id, checked }}
-                                />
-                                <Label for={id} optionalAttributes={{ "aria-label": choice.screenReaderText }}>{htmlDecoder( choice.label )}</Label>
-                            </div>
-                        );
-                    } )}
-                </fieldset>
-            );
-        }
-    };
+						return (
+							<div className={props.optionClassName + " " + choiceName} key={index}>
+								<Input name={fieldName} type="radio" label={choice.label} onChange={props.onChange}
+								       value={choiceName} optionalAttributes={ { id, checked } }
+								/>
+								<Label for={id}
+								       optionalAttributes={ { "aria-label": choice.screenReaderText } }>{htmlDecoder( choice.label )}</Label>
+							</div>
+						);
+					} )}
+				</fieldset>
+			);
+		}
+	};
 
 	return (
 		<div className={props.className}>
@@ -76,7 +75,7 @@ const Choice = ( props ) => {
 
 Choice.propTypes = {
 	component: React.PropTypes.string,
-    type: React.PropTypes.string,
+	type: React.PropTypes.string,
 	value: React.PropTypes.string,
 	properties: React.PropTypes.object,
 	"default": React.PropTypes.string,
@@ -88,7 +87,7 @@ Choice.propTypes = {
 
 Choice.defaultProps = {
 	component: "",
-    type: "radio",
+	type: "radio",
 	value: "",
 	properties: {
 		label: "",

--- a/composites/OnboardingWizard/components/Choice.js
+++ b/composites/OnboardingWizard/components/Choice.js
@@ -19,14 +19,13 @@ const Choice = ( props ) => {
 	let type = props.properties.type;
 
 	let fieldSet = () => {
-		let choiceName;
 		let field;
 
 		if ( type === "select" ) {
 			field =
 				<fieldset className={"yoast-wizard-input-select-" + fieldName}>
 					<select defaultValue={props.value} name={fieldName}
-					        className={props.optionClassName + " " + choiceName} onChange={props.onChange}>
+					        className={props.optionClassName} onChange={props.onChange}>
 						{fieldKeys.map( ( choiceName, index ) => {
 							let choice = choices[ choiceName ];
 

--- a/composites/OnboardingWizard/components/Choice.js
+++ b/composites/OnboardingWizard/components/Choice.js
@@ -18,6 +18,11 @@ const Choice = ( props ) => {
 	let fieldName = props.name;
 	let type = props.properties.type;
 
+	if ( typeof type === "undefined" ) {
+		type = "radio";
+	}
+	let wrapperClass = "yoast-wizard-input-" + type;
+
 	let fieldSet = () => {
 		let field;
 
@@ -65,7 +70,7 @@ const Choice = ( props ) => {
 	};
 
 	return (
-		<div className={props.className}>
+		<div className={wrapperClass}>
 			<p className="yoast-wizard-field-description">{props.properties.label}</p>
 			{fieldSet()}
 			<Explanation text={props.properties.explanation}/>


### PR DESCRIPTION
You can now add `$this->set_property( 'type', 'select' );` to the `__constructor()` of your `WPSEO_Config_Field_Choice` class. The choices you added will now be represented as a regular selectbox ( instead of radios )

Bugfix
Give each field a unique fieldkey based upon its name, rather than a key.

Fixes: #114 