### PR TITLE
Remove react-hot-loader/babel from .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["es2015", "react"],
-  "plugins": ["react-hot-loader/babel"]
+  "presets": ["es2015", "react"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require( "path" );
-const webpack = require("webpack");
+const webpack = require( "webpack" );
 
 const PORT = 3333;
 
@@ -34,7 +34,23 @@ module.exports = {
 			{
 				test: /\.js$/,
 				exclude: /node_modules/,
-				use: [ "babel-loader" ],
+				use: [ {
+					loader: "babel-loader",
+					options: {
+						babelrc: false,
+						presets: [ "es2015", "react" ],
+
+						env: {
+							development: {
+								plugins: [
+									"react-hot-loader/babel",
+								],
+							},
+
+							production: {},
+						},
+					},
+				} ],
 			},
 			{
 				test: /\.json$/,


### PR DESCRIPTION
Fixes a bug where the production build would fail when Yoast components is used as dependency in other projects (like `wordpress-seo`), because a dev dependency is used in the `.babelrc` file.