### PR TITLE
252 linkbutton component

### DIFF
--- a/composites/Plugin/Shared/components/Button.js
+++ b/composites/Plugin/Shared/components/Button.js
@@ -50,6 +50,7 @@ export function addBaseStyle( component ) {
 		@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
 			// IE 10+
 			::after {
+				display: inline-block;
 				content: "";
 				min-height: ${ `${ ieMinHeight }px` };
 			}

--- a/composites/Plugin/Shared/components/Button.js
+++ b/composites/Plugin/Shared/components/Button.js
@@ -9,6 +9,30 @@ import { Icon } from "./Icon";
 import { rgba } from "../../../../style-guide/helpers";
 
 /**
+ * Returns a component with applied base button styles.
+ *
+ * @param {ReactElement} component The original component.
+ *
+ * @returns {ReactElement} Component with applied base button styles.
+ */
+export function addBaseStyle( component ) {
+	return styled( component )`
+		vertical-align: middle;
+		margin: 0;
+		padding: 4px 10px;
+		border-radius: 3px;
+		cursor: pointer;
+		box-sizing: border-box;
+		font-size: inherit;
+		font-family: inherit;
+		font-weight: inherit;
+		text-align: left;
+		height: 32px;
+		overflow: visible;
+	`;
+}
+
+/**
  * Returns a component with applied focus styles.
  *
  * @param {ReactElement} component The original component.
@@ -64,6 +88,12 @@ export function addActiveStyle( component ) {
 	`;
 }
 
+export function addFontSizeStyles( component ) {
+	return styled( component )`
+		font-size: 0.8rem;
+	`;
+}
+
 /**
  * Returns a component with all button selector styles applied.
  *
@@ -71,7 +101,7 @@ export function addActiveStyle( component ) {
  *
  * @returns {ReactElement} Component with applied styles.
  */
-export const addButtonStyles = _flow( [ addFocusStyle, addHoverStyle, addActiveStyle ] );
+export const addButtonStyles = _flow( [ addBaseStyle, addFocusStyle, addHoverStyle, addActiveStyle ] );
 
 /**
  * Returns a basic styled button.
@@ -86,19 +116,6 @@ export const BaseButton = addButtonStyles(
 		border: 1px solid ${ props => props.borderColor };
 		background: ${ props => props.backgroundColor };
 		box-shadow: 0 1px 0 ${ props => rgba( props.boxShadowColor, 1 ) };
-		vertical-align: middle;
-		margin: 0;
-		padding: 4px 10px;
-		border-radius: 3px;
-		cursor: pointer;
-		box-sizing: border-box;
-		font-size: inherit;
-		font-family: inherit;
-		font-weight: inherit;
-		text-align: left;
-		outline: none;
-		min-height: 32px;
-		overflow: visible;
 	`
 );
 
@@ -124,10 +141,7 @@ BaseButton.defaultProps = {
  *
  * @returns {ReactElement} Styled button.
  */
-export const Button = styled( BaseButton )`
-	font-size: 0.8rem;
-	line-height: 1.4;
-`;
+export const Button = addFontSizeStyles( BaseButton );
 
 /**
  * Returns a button with inline flex styles.
@@ -138,7 +152,7 @@ export const Button = styled( BaseButton )`
  */
 export const InlineFlexButton = styled( Button )`
 	display: inline-flex;
-	flex-direction: row;
+	align-items: center;
 `;
 
 /**
@@ -151,8 +165,6 @@ export const InlineFlexButton = styled( Button )`
 function addIconTextStyle( icon ) {
 	return styled( icon )`
 		margin: 0 8px 0 0;
-		display: flex;
-		align-self: center;
 		flex-shrink: 0;
 	`;
 }

--- a/composites/Plugin/Shared/components/Button.js
+++ b/composites/Plugin/Shared/components/Button.js
@@ -88,6 +88,13 @@ export function addActiveStyle( component ) {
 	`;
 }
 
+/**
+ * Returns a component with applied font size style.
+ *
+ * @param {ReactElement} component The original component.
+ *
+ * @returns {ReactElement} Component with applied font size styles.
+ */
 export function addFontSizeStyles( component ) {
 	return styled( component )`
 		font-size: 0.8rem;

--- a/composites/Plugin/Shared/components/Button.js
+++ b/composites/Plugin/Shared/components/Button.js
@@ -8,6 +8,14 @@ import colors from "../../../../style-guide/colors.json";
 import { Icon } from "./Icon";
 import { rgba } from "../../../../style-guide/helpers";
 
+const settings = {
+	minHeight: 32,
+	verticalPadding: 4,
+	borderWidth: 1,
+};
+
+const ieMinHeight = settings.minHeight - ( settings.verticalPadding * 2 ) - ( settings.borderWidth * 2 );
+
 /**
  * Returns a component with applied base button styles.
  *
@@ -17,9 +25,13 @@ import { rgba } from "../../../../style-guide/helpers";
  */
 export function addBaseStyle( component ) {
 	return styled( component )`
+		display: inline-flex;
+		align-items: center;
 		vertical-align: middle;
+		border-width: ${ `${ settings.borderWidth }px` };
+		border-style: solid;
 		margin: 0;
-		padding: 4px 10px;
+		padding: ${ `${ settings.verticalPadding }px` } 10px;
 		border-radius: 3px;
 		cursor: pointer;
 		box-sizing: border-box;
@@ -27,8 +39,21 @@ export function addBaseStyle( component ) {
 		font-family: inherit;
 		font-weight: inherit;
 		text-align: left;
-		height: 32px;
 		overflow: visible;
+		min-height: ${ `${ settings.minHeight }px` };
+
+		svg {
+			// Safari 10
+			align-self: center;
+		}
+
+		@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+			// IE 10+
+			::after {
+				content: "";
+				min-height: ${ `${ ieMinHeight }px` };
+			}
+		}
 	`;
 }
 
@@ -120,7 +145,7 @@ export const addButtonStyles = _flow( [ addBaseStyle, addFocusStyle, addHoverSty
 export const BaseButton = addButtonStyles(
 	styled.button`
 		color: ${ props => props.textColor };
-		border: 1px solid ${ props => props.borderColor };
+		border-color: ${ props => props.borderColor };
 		background: ${ props => props.backgroundColor };
 		box-shadow: 0 1px 0 ${ props => rgba( props.boxShadowColor, 1 ) };
 	`
@@ -149,18 +174,6 @@ BaseButton.defaultProps = {
  * @returns {ReactElement} Styled button.
  */
 export const Button = addFontSizeStyles( BaseButton );
-
-/**
- * Returns a button with inline flex styles.
- *
- * @param {object} props Component props.
- *
- * @returns {ReactElement} Styled component.
- */
-export const InlineFlexButton = styled( Button )`
-	display: inline-flex;
-	align-items: center;
-`;
 
 /**
  * Applies styles to icon for IconButton with text.
@@ -194,10 +207,10 @@ export const IconButton = ( props ) => {
 	const newProps = _omit( props, "icon" );
 
 	return (
-		<InlineFlexButton { ...newProps } >
+		<Button { ...newProps }>
 			<IconComponent icon={ icon } color={ iconColor } />
 			{ text }
-		</InlineFlexButton>
+		</Button>
 	);
 };
 

--- a/composites/Plugin/Shared/components/LinkButton.js
+++ b/composites/Plugin/Shared/components/LinkButton.js
@@ -14,11 +14,9 @@ import { addButtonStyles, addFontSizeStyles } from "./Button";
  */
 export const BaseLinkButton = addButtonStyles(
 	styled.a`
-		display: inline-flex;
-		align-items: center;
 		text-decoration: none;
 		color: ${ props => props.textColor };
-		border: 1px solid ${ props => props.borderColor };
+		border-color: ${ props => props.borderColor };
 		background: ${ props => props.backgroundColor };
 		box-shadow: 0 1px 0 ${ props => rgba( props.boxShadowColor, 1 ) };
 	`

--- a/composites/Plugin/Shared/components/LinkButton.js
+++ b/composites/Plugin/Shared/components/LinkButton.js
@@ -1,0 +1,48 @@
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+import colors from "../../../../style-guide/colors.json";
+import { rgba } from "../../../../style-guide/helpers";
+import { addButtonStyles, addFontSizeStyles } from "./Button";
+
+/**
+ * Returns a basic link styled like a button.
+ *
+ * @param {object} props Component props.
+ *
+ * @returns {ReactElement} Styled button.
+ */
+export const BaseLinkButton = addButtonStyles(
+	styled.a`
+		display: inline-flex;
+		align-items: center;
+		text-decoration: none;
+		color: ${ props => props.textColor };
+		border: 1px solid ${ props => props.borderColor };
+		background: ${ props => props.backgroundColor };
+		box-shadow: 0 1px 0 ${ props => rgba( props.boxShadowColor, 1 ) };
+	`
+);
+
+BaseLinkButton.propTypes = {
+	backgroundColor: PropTypes.string,
+	textColor: PropTypes.string,
+	borderColor: PropTypes.string,
+	boxShadowColor: PropTypes.string,
+};
+
+BaseLinkButton.defaultProps = {
+	backgroundColor: colors.$color_button,
+	textColor: colors.$color_button_text,
+	borderColor: colors.$color_button_border,
+	boxShadowColor: colors.$color_button_border,
+};
+
+/**
+ * Returns a link styled like a button with set font size.
+ *
+ * @param {object} props Component props.
+ *
+ * @returns {ReactElement} Styled link.
+ */
+export const LinkButton = addFontSizeStyles( BaseLinkButton );

--- a/composites/Plugin/Shared/tests/LinkButtonTest.js
+++ b/composites/Plugin/Shared/tests/LinkButtonTest.js
@@ -1,0 +1,22 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import { BaseLinkButton, LinkButton } from "../components/LinkButton";
+
+test( "the BaseLinkButton matches the snapshot", () => {
+	const component = renderer.create(
+		<BaseLinkButton>LinkButtonValue</BaseLinkButton>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );
+
+test( "the LinkButton matches the snapshot", () => {
+	const component = renderer.create(
+		<LinkButton>LinkButtonValue</LinkButton>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );

--- a/composites/Plugin/Shared/tests/__snapshots__/ButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/ButtonTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BaseButton executes callback 1`] = `
 <button
-  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -12,7 +12,7 @@ exports[`BaseButton executes callback 1`] = `
 
 exports[`BaseButton executes callback 2`] = `
 <button
-  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -22,7 +22,7 @@ exports[`BaseButton executes callback 2`] = `
 
 exports[`SnippetPreviewButton executes callback 1`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -32,7 +32,7 @@ exports[`SnippetPreviewButton executes callback 1`] = `
 
 exports[`SnippetPreviewButton executes callback 2`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -42,7 +42,7 @@ exports[`SnippetPreviewButton executes callback 2`] = `
 
 exports[`the BaseButton matches the snapshot 1`] = `
 <button
-  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
   type="button"
 >
   ButtonValue
@@ -51,24 +51,24 @@ exports[`the BaseButton matches the snapshot 1`] = `
 
 exports[`the IconButton matches the snapshot 1`] = `
 <button
-  className="sc-bZQynM hjxBKu sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
   type="button"
 >
   <svg
     aria-hidden="true"
-    className="sc-gzVnrw gRPBNm"
+    className="sc-bZQynM gdBXij"
   />
 </button>
 `;
 
 exports[`the IconButton with text matches the snapshot 1`] = `
 <button
-  className="sc-bZQynM hjxBKu sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
   type="button"
 >
   <svg
     aria-hidden="true"
-    className="sc-htoDjs kcKEfw sc-dnqmqq IcJuo"
+    className="sc-gzVnrw kYMwGB sc-htoDjs gKJpvu"
   />
   Click
 </button>
@@ -76,7 +76,7 @@ exports[`the IconButton with text matches the snapshot 1`] = `
 
 exports[`the SnippetPreviewButton matches the snapshot 1`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
   type="button"
 >
   ButtonValue

--- a/composites/Plugin/Shared/tests/__snapshots__/ButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/ButtonTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BaseButton executes callback 1`] = `
 <button
-  className="sc-bxivhb kBfEqg sc-htpNat clPCcB sc-bwzfXH kGsEoO sc-bdVaJa jeGHIR"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
   onClick={[Function]}
   type="button"
 >
@@ -12,7 +12,7 @@ exports[`BaseButton executes callback 1`] = `
 
 exports[`BaseButton executes callback 2`] = `
 <button
-  className="sc-bxivhb kBfEqg sc-htpNat clPCcB sc-bwzfXH kGsEoO sc-bdVaJa jeGHIR"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
   onClick={[Function]}
   type="button"
 >
@@ -22,7 +22,7 @@ exports[`BaseButton executes callback 2`] = `
 
 exports[`SnippetPreviewButton executes callback 1`] = `
 <button
-  className="sc-ifAKCX ckKDht sc-bxivhb kBfEqg sc-htpNat clPCcB sc-bwzfXH kGsEoO sc-bdVaJa jeGHIR"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
   onClick={[Function]}
   type="button"
 >
@@ -32,7 +32,7 @@ exports[`SnippetPreviewButton executes callback 1`] = `
 
 exports[`SnippetPreviewButton executes callback 2`] = `
 <button
-  className="sc-ifAKCX ckKDht sc-bxivhb kBfEqg sc-htpNat clPCcB sc-bwzfXH kGsEoO sc-bdVaJa jeGHIR"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
   onClick={[Function]}
   type="button"
 >
@@ -42,7 +42,7 @@ exports[`SnippetPreviewButton executes callback 2`] = `
 
 exports[`the BaseButton matches the snapshot 1`] = `
 <button
-  className="sc-bxivhb kBfEqg sc-htpNat clPCcB sc-bwzfXH kGsEoO sc-bdVaJa jeGHIR"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
   type="button"
 >
   ButtonValue
@@ -51,24 +51,24 @@ exports[`the BaseButton matches the snapshot 1`] = `
 
 exports[`the IconButton matches the snapshot 1`] = `
 <button
-  className="sc-EHOje bYWNZw sc-ifAKCX ckKDht sc-bxivhb kBfEqg sc-htpNat clPCcB sc-bwzfXH kGsEoO sc-bdVaJa jeGHIR"
+  className="sc-bZQynM hjxBKu sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
   type="button"
 >
   <svg
     aria-hidden="true"
-    className="sc-bZQynM gdBXij"
+    className="sc-gzVnrw gRPBNm"
   />
 </button>
 `;
 
 exports[`the IconButton with text matches the snapshot 1`] = `
 <button
-  className="sc-EHOje bYWNZw sc-ifAKCX ckKDht sc-bxivhb kBfEqg sc-htpNat clPCcB sc-bwzfXH kGsEoO sc-bdVaJa jeGHIR"
+  className="sc-bZQynM hjxBKu sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
   type="button"
 >
   <svg
     aria-hidden="true"
-    className="sc-gzVnrw gGhCha sc-htoDjs gKJpvu"
+    className="sc-htoDjs kcKEfw sc-dnqmqq IcJuo"
   />
   Click
 </button>
@@ -76,7 +76,7 @@ exports[`the IconButton with text matches the snapshot 1`] = `
 
 exports[`the SnippetPreviewButton matches the snapshot 1`] = `
 <button
-  className="sc-ifAKCX ckKDht sc-bxivhb kBfEqg sc-htpNat clPCcB sc-bwzfXH kGsEoO sc-bdVaJa jeGHIR"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fALjbt sc-bdVaJa bXkERd"
   type="button"
 >
   ButtonValue

--- a/composites/Plugin/Shared/tests/__snapshots__/ButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/ButtonTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BaseButton executes callback 1`] = `
 <button
-  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -12,7 +12,7 @@ exports[`BaseButton executes callback 1`] = `
 
 exports[`BaseButton executes callback 2`] = `
 <button
-  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -22,7 +22,7 @@ exports[`BaseButton executes callback 2`] = `
 
 exports[`SnippetPreviewButton executes callback 1`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -32,7 +32,7 @@ exports[`SnippetPreviewButton executes callback 1`] = `
 
 exports[`SnippetPreviewButton executes callback 2`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -42,7 +42,7 @@ exports[`SnippetPreviewButton executes callback 2`] = `
 
 exports[`the BaseButton matches the snapshot 1`] = `
 <button
-  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
   type="button"
 >
   ButtonValue
@@ -51,7 +51,7 @@ exports[`the BaseButton matches the snapshot 1`] = `
 
 exports[`the IconButton matches the snapshot 1`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
   type="button"
 >
   <svg
@@ -63,7 +63,7 @@ exports[`the IconButton matches the snapshot 1`] = `
 
 exports[`the IconButton with text matches the snapshot 1`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
   type="button"
 >
   <svg
@@ -76,7 +76,7 @@ exports[`the IconButton with text matches the snapshot 1`] = `
 
 exports[`the SnippetPreviewButton matches the snapshot 1`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH hVByhd sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
   type="button"
 >
   ButtonValue

--- a/composites/Plugin/Shared/tests/__snapshots__/LinkButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/LinkButtonTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the BaseLinkButton matches the snapshot 1`] = `
 <a
-  className="sc-gZMcBi caVfpb sc-iwsKbI ANExe sc-dnqmqq hpxHJh sc-htoDjs vOazz sc-gzVnrw inKRYv"
+  className="sc-iwsKbI cKLwUL sc-dnqmqq cbsuMR sc-htoDjs ispJkh sc-gzVnrw dzwIfy sc-bZQynM hUnLvZ"
 >
   LinkButtonValue
 </a>
@@ -10,7 +10,7 @@ exports[`the BaseLinkButton matches the snapshot 1`] = `
 
 exports[`the LinkButton matches the snapshot 1`] = `
 <a
-  className="sc-gqjmRU eOiadv sc-gZMcBi caVfpb sc-iwsKbI ANExe sc-dnqmqq hpxHJh sc-htoDjs vOazz sc-gzVnrw inKRYv"
+  className="sc-gZMcBi hXZHGD sc-iwsKbI cKLwUL sc-dnqmqq cbsuMR sc-htoDjs ispJkh sc-gzVnrw dzwIfy sc-bZQynM hUnLvZ"
 >
   LinkButtonValue
 </a>

--- a/composites/Plugin/Shared/tests/__snapshots__/LinkButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/LinkButtonTest.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the BaseLinkButton matches the snapshot 1`] = `
+<a
+  className="sc-gZMcBi caVfpb sc-iwsKbI ANExe sc-dnqmqq hpxHJh sc-htoDjs vOazz sc-gzVnrw inKRYv"
+>
+  LinkButtonValue
+</a>
+`;
+
+exports[`the LinkButton matches the snapshot 1`] = `
+<a
+  className="sc-gqjmRU eOiadv sc-gZMcBi caVfpb sc-iwsKbI ANExe sc-dnqmqq hpxHJh sc-htoDjs vOazz sc-gzVnrw inKRYv"
+>
+  LinkButtonValue
+</a>
+`;

--- a/composites/Plugin/Shared/tests/__snapshots__/LinkButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/LinkButtonTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the BaseLinkButton matches the snapshot 1`] = `
 <a
-  className="sc-iwsKbI cKLwUL sc-dnqmqq cbsuMR sc-htoDjs ispJkh sc-gzVnrw dzwIfy sc-bZQynM hUnLvZ"
+  className="sc-iwsKbI cKLwUL sc-dnqmqq cbsuMR sc-htoDjs ispJkh sc-gzVnrw fvAesF sc-bZQynM hUnLvZ"
 >
   LinkButtonValue
 </a>
@@ -10,7 +10,7 @@ exports[`the BaseLinkButton matches the snapshot 1`] = `
 
 exports[`the LinkButton matches the snapshot 1`] = `
 <a
-  className="sc-gZMcBi hXZHGD sc-iwsKbI cKLwUL sc-dnqmqq cbsuMR sc-htoDjs ispJkh sc-gzVnrw dzwIfy sc-bZQynM hUnLvZ"
+  className="sc-gZMcBi hXZHGD sc-iwsKbI cKLwUL sc-dnqmqq cbsuMR sc-htoDjs ispJkh sc-gzVnrw fvAesF sc-bZQynM hUnLvZ"
 >
   LinkButtonValue
 </a>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added LinkButton component.

## Relevant technical choices:

Noticed a pre-existing CSS issue in the buttons, where `min-height` triggers a bug in IE 11 and other CSS produced misplaced icon and text in Edge. I think we're maybe a bit too much optimistic with `flexbox`, it doesn't work so well in some browsers especially with SVG icons (not just old browsers but also Safari...)

Details on the IE bug:
https://github.com/philipwalton/flexbugs#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items
min-height on a flex container won't apply to its flex items - Internet Explorer 10-11 (fixed in Edge)

IE 11:

![screenshot 49](https://user-images.githubusercontent.com/1682452/29973639-920a5c36-8f30-11e7-83e3-3906a64c22a7.png)

Edge:

![screenshot 50](https://user-images.githubusercontent.com/1682452/29973662-9f4a1b98-8f30-11e7-896c-370ac58502d6.png)

Easiest fix for the IE 11 bug: use height instead. Was there a specific reason to use min-height?

The CSS changes introduced here are not perfect, but at least the rendering is more or less consistent across browsers. Please test in depth in all browsers and platforms including IE/Edge.

Other changes:
- we don't need line-height, and it contributes to the icons misalignment (also on Safari 10)
- button elements already vertically center text natively, no need for line-height
- for links, we use `display: inline-flex;` and `align-items: center;`, treating the link content as flex items

Question:
- should we pass other link props?

## Test instructions

Use the following content in `ContentAnalysis.js` and run `yarn start`, then check localhost:3333

```
import React from "react";
import styled from "styled-components";
import { BaseButton, Button, InlineFlexButton, IconButton } from "../../Shared/components/Button";
import { YoastButton } from "../../Shared/components/YoastButton";
import { edit } from "../../../../style-guide/svg";
import { BaseLinkButton, LinkButton } from "../../Shared/components/LinkButton";

export const ContentAnalysisContainer = styled.div`
	min-height: 700px;
	padding: 40px;
	background-color: white;

	button,
	a {
		margin-right: 10px;
	}
`;

/**
 * Returns the ContentAnalysis component.
 *
 * @returns {ReactElement} The ContentAnalysis component.
 */
export default function ContentAnalysis() {
	return <ContentAnalysisContainer>
		<h2>Buttons</h2>
		<BaseButton>Base Button</BaseButton>
		<Button>Button</Button>
		<IconButton icon={ edit } iconColor="#c00" aria-label="IconButton with icon only" />
		<IconButton icon={ edit } iconColor="#c00">Icon Button</IconButton>
		<YoastButton>Yoast Button</YoastButton>
		<YoastButton backgroundColor="lightblue" textColor="#333" withTextShadow={ false }>Yoast Button</YoastButton>
		<h2>Links</h2>
		<BaseLinkButton href="#somewhere1">Base Button</BaseLinkButton>
		<LinkButton href="#somewhere2">Button</LinkButton>
	</ContentAnalysisContainer>;
}
```

Fixes #252
