### PR TITLE
Applied a max width to the onboarding wizard content

### DIFF
--- a/composites/OnboardingWizard/Step.js
+++ b/composites/OnboardingWizard/Step.js
@@ -258,7 +258,9 @@ class Step extends React.Component {
 			<div className={`${this.props.classPrefix}--step--container`} ref="stepContainer"
 				tabIndex="-1" aria-labelledby="step-title">
 				<h1 id="step-title">{this.props.title}</h1>
-				{ this.getFieldComponents( this.props.fields ) }
+					<div className={`${this.props.classPrefix}-content-container`}>
+						{ this.getFieldComponents( this.props.fields ) }
+					</div>
 			</div>
 		);
 	}

--- a/composites/OnboardingWizard/Step.js
+++ b/composites/OnboardingWizard/Step.js
@@ -258,9 +258,9 @@ class Step extends React.Component {
 			<div className={`${this.props.classPrefix}--step--container`} ref="stepContainer"
 				tabIndex="-1" aria-labelledby="step-title">
 				<h1 id="step-title">{this.props.title}</h1>
-					<div className={ `${ this.props.classPrefix }-content-container` }>
+				<div className={ `${ this.props.classPrefix }-content-container` }>
 					{ this.getFieldComponents( this.props.fields ) }
-					</div>
+				</div>
 			</div>
 		);
 	}

--- a/composites/OnboardingWizard/Step.js
+++ b/composites/OnboardingWizard/Step.js
@@ -258,8 +258,8 @@ class Step extends React.Component {
 			<div className={`${this.props.classPrefix}--step--container`} ref="stepContainer"
 				tabIndex="-1" aria-labelledby="step-title">
 				<h1 id="step-title">{this.props.title}</h1>
-					<div className={`${this.props.classPrefix}-content-container`}>
-						{ this.getFieldComponents( this.props.fields ) }
+					<div className={ `${ this.props.classPrefix }-content-container` }>
+					{ this.getFieldComponents( this.props.fields ) }
 					</div>
 			</div>
 		);

--- a/composites/OnboardingWizard/onboarding-wizard.scss
+++ b/composites/OnboardingWizard/onboarding-wizard.scss
@@ -316,6 +316,6 @@ body {
   }
 }
 
-.#{$prefix}-content-container {
+.#{ $prefix }-content-container {
   max-width: 560px;
 }

--- a/composites/OnboardingWizard/onboarding-wizard.scss
+++ b/composites/OnboardingWizard/onboarding-wizard.scss
@@ -186,7 +186,6 @@ body {
     fieldset {
       border: 0;
       margin: 1em 0;
-      padding-left: 0.5em;
     }
   }
 
@@ -258,7 +257,7 @@ body {
             float: left;
             width: 30px !important;
             margin: 0 5px 5px 0 !important;
-            padding: 9px 6px;
+            padding: 6px 3px;
             border: 1px solid $color_button_border;
             /* Don't change: these mimic Google's font and font size for titles */
             font-family: Arial, Helvetica, sans-serif !important;
@@ -315,4 +314,8 @@ body {
     background: #fff;
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
   }
+}
+
+.#{$prefix}-content-container {
+  max-width: 560px;
 }


### PR DESCRIPTION
Applied the max-width of 560 px to the onboarding wizard width. Reduced the size of the seperator tiles slightly to have them fit on a single line.

Testinstructions:

1. Make sure you run grunt build
2. Checkout the wizard on localhost:3333. Take a quick look at each page of the wizard to make sure the pages look presentable, and pay particular atttention to the width of the content of the pages, confirming they don't exceed the 560 pixels set in the issue.

fixes #245 