### PR TITLE
Add nav and main landmarks to the Configuration wizard

### DIFF
--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -303,7 +303,7 @@ class OnboardingWizard extends React.Component {
 					<YoastLogo height={93} width={200}/>
 					<StepIndicator steps={this.props.steps} stepIndex={this.getCurrentStepNumber() - 1}
 					               onClick={( stepNumber, evt ) => this.postStep( stepNumber, evt )}/>
-					<div className="yoast-wizard-container">
+					<main className="yoast-wizard-container">
 						<div className="yoast-wizard">
 							{ this.renderErrorMessage() }
 							<Step ref="step" currentStep={this.state.currentStepId} title={step.title}
@@ -313,7 +313,7 @@ class OnboardingWizard extends React.Component {
 							{ navigation }
 						</div>
 						{( this.state.isLoading ) ? <div className="yoast-wizard-overlay"><LoadingIndicator/></div> : ""}
-					</div>
+					</main>
 				</div>
 			</MuiThemeProvider>
 		);

--- a/composites/OnboardingWizard/StepIndicator.js
+++ b/composites/OnboardingWizard/StepIndicator.js
@@ -89,11 +89,11 @@ class StepIndicator extends React.Component {
 	 */
 	render() {
 		return (
-			<div className="yoast-wizard--stepper">
+			<nav className="yoast-wizard--stepper">
 				<Stepper linear={false} activeStep={this.state.stepIndex}>
 					{this.getStepButtonComponents()}
 				</Stepper>
-			</div>
+			</nav>
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added landmark regions for assistive technologies to the Configuration wizard.

## Test instructions

This PR can be tested by following these steps:

* will be completed by #256  and https://github.com/Yoast/wordpress-seo/issues/7807
* use a screen reader and check the landmark regions are reported correctly, for example with Safari+VoiceOver 
  * press Control-Option-U to open the Rotor
  * press Control-Option-Right arrow (or Left) to reach the Landmark list
  * verify the navigation and main regions are listed
  * press Control-Option-Down arrow (or Up) to select one of the regions and jump to it

Fixes #258
