### PR TITLE
Added Svg Icon component using svg-react-loader

### DIFF
--- a/composites/SnippetPreview/components/Icon.js
+++ b/composites/SnippetPreview/components/Icon.js
@@ -12,19 +12,20 @@ import styled from "styled-components";
 export const Icon = ( props ) => {
 	const IconComponent = styled( props.icon )`
 		float: left;
-		width: ${ props => props.size }px;
-		height: ${ props => props.size }px;
-		fill: ${ props => props.color };
+		width: ${ props => props.iconSize }px;
+		height: ${ props => props.iconSize }px;
+		fill: ${ props => props.iconColor };
 	`;
-	return <IconComponent aria-hidden="true" { ...props } />;
+
+	return <IconComponent aria-hidden="true" iconSize={ props.iconSize } iconColor={ props.iconColor } />;
 };
 
 Icon.propTypes = {
 	icon: PropTypes.func.isRequired,
-	color: PropTypes.string.isRequired,
-	size: PropTypes.number,
+	iconColor: PropTypes.string.isRequired,
+	iconSize: PropTypes.number,
 };
 
 Icon.defaultProps = {
-	size: 16,
+	iconSize: 16,
 };

--- a/composites/SnippetPreview/components/Icon.js
+++ b/composites/SnippetPreview/components/Icon.js
@@ -20,7 +20,7 @@ export const Icon = ( props ) => {
 };
 
 Icon.propTypes = {
-	icon: PropTypes.string.isRequired,
+	icon: PropTypes.func.isRequired,
 	color: PropTypes.string.isRequired,
 	size: PropTypes.number,
 };

