### PR TITLE
Fixed ESLint ajaxHelper.js complexity warning

### DIFF
--- a/composites/OnboardingWizard/helpers/ajaxHelper.js
+++ b/composites/OnboardingWizard/helpers/ajaxHelper.js
@@ -90,14 +90,14 @@ let parseHeaders = ( type, config ) => {
  * @summary Takes the target object and overwrites fields that are undefined
  * 			or empty with the defaults object values
  *
- * @param {Object} target Target to apply default values
- * @param {Object} defaults Default values
- * @returns {Object} Target object with overwritten values
+ * @param {Object} target 	Target to apply default values.
+ * @param {Object} defaults Default values.
+ * @returns {Object} 		Target object with overwritten values.
  */
 let overwriteObjectWithDefaultValues = ( target, defaults ) => {
 	for ( let key in defaults ) {
 		if ( defaults.hasOwnProperty( key ) ) {
-			if( typeof target[ key ] === "undefined" || target[ key ] === "" ) {
+			if ( typeof target[ key ] === "undefined" || target[ key ] === "" ) {
 				target[ key ] = defaults[ key ];
 			}
 		}

--- a/composites/OnboardingWizard/helpers/ajaxHelper.js
+++ b/composites/OnboardingWizard/helpers/ajaxHelper.js
@@ -88,13 +88,13 @@ let parseHeaders = ( type, config ) => {
 
 /**
  * @summary Takes the target object and overwrites fields that are undefined
- * 			with default object
+ * 			or empty with the defaults object values
  *
  * @param {Object} target Target to apply default values
  * @param {Object} defaults Default values
- * @returns {Object} Shallow copied target object with applied defaults
+ * @returns {Object} Target object with overwritten values
  */
-let overwriteUndefinedKeysWithDefaults = ( target, defaults ) => {
+let overwriteObjectWithDefaultValues = ( target, defaults ) => {
 	for ( let key in defaults ) {
 		if ( defaults.hasOwnProperty( key ) ) {
 			if( typeof target[ key ] === "undefined" || target[ key ] === "" ) {
@@ -120,7 +120,7 @@ let parseRequestArgs = ( requestArgs, type ) => {
 		contentType: "application/json",
 	};
 
-	let config = overwriteUndefinedKeysWithDefaults( requestArgs, defaults );
+	let config = overwriteObjectWithDefaultValues( requestArgs, defaults );
 
 	if ( typeof config.headers !== "undefined" || config.headers !== "" ) {
 		parseHeaders( type, config );

--- a/composites/OnboardingWizard/helpers/ajaxHelper.js
+++ b/composites/OnboardingWizard/helpers/ajaxHelper.js
@@ -88,7 +88,7 @@ let parseHeaders = ( type, config ) => {
 
 /**
  * @summary Takes the target object and overwrites fields that are undefined
- * 			or empty with the defaults object values
+ *          or empty with the defaults object values.
  *
  * @param {Object} target 	Target to apply default values.
  * @param {Object} defaults Default values.

--- a/composites/OnboardingWizard/helpers/ajaxHelper.js
+++ b/composites/OnboardingWizard/helpers/ajaxHelper.js
@@ -68,7 +68,7 @@ let sendJQueryRequest = ( url, requestParams ) => {
  * @param {Object} config The config containing the headers.
  * @returns {void}
  */
-var parseHeaders = ( type, config ) => {
+let parseHeaders = ( type, config ) => {
 	if ( type === "jquery" ) {
 		Object.assign( config, {
 			beforeSend: ( xhr ) => {
@@ -87,6 +87,25 @@ var parseHeaders = ( type, config ) => {
 };
 
 /**
+ * @summary Takes the target object and overwrites fields that are undefined
+ * 			with default object
+ *
+ * @param {Object} target Target to apply default values
+ * @param {Object} defaults Default values
+ * @returns {Object} Shallow copied target object with applied defaults
+ */
+let overwriteUndefinedKeysWithDefaults = ( target, defaults ) => {
+	for ( let key in defaults ) {
+		if ( defaults.hasOwnProperty( key ) ) {
+			if( typeof target[ key ] === "undefined" || target[ key ] === "" ) {
+				target[ key ] = defaults[ key ];
+			}
+		}
+	}
+	return target;
+};
+
+/**
  * @summary Parses the arguments needed for sending a JSON or Fetch request.
  *
  * @param {Object} requestArgs The arguments for the request.
@@ -101,15 +120,7 @@ let parseRequestArgs = ( requestArgs, type ) => {
 		contentType: "application/json",
 	};
 
-	let config = requestArgs;
-
-	for ( var key in defaults ) {
-		if ( defaults.hasOwnProperty( key ) ) {
-			if( typeof config[ key ] === "undefined" || config[ key ] === "" ) {
-				config[ key ] = defaults[ key ];
-			}
-		}
-	}
+	let config = overwriteUndefinedKeysWithDefaults( requestArgs, defaults );
 
 	if ( typeof config.headers !== "undefined" || config.headers !== "" ) {
 		parseHeaders( type, config );


### PR DESCRIPTION
On running `grunt check` ESLint would produce a warning about the complexity of the `parseRequestArgs` function. I reduced the complexity of this function by extracting a piece of functionality of this function to  `overwriteObjectWithDefaultValues` which does the exact same thing.

## To test:
1. Make sure the development env is running.
2. Open te Configuration Wizard on `localhost:3333`.
3. Everytime you go to a different step in the wizard the newly added function is called.
4. Walk through the configuration wizard and make sure no unexpected behaviour occurs.