### PR TITLE
Added configuration to allow test environment to be served to network.

### DIFF
--- a/composites/OnboardingWizard/config/api-config.js
+++ b/composites/OnboardingWizard/config/api-config.js
@@ -3,8 +3,11 @@
  *
  * @type {{url: string, headers: {X-WP-Nonce: string}}}
  */
+
+let host = window.location.host.split( ":" )[ 0 ];
+
 let apiConfig = {
-	url: "http://127.0.0.1:8882/onboarding",
+	url: "http://" + host + ":8882/onboarding",
 	headers: {
 		// The nonce is for WordPress only.
 		"X-WP-Nonce": "test1234",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,8 @@ module.exports = {
 	},
 	devServer: {
 		inline: true,
+		host: "0.0.0.0",
+		disableHostCheck: true,
 		port: PORT,
 		historyApiFallback: true,
 		hot: true,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Test environment can be served to machines in the same network ( i.e. mobile phones )

## Relevant technical choices:

* Host has been changed from `localhost` to `0.0.0.0`.

## Test instructions

This PR can be tested by following these steps:

* Make sure your firewall/router settings allow you to connect to the machine that is serving the test environment.
* Run the test environment (`yarn start`).
* Open a browser on a different device in your network and open `[your device's ip]:3333`
