### PR TITLE
SVG edit icon improvements

### DIFF
--- a/composites/Plugin/Shared/components/Icon.js
+++ b/composites/Plugin/Shared/components/Icon.js
@@ -20,7 +20,7 @@ export const Icon = ( props ) => {
 	// Remove the props that are no longer needed
 	const newProps = _omit( props, [ "icon", "size", "color" ] );
 
-	return <IconComponent aria-hidden="true" { ...newProps } />;
+	return <IconComponent role="img" aria-hidden="true" focusable="false" { ...newProps } />;
 };
 
 Icon.propTypes = {

--- a/composites/Plugin/Shared/tests/__snapshots__/ButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/ButtonTest.js.snap
@@ -57,6 +57,8 @@ exports[`the IconButton matches the snapshot 1`] = `
   <svg
     aria-hidden="true"
     className="sc-bZQynM gdBXij"
+    focusable="false"
+    role="img"
   />
 </button>
 `;
@@ -69,6 +71,8 @@ exports[`the IconButton with text matches the snapshot 1`] = `
   <svg
     aria-hidden="true"
     className="sc-gzVnrw kYMwGB sc-htoDjs gKJpvu"
+    focusable="false"
+    role="img"
   />
   Click
 </button>

--- a/composites/Plugin/Shared/tests/__snapshots__/IconTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/IconTest.js.snap
@@ -4,5 +4,7 @@ exports[`the Icon matches the snapshot 1`] = `
 <svg
   aria-hidden="true"
   className="sc-bdVaJa dURRQD"
+  focusable="false"
+  role="img"
 />
 `;

--- a/style-guide/svg/edit.svg
+++ b/style-guide/svg/edit.svg
@@ -1,6 +1,3 @@
-<?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
-        "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg fill="#000" width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg">
     <path d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z" />
 </svg>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improved SVG icons accessibility

## Relevant technical choices:

* adds the following attributes to the SVG markup: `role="img" aria-hidden="true" focusable="false"`

## Test instructions

This PR can be tested by following these steps:

* `role="img" aria-hidden="true"` make sure the icon is exposed to assistive technologies like an image and **not** announced
* `focusable="false"` fixes an IE 11 bug: when SVG icons are within focusable elements, they're considered focusable too, thus requiring to press Tab twice to navigate
* to test the IE 11 bug, use the following code in ContentAnalysis.js and verify you have to press Tab just once

```
import React from "react";
import styled from "styled-components";
import { IconButton } from "../../Shared/components/Button";
import { edit } from "../../../../style-guide/svg";

export const ContentAnalysisContainer = styled.div`
	min-height: 700px;
	padding: 40px;
	background-color: white;

	button{
		margin-right: 10px;
	}

	.with-max-width {
		max-width: 152px;
	}
`;

/**
 * Returns the ContentAnalysis component.
 *
 * @returns {ReactElement} The ContentAnalysis component.
 */
export default function ContentAnalysis() {
	return <ContentAnalysisContainer>
		<h2>Buttons</h2>
		<IconButton icon={ edit } iconColor="#c00" aria-label="IconButton with icon only" />
		<IconButton icon={ edit } iconColor="#c00">Icon Button</IconButton>
		<IconButton icon={ edit } iconColor="#c00" className="with-max-width">Icon Button a very long text here bla bla</IconButton>
	</ContentAnalysisContainer>;
}

```

Fixes #255 
