### PR TITLE
Add aria-current to the onboarding wizard active step.

### DIFF
--- a/composites/OnboardingWizard/StepIndicator.js
+++ b/composites/OnboardingWizard/StepIndicator.js
@@ -55,6 +55,7 @@ class StepIndicator extends React.Component {
 					key: "step-indicator-" + key,
 					className: "yoast-wizard--step yoast-wizard--step__active",
 					"aria-label": ariaLabel,
+					"aria-current": "step",
 					style: {
 						verticalAlign: "middle",
 					},


### PR DESCRIPTION
Simple enhancement for screen reader users. Will give context about the current step in the wizard:

![screen shot 2017-07-27 at 12 28 23](https://user-images.githubusercontent.com/1682452/28666701-d3b6d396-72c8-11e7-82e4-35efdf2b51f8.png)

Fixes https://github.com/Yoast/wordpress-seo/issues/7092

To test:
Run yarn start in the root folder.
Go to http://localhost:3333
click on "Wizard"
go through the steps and check `aria-current="step"` is on the active step button