--- a/composites/SnippetPreview/components/Icon.js
+++ b/composites/SnippetPreview/components/Icon.js
@@ -16,7 +16,7 @@ export const Icon = ( props ) => {
 		height: ${ props => props.size }px;
 		fill: ${ props => props.color };
 	`;
-	return <IconComponent { ...props } />;
+	return <IconComponent aria-hidden="true" { ...props } />;
 };
 
 Icon.propTypes = {

--- a/composites/SnippetPreview/components/Icon.js
+++ b/composites/SnippetPreview/components/Icon.js
@@ -2,17 +2,15 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
-import * as Icons from "../../../style-guide/svg";
-
 /**
- * Returns an icon.
+ * Returns the Icon component.
  *
  * @param {object} props Component props.
  *
- * @returns {ReactElement} Icon.
+ * @returns {ReactElement} Icon component.
  */
 export const Icon = ( props ) => {
-	const IconComponent = styled( Icons[ props.icon ] )`
+	const IconComponent = styled( props.icon )`
 		float: left;
 		width: ${ props => props.size }px;
 		height: ${ props => props.size }px;
@@ -22,13 +20,11 @@ export const Icon = ( props ) => {
 };
 
 Icon.propTypes = {
-	icon: PropTypes.string,
-	color: PropTypes.string,
+	icon: PropTypes.string.isRequired,
+	color: PropTypes.string.isRequired,
 	size: PropTypes.number,
 };
 
 Icon.defaultProps = {
 	size: 16,
-	color: "#555",
-	icon: "edit",
 };

--- a/composites/SnippetPreview/components/Icon.js
+++ b/composites/SnippetPreview/components/Icon.js
@@ -1,0 +1,34 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+import * as Icons from "../../../style-guide/svg";
+
+/**
+ * Returns an icon.
+ *
+ * @param {object} props Component props.
+ *
+ * @returns {ReactElement} Icon.
+ */
+export const Icon = ( props ) => {
+	const IconComponent = styled( Icons[ props.icon ] )`
+		float: left;
+		width: ${ props => props.size }px;
+		height: ${ props => props.size }px;
+		fill: ${ props => props.color };
+	`;
+	return <IconComponent { ...props } />;
+};
+
+Icon.propTypes = {
+	icon: PropTypes.string,
+	color: PropTypes.string,
+	size: PropTypes.number,
+};
+
+Icon.defaultProps = {
+	size: 16,
+	color: "#555",
+	icon: "edit",
+};

--- a/composites/SnippetPreview/components/Icon.js
+++ b/composites/SnippetPreview/components/Icon.js
@@ -11,21 +11,20 @@ import styled from "styled-components";
  */
 export const Icon = ( props ) => {
 	const IconComponent = styled( props.icon )`
-		float: left;
-		width: ${ props => props.iconSize }px;
-		height: ${ props => props.iconSize }px;
-		fill: ${ props => props.iconColor };
+		width: ${ props.iconSize };
+		height: ${ props.iconSize };
+		fill: ${ props.iconColor };
 	`;
 
-	return <IconComponent aria-hidden="true" iconSize={ props.iconSize } iconColor={ props.iconColor } />;
+	return <IconComponent aria-hidden="true" />;
 };
 
 Icon.propTypes = {
 	icon: PropTypes.func.isRequired,
 	iconColor: PropTypes.string.isRequired,
-	iconSize: PropTypes.number,
+	iconSize: PropTypes.string,
 };
 
 Icon.defaultProps = {
-	iconSize: 16,
+	iconSize: "16px",
 };

--- a/composites/SnippetPreview/tests/IconTest.js
+++ b/composites/SnippetPreview/tests/IconTest.js
@@ -1,11 +1,12 @@
 import React from "react";
 import renderer from "react-test-renderer";
 
+import Edit from "../../../style-guide/svg/edit.svg";
 import { Icon } from "../components/Icon";
 
 test( "the Icon matches the snapshot", () => {
 	const component = renderer.create(
-		<Icon />
+		<Icon icon={ Edit } color="black"  />
 	);
 
 	let tree = component.toJSON();

--- a/composites/SnippetPreview/tests/IconTest.js
+++ b/composites/SnippetPreview/tests/IconTest.js
@@ -1,12 +1,12 @@
 import React from "react";
 import renderer from "react-test-renderer";
 
-import Edit from "../../../style-guide/svg/edit.svg";
+import edit from "../../../style-guide/svg/edit.svg";
 import { Icon } from "../components/Icon";
 
 test( "the Icon matches the snapshot", () => {
 	const component = renderer.create(
-		<Icon icon={ Edit } iconColor="black"  />
+		<Icon icon={ edit } iconColor="black" iconSize="16px" />
 	);
 
 	let tree = component.toJSON();

--- a/composites/SnippetPreview/tests/IconTest.js
+++ b/composites/SnippetPreview/tests/IconTest.js
@@ -6,7 +6,7 @@ import { Icon } from "../components/Icon";
 
 test( "the Icon matches the snapshot", () => {
 	const component = renderer.create(
-		<Icon icon={ Edit } color="black"  />
+		<Icon icon={ Edit } iconColor="black"  />
 	);
 
 	let tree = component.toJSON();

--- a/composites/SnippetPreview/tests/IconTest.js
+++ b/composites/SnippetPreview/tests/IconTest.js
@@ -1,0 +1,13 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import { Icon } from "../components/Icon";
+
+test( "the Icon matches the snapshot", () => {
+	const component = renderer.create(
+		<Icon />
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );

--- a/composites/SnippetPreview/tests/__snapshots__/IconTest.js.snap
+++ b/composites/SnippetPreview/tests/__snapshots__/IconTest.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the Icon matches the snapshot 1`] = `
+<svg
+  className="sc-bdVaJa ekYXbX"
+  color="#555"
+  icon="edit"
+  size={16}
+/>
+`;

--- a/composites/SnippetPreview/tests/__snapshots__/IconTest.js.snap
+++ b/composites/SnippetPreview/tests/__snapshots__/IconTest.js.snap
@@ -3,8 +3,8 @@
 exports[`the Icon matches the snapshot 1`] = `
 <svg
   aria-hidden="true"
-  className="sc-bdVaJa inStFx"
-  iconColor={undefined}
+  className="sc-bdVaJa jEZkCV"
+  iconColor="black"
   iconSize={16}
 />
 `;

--- a/composites/SnippetPreview/tests/__snapshots__/IconTest.js.snap
+++ b/composites/SnippetPreview/tests/__snapshots__/IconTest.js.snap
@@ -3,9 +3,8 @@
 exports[`the Icon matches the snapshot 1`] = `
 <svg
   aria-hidden="true"
-  className="sc-bdVaJa jEZkCV"
-  color="black"
-  icon={[Function]}
-  size={16}
+  className="sc-bdVaJa inStFx"
+  iconColor={undefined}
+  iconSize={16}
 />
 `;

