### PR TITLE
Allow non-Icon specific props to be passed down in Icon component

### DIFF
--- a/composites/SnippetPreview/components/Icon.js
+++ b/composites/SnippetPreview/components/Icon.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
+import _omit from "lodash/omit";
 
 /**
  * Returns the Icon component.
@@ -11,20 +12,23 @@ import styled from "styled-components";
  */
 export const Icon = ( props ) => {
 	const IconComponent = styled( props.icon )`
-		width: ${ props.iconSize };
-		height: ${ props.iconSize };
-		fill: ${ props.iconColor };
+		width: ${ props.size };
+		height: ${ props.size };
+		fill: ${ props.color };
 	`;
 
-	return <IconComponent aria-hidden="true" />;
+	// Remove the props that are no longer needed
+	const newProps = _omit( props, [ "icon", "size", "color" ] );
+
+	return <IconComponent aria-hidden="true" { ...newProps } />;
 };
 
 Icon.propTypes = {
 	icon: PropTypes.func.isRequired,
-	iconColor: PropTypes.string.isRequired,
-	iconSize: PropTypes.string,
+	color: PropTypes.string.isRequired,
+	size: PropTypes.string,
 };
 
 Icon.defaultProps = {
-	iconSize: "16px",
+	size: "16px",
 };

--- a/composites/SnippetPreview/tests/IconTest.js
+++ b/composites/SnippetPreview/tests/IconTest.js
@@ -6,7 +6,7 @@ import { Icon } from "../components/Icon";
 
 test( "the Icon matches the snapshot", () => {
 	const component = renderer.create(
-		<Icon icon={ edit } iconColor="black" iconSize="16px" />
+		<Icon icon={ edit } color="black" size="16px" />
 	);
 
 	let tree = component.toJSON();

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "grunt-scss-to-json": "^1.0.1",
     "interpolate-components": "^1.1.0",
     "jed": "^1.1.1",
+    "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
     "styled-components": "^2.1.1",
     "whatwg-fetch": "^1.0.0"


### PR DESCRIPTION
When applying a `styled-components` decorator to apply some additional stying to the Icon component I found out the changes were not showing up.

## Technical decisions
This PR fixes that by passing all props that are not specific for the Icon down to the outputted component. By using `lodash`'s `omit` all props that are not specific to the Icon component are removed and passed to the returned component.

This also allows the Icon's API to be cleaner by changing `iconSize` and `iconColor` to `size` and `color` respectively, because they won't be passed down to the html element as attributes anyway.

## Test
To test replace the content of `SnippedPreview.js` with the following content:

```js
import React from "react";
import styled from "styled-components";

import { Icon } from "./Icon";
import { edit } from "../../../style-guide/svg";

export const SnippetPreviewDiv = styled.div`
	height: 700px;
	width: 100%;
	background-color: white;
`;

/**
 * Returns the SnippetPreview component.
 *
 * @returns {ReactElement} The SnippetPreview component.
 */
export default function SnippetPreview() {
	const DecoratedIcon = styled( Icon )`
		border: 10px solid black;
	`;
	return <SnippetPreviewDiv><DecoratedIcon icon={ edit } color="#000"/></SnippetPreviewDiv>;
};
```
