### PR TITLE
244 choice component subtext

### DIFF
--- a/composites/OnboardingWizard/components/Choice.js
+++ b/composites/OnboardingWizard/components/Choice.js
@@ -67,8 +67,9 @@ const Choice = ( props ) => {
 	return (
 		<div className={wrapperClass}>
 			<p className="yoast-wizard-field-description">{props.properties.label}</p>
+			<p> {props.properties.description} </p>
 			{fieldSet()}
-			<Explanation text={props.properties.explanation}/>
+			<Explanation text={props.properties.description}/>
 		</div>
 	);
 };
@@ -77,7 +78,11 @@ Choice.propTypes = {
 	component: PropTypes.string,
 	type: PropTypes.string,
 	value: PropTypes.string,
-	properties: PropTypes.object,
+	properties: PropTypes.shape( {
+		label: PropTypes.string,
+		choices: PropTypes.object,
+		description: PropTypes.string,
+	} ),
 	"default": PropTypes.string,
 	name: PropTypes.string.isRequired,
 	onChange: PropTypes.func,
@@ -92,6 +97,7 @@ Choice.defaultProps = {
 	properties: {
 		label: "",
 		choices: {},
+		description: "",
 	},
 	"default": "",
 };

--- a/composites/OnboardingWizard/components/Choice.js
+++ b/composites/OnboardingWizard/components/Choice.js
@@ -83,6 +83,7 @@ Choice.propTypes = {
 		choices: PropTypes.object,
 		explanation: PropTypes.string,
 		description: PropTypes.string,
+		type: PropTypes.string,
 	} ),
 	"default": PropTypes.string,
 	name: PropTypes.string.isRequired,

--- a/composites/OnboardingWizard/components/Choice.js
+++ b/composites/OnboardingWizard/components/Choice.js
@@ -67,7 +67,7 @@ const Choice = ( props ) => {
 	return (
 		<div className={ wrapperClass }>
 			<p className="yoast-wizard-field-description">{ props.properties.label }</p>
-			<p> { props.properties.description } </p>
+			<p>{ props.properties.description }</p>
 			{ fieldSet() }
 			<Explanation text={ props.properties.explanation }/>
 		</div>

--- a/composites/OnboardingWizard/components/Choice.js
+++ b/composites/OnboardingWizard/components/Choice.js
@@ -65,11 +65,11 @@ const Choice = ( props ) => {
 	};
 
 	return (
-		<div className={wrapperClass}>
-			<p className="yoast-wizard-field-description">{props.properties.label}</p>
-			<p> {props.properties.description} </p>
-			{fieldSet()}
-			<Explanation text={props.properties.description}/>
+		<div className={ wrapperClass }>
+			<p className="yoast-wizard-field-description">{ props.properties.label }</p>
+			<p> { props.properties.description } </p>
+			{ fieldSet() }
+			<Explanation text={ props.properties.explanation }/>
 		</div>
 	);
 };
@@ -81,6 +81,7 @@ Choice.propTypes = {
 	properties: PropTypes.shape( {
 		label: PropTypes.string,
 		choices: PropTypes.object,
+		explanation: PropTypes.string,
 		description: PropTypes.string,
 	} ),
 	"default": PropTypes.string,

--- a/composites/OnboardingWizard/onboarding-wizard.scss
+++ b/composites/OnboardingWizard/onboarding-wizard.scss
@@ -199,6 +199,7 @@ body {
       display: block;
       margin: 0.5em 0 0;
       font-weight: bold;
+      font-size: 14px;
     }
 
     [type="text"] {


### PR DESCRIPTION
Fixes #244
Related #240

Added a property to the choice component, which can be used to send a paragraph of text, which should be displayed between the title of the choice and the radio buttons. 

I gave the component the name `description` instead of `html`.

Test instructions:

to the choice-component where you want to add a description (let's say the company website/personal website of page 4 of the wizard), add "descriptions" to the properties of "properties". I've added it to the example page in the code block below, simply replace the entire "publishingEntity" around line 86 of production-config.js.

```
		"publishingEntity": {
			"componentName": "Choice",
			"properties": {
				"label": "Is this a personal site or is it for a company?",
				"choices": {
					"person": {
						"label": "Personal website",
					},
					"company": {
						"label": "Company website",
					},
				},
				"description": "This bit of text describes the radio buttons shown",
			},
			"data": "person",
		},
```