--- a/composites/SnippetPreview/tests/__snapshots__/IconTest.js.snap
+++ b/composites/SnippetPreview/tests/__snapshots__/IconTest.js.snap
@@ -2,6 +2,7 @@
 
 exports[`the Icon matches the snapshot 1`] = `
 <svg
+  aria-hidden="true"
   className="sc-bdVaJa jEZkCV"
   color="black"
   icon={[Function]}

--- a/composites/SnippetPreview/tests/__snapshots__/IconTest.js.snap
+++ b/composites/SnippetPreview/tests/__snapshots__/IconTest.js.snap
@@ -3,8 +3,6 @@
 exports[`the Icon matches the snapshot 1`] = `
 <svg
   aria-hidden="true"
-  className="sc-bdVaJa jEZkCV"
-  iconColor="black"
-  iconSize={16}
+  className="sc-bdVaJa dURRQD"
 />
 `;

--- a/composites/SnippetPreview/tests/__snapshots__/IconTest.js.snap
+++ b/composites/SnippetPreview/tests/__snapshots__/IconTest.js.snap
@@ -2,9 +2,9 @@
 
 exports[`the Icon matches the snapshot 1`] = `
 <svg
-  className="sc-bdVaJa ekYXbX"
-  color="#555"
-  icon="edit"
+  className="sc-bdVaJa jEZkCV"
+  color="black"
+  icon={[Function]}
   size={16}
 />
 `;

--- a/jest/__mocks__/fileMock.js
+++ b/jest/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = "test-file-stub";

--- a/jest/__mocks__/svgReactLoaderMock.js
+++ b/jest/__mocks__/svgReactLoaderMock.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+const SvgMock = props => {
+	return (
+		<svg {...props}></svg>
+	);
+};
+
+module.exports = SvgMock;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
     "test": "jest"
   },
   "jest": {
+    "moduleNameMapper": {
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/jest/__mocks__/fileMock.js",
+      "\\.(svg)$": "<rootDir>/jest/__mocks__/svgReactLoaderMock.js",
+      "\\.(css|less)$": "<rootDir>/jest/__mocks__/styleMock.js"
+    },
     "unmockedModulePathPatterns": [
       "react",
       "enzyme",
@@ -68,6 +73,7 @@
     "react-test-renderer": "^15.6.1",
     "sassdash": "^0.8.2",
     "stubby": "^0.3.1",
+    "svg-react-loader": "^0.4.4",
     "webpack": "^3.2.0",
     "webpack-dev-server": "^2.5.1"
   },

--- a/style-guide/svg/edit.svg
+++ b/style-guide/svg/edit.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+        "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg fill="#000" width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg">
+    <path d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z" />
+</svg>

--- a/style-guide/svg/index.js
+++ b/style-guide/svg/index.js
@@ -1,0 +1,3 @@
+import edit from "./edit.svg";
+
+export { edit };

--- a/style-guide/svg/index.js
+++ b/style-guide/svg/index.js
@@ -1,0 +1,1 @@
+export { default as edit } from "./edit.svg";

--- a/style-guide/svg/index.js
+++ b/style-guide/svg/index.js
@@ -1,3 +1,0 @@
-import edit from "./edit.svg";
-
-export { edit };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,12 +56,21 @@ module.exports = {
 				test: /\.json$/,
 				use: [ "json-loader" ],
 			},
+			{
+				test: /\.svg$/,
+				use: [ {
+					loader: "svg-react-loader",
+					options: {
+						stripdeclarations: true,
+					},
+				} ],
+			},
 		],
 	},
 	plugins: [
 		new webpack.HotModuleReplacementPlugin(),
 	],
 	resolve: {
-		extensions: [ ".json", ".jsx", ".js" ],
+		extensions: [ ".json", ".jsx", ".js", ".svg" ],
 	},
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,6 +289,10 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+atob@~1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
+
 autoprefixer@^6.4.0:
   version "6.6.1"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.6.1.tgz#11a4077abb4b313253ec2f6e1adb91ad84253519"
@@ -1524,6 +1528,15 @@ css-to-react-native@^2.0.3:
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
+
+css@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.1.tgz#73a4c81de85db664d4ee674f7d47085e3b2d55dc"
+  dependencies:
+    inherits "^2.0.1"
+    source-map "^0.1.38"
+    source-map-resolve "^0.3.0"
+    urix "^0.1.0"
 
 cssmin@^0.4.3:
   version "0.4.3"
@@ -3789,7 +3802,7 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
-loader-utils@^1.0.2, loader-utils@^1.1.0:
+loader-utils@1.1.0, loader-utils@^1.0.2, loader-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
   dependencies:
@@ -4695,6 +4708,10 @@ querystringify@0.0.x:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-0.0.4.tgz#0cf7f84f9463ff0ae51c4c4b142d95be37724d9c"
 
+ramda@0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
+
 randomatic@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"
@@ -5049,6 +5066,10 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
+resolve-url@~0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+
 resolve@1.1.7, resolve@~1.1.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
@@ -5109,6 +5130,10 @@ rx@2.3.24:
   version "2.3.24"
   resolved "https://registry.yarnpkg.com/rx/-/rx-2.3.24.tgz#14f950a4217d7e35daa71bbcbe58eff68ea4b2b7"
 
+rx@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
+
 safe-buffer@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.0.tgz#fe4c8460397f9eaaaa58e73be46273408a45e223"
@@ -5160,7 +5185,7 @@ sassdash@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/sassdash/-/sassdash-0.8.2.tgz#42d59b4932f13034695604bd8437e2b598afd368"
 
-sax@^1.2.1:
+sax@>=0.6.0, sax@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -5303,15 +5328,34 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
+source-map-resolve@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.3.1.tgz#610f6122a445b8dd51535a2a71b783dfc1248761"
+  dependencies:
+    atob "~1.1.0"
+    resolve-url "~0.2.1"
+    source-map-url "~0.3.0"
+    urix "~0.1.0"
+
 source-map-support@^0.4.2:
   version "0.4.8"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.8.tgz#4871918d8a3af07289182e974e32844327b2e98b"
   dependencies:
     source-map "^0.5.3"
 
+source-map-url@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
+
 source-map@0.5.6, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
+source-map@^0.1.38:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  dependencies:
+    amdefine ">=0.0.4"
 
 source-map@^0.4.4:
   version "0.4.4"
@@ -5536,6 +5580,17 @@ supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.1.2, supports-co
   dependencies:
     has-flag "^1.0.0"
 
+svg-react-loader@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/svg-react-loader/-/svg-react-loader-0.4.4.tgz#ea3b2ebc8ff8eaafd7cca5b86750f90a2faac4fd"
+  dependencies:
+    css "2.2.1"
+    loader-utils "1.1.0"
+    ramda "0.21.0"
+    rx "4.1.0"
+    traverse "0.6.6"
+    xml2js "0.4.17"
+
 symbol-observable@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
@@ -5634,6 +5689,10 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
+traverse@0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+
 tree-kill@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.1.0.tgz#c963dcf03722892ec59cba569e940b71954d1729"
@@ -5727,6 +5786,10 @@ underscore.string@~3.2.3:
 unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
+urix@^0.1.0, urix@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
 
 url-parse@1.0.x:
   version "1.0.5"
@@ -6003,6 +6066,19 @@ write@^0.2.1:
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+
+xml2js@0.4.17:
+  version "0.4.17"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.17.tgz#17be93eaae3f3b779359c795b419705a8817e868"
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "^4.1.0"
+
+xmlbuilder@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-4.2.1.tgz#aa58a3041a066f90eaa16c2f5389ff19f3f461a5"
+  dependencies:
+    lodash "^4.0.0"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
Also added jest configuration to map svg files to `/jest/__mocks__/svgReactLoaderMock.js`, because jest doesn't use webpack loaders.

## Technical decisions
* Implemented `svg-react-loader`, which creates react components from `.svg` files.
* Added svg mocking instructions to `package.json` that tell jest to mock imports of `.svg` files to `/jest/__mocks__/svgReactLoaderMock.js`.

## Testing
1. Paste the following in `SnippetPreview.js`:
```js
import React from "react";
import styled from "styled-components";

import { Icon } from "./Icon";
import { edit } from "../../../style-guide/svg";

export const SnippetPreviewDiv = styled.div`
	height: 700px;
	width: 100%;
	background-color: white;
`;

/**
 * Returns the SnippetPreview component.
 *
 * @returns {ReactElement} The SnippetPreview component.
 */
export default function SnippetPreview() {
	return <SnippetPreviewDiv><Icon icon={ edit } iconColor="#000"/></SnippetPreviewDiv>;
}

```
2. Test using the `iconSize` and `iconColor` props on the `Icon` component.
3. Additionally you can add and `.svg` file (make sure it's a square icon) to `/style-guide/svg` and export it in `/style-guide/svg/index.js`. Then the name you use to export the svg in `index.js` can be used as the `icon` prop on the `Icon` component.

Fixes #189 
