### PR TITLE
Added backwards compatibility for SnippetPreview.js

### DIFF
--- a/composites/SnippetPreview/components/SnippetPreview.js
+++ b/composites/SnippetPreview/components/SnippetPreview.js
@@ -1,0 +1,3 @@
+// TODO: Remove in next major release, needed for backward compatibility
+import SnippetPreview from "../../Plugin/SnippetPreview/components/SnippetPreview";
+export default SnippetPreview;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* 

## Relevant technical choices:

* Temporarily added a `SnippetPreview.js` in its previous location (before folder restructure introduced in PR #232), to ensure backwards compatibility.

## Test instructions

This PR can be tested by following these steps:

* Import SnippetPreview from its previous location `composites/SnippetPreview/components/SnippetPreview.js`, and make sure it's the same component as `composites/Plugin/SnippetPreview/components/SnippetPreview.js`.
