### PR TITLE
Add Yoast Link Button component.

### DIFF
--- a/composites/Plugin/Shared/components/Button.js
+++ b/composites/Plugin/Shared/components/Button.js
@@ -48,8 +48,8 @@ export function addBaseStyle( component ) {
 			align-self: center;
 		}
 
+		// Only needed for IE 10+.
 		@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-			// IE 10+
 			::after {
 				display: inline-block;
 				content: "";

--- a/composites/Plugin/Shared/components/Button.js
+++ b/composites/Plugin/Shared/components/Button.js
@@ -27,6 +27,7 @@ export function addBaseStyle( component ) {
 	return styled( component )`
 		display: inline-flex;
 		align-items: center;
+		justify-content: center;
 		vertical-align: middle;
 		border-width: ${ `${ settings.borderWidth }px` };
 		border-style: solid;

--- a/composites/Plugin/Shared/components/YoastButton.js
+++ b/composites/Plugin/Shared/components/YoastButton.js
@@ -1,8 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
+
 import colors from "../../../../style-guide/colors.json";
 import { rgba } from "../../../../style-guide/helpers";
+
+const settings = {
+	minHeight: 48,
+	verticalPadding: 0,
+	borderWidth: 0,
+};
+
+const ieMinHeight = settings.minHeight - ( settings.verticalPadding * 2 ) - ( settings.borderWidth * 2 );
 
 /**
  * Returns a component with a Yoast button-like style.
@@ -20,9 +29,10 @@ export function addButtonStyles( component ) {
 		align-items: center;
 		justify-content: center;
 		vertical-align: middle;
-		height: 48px;
+		min-height: ${ `${ settings.minHeight }px` };
 		margin: 0;
 		padding: 0 16px;
+		padding: ${ `${ settings.verticalPadding }px` } 16px;
 		border: 0;
 		border-radius: 4px;
 		box-sizing: border-box;
@@ -49,6 +59,15 @@ export function addButtonStyles( component ) {
 			align-items: inherit;
 			justify-content: inherit;
 			width: 100%;
+		}
+
+		// Only needed for IE 10+.
+		@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+			::after {
+				display: inline-block;
+				content: "";
+				min-height: ${ `${ ieMinHeight }px` };
+			}
 		}
 	`;
 }

--- a/composites/Plugin/Shared/components/YoastButton.js
+++ b/composites/Plugin/Shared/components/YoastButton.js
@@ -1,3 +1,4 @@
+import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import colors from "../../../../style-guide/colors.json";
@@ -15,12 +16,14 @@ import { rgba } from "../../../../style-guide/helpers";
  */
 export function addButtonStyles( component ) {
 	return styled( component )`
-		display: inline-block;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		vertical-align: middle;
 		height: 48px;
 		margin: 0;
 		padding: 0 16px;
 		border: 0;
-		vertical-align: middle;
 		border-radius: 4px;
 		box-sizing: border-box;
 		font: 400 14px/24px "Open Sans", sans-serif;
@@ -39,18 +42,47 @@ export function addButtonStyles( component ) {
 			transform: translateY( 1px );
 			box-shadow: none;
 		}
+
+		// Only needed for Safari 10.
+		span {
+			display: inherit;
+			align-items: inherit;
+			justify-content: inherit;
+			width: 100%;
+		}
 	`;
 }
 
 /**
+ * Returns a component with a button and an inner span element.
+ *
+ * The inner span is only needed to fix a Safari 10 bug with flexbox and button
+ * elements. This bug is fixed in Safari Technology Previs and in the future it
+ * will be possible to remove this component and directly style a button element.
+ * See https://github.com/philipwalton/flexbugs#9-some-html-elements-cant-be-flex-containers
+ *
+ * @returns {ReactElement} The button with inner span.
+ */
+const YoastButtonBase = ( { className, onClick, type, children } ) => (
+	<button className={ className } onClick={ onClick } type={ type }>
+		<span>
+			{ children }
+		</span>
+	</button>
+);
+
+/**
  * Returns a Button with the Yoast button style.
+ *
+ * We're styling the YoastButtonBase component just because of the Safari 10 bug.
+ * In the future, it will be possible to directly style a button element.
  *
  * @param {object} props Component props.
  *
  * @returns {ReactElement} Styled button.
  */
 export const YoastButton = addButtonStyles(
-	styled.button`
+	styled( YoastButtonBase )`
 		color: ${ props => props.textColor };
 		background: ${ props => props.backgroundColor };
 		min-width: 152px;

--- a/composites/Plugin/Shared/components/YoastButton.js
+++ b/composites/Plugin/Shared/components/YoastButton.js
@@ -85,8 +85,7 @@ YoastButtonBase.defaultProps = {
 /**
  * Returns a Button with the Yoast button style.
  *
- * We're styling the YoastButtonBase component just because of the Safari 10 bug.
- * In the future, it will be possible to directly style a button element.
+ * See the Safari 10 bug description in the YoastButtonBase JSDoc.
  *
  * @param {object} props Component props.
  *

--- a/composites/Plugin/Shared/components/YoastButton.js
+++ b/composites/Plugin/Shared/components/YoastButton.js
@@ -71,6 +71,17 @@ const YoastButtonBase = ( { className, onClick, type, children } ) => (
 	</button>
 );
 
+YoastButtonBase.propTypes = {
+	className: PropTypes.string,
+	onClick: PropTypes.func,
+	type: PropTypes.string,
+	children: PropTypes.string,
+};
+
+YoastButtonBase.defaultProps = {
+	type: "button",
+};
+
 /**
  * Returns a Button with the Yoast button style.
  *
@@ -99,13 +110,11 @@ export const YoastButton = addButtonStyles(
 YoastButton.propTypes = {
 	backgroundColor: PropTypes.string,
 	textColor: PropTypes.string,
-	type: PropTypes.string,
 	withTextShadow: PropTypes.bool,
 };
 
 YoastButton.defaultProps = {
 	backgroundColor: colors.$color_green_medium_light,
 	textColor: colors.$color_white,
-	type: "button",
 	withTextShadow: true,
 };

--- a/composites/Plugin/Shared/components/YoastLinkButton.js
+++ b/composites/Plugin/Shared/components/YoastLinkButton.js
@@ -4,11 +4,11 @@ import colors from "../../../../style-guide/colors.json";
 import { addButtonStyles } from "./YoastButton";
 
 /**
- * Returns a Button with the Yoast button style.
+ * Returns a Link with the Yoast button style.
  *
  * @param {object} props Component props.
  *
- * @returns {ReactElement} Styled button.
+ * @returns {ReactElement} Styled link.
  */
 export const YoastLinkButton = addButtonStyles(
 	styled.a`

--- a/composites/Plugin/Shared/components/YoastLinkButton.js
+++ b/composites/Plugin/Shared/components/YoastLinkButton.js
@@ -1,0 +1,34 @@
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import colors from "../../../../style-guide/colors.json";
+import { rgba } from "../../../../style-guide/helpers";
+import { addButtonStyles } from "./YoastButton";
+
+/**
+ * Returns a Button with the Yoast button style.
+ *
+ * @param {object} props Component props.
+ *
+ * @returns {ReactElement} Styled button.
+ */
+export const YoastLinkButton = addButtonStyles(
+	styled.a`
+		text-decoration: none;
+		color: ${ props => props.textColor };
+		background: ${ props => props.backgroundColor };
+		min-width: 152px;
+		${ props => props.withTextShadow ? `text-shadow: 0 0 2px ${ colors.$color_black }` : "" };
+	`
+);
+
+YoastLinkButton.propTypes = {
+	backgroundColor: PropTypes.string,
+	textColor: PropTypes.string,
+	withTextShadow: PropTypes.bool,
+};
+
+YoastLinkButton.defaultProps = {
+	backgroundColor: colors.$color_green_medium_light,
+	textColor: colors.$color_white,
+	withTextShadow: true,
+};

--- a/composites/Plugin/Shared/components/YoastLinkButton.js
+++ b/composites/Plugin/Shared/components/YoastLinkButton.js
@@ -1,7 +1,6 @@
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import colors from "../../../../style-guide/colors.json";
-import { rgba } from "../../../../style-guide/helpers";
 import { addButtonStyles } from "./YoastButton";
 
 /**

--- a/composites/Plugin/Shared/tests/YoastLinkButtonTest.js
+++ b/composites/Plugin/Shared/tests/YoastLinkButtonTest.js
@@ -1,0 +1,13 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import { YoastLinkButton } from "../components/YoastLinkButton";
+
+test( "the YoastLinkButton matches the snapshot", () => {
+	const component = renderer.create(
+		<YoastLinkButton>YoastLinkButtonValue</YoastLinkButton>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );

--- a/composites/Plugin/Shared/tests/__snapshots__/ButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/ButtonTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BaseButton executes callback 1`] = `
 <button
-  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -12,7 +12,7 @@ exports[`BaseButton executes callback 1`] = `
 
 exports[`BaseButton executes callback 2`] = `
 <button
-  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -22,7 +22,7 @@ exports[`BaseButton executes callback 2`] = `
 
 exports[`SnippetPreviewButton executes callback 1`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -32,7 +32,7 @@ exports[`SnippetPreviewButton executes callback 1`] = `
 
 exports[`SnippetPreviewButton executes callback 2`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -42,7 +42,7 @@ exports[`SnippetPreviewButton executes callback 2`] = `
 
 exports[`the BaseButton matches the snapshot 1`] = `
 <button
-  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
   type="button"
 >
   ButtonValue
@@ -51,7 +51,7 @@ exports[`the BaseButton matches the snapshot 1`] = `
 
 exports[`the IconButton matches the snapshot 1`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
   type="button"
 >
   <svg
@@ -65,7 +65,7 @@ exports[`the IconButton matches the snapshot 1`] = `
 
 exports[`the IconButton with text matches the snapshot 1`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
   type="button"
 >
   <svg
@@ -80,7 +80,7 @@ exports[`the IconButton with text matches the snapshot 1`] = `
 
 exports[`the SnippetPreviewButton matches the snapshot 1`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH fpmUPV sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
   type="button"
 >
   ButtonValue

--- a/composites/Plugin/Shared/tests/__snapshots__/ButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/ButtonTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BaseButton executes callback 1`] = `
 <button
-  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH crULWx sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -12,7 +12,7 @@ exports[`BaseButton executes callback 1`] = `
 
 exports[`BaseButton executes callback 2`] = `
 <button
-  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH crULWx sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -22,7 +22,7 @@ exports[`BaseButton executes callback 2`] = `
 
 exports[`SnippetPreviewButton executes callback 1`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH crULWx sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -32,7 +32,7 @@ exports[`SnippetPreviewButton executes callback 1`] = `
 
 exports[`SnippetPreviewButton executes callback 2`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH crULWx sc-bdVaJa dHgGrL"
   onClick={[Function]}
   type="button"
 >
@@ -42,7 +42,7 @@ exports[`SnippetPreviewButton executes callback 2`] = `
 
 exports[`the BaseButton matches the snapshot 1`] = `
 <button
-  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
+  className="sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH crULWx sc-bdVaJa dHgGrL"
   type="button"
 >
   ButtonValue
@@ -51,7 +51,7 @@ exports[`the BaseButton matches the snapshot 1`] = `
 
 exports[`the IconButton matches the snapshot 1`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH crULWx sc-bdVaJa dHgGrL"
   type="button"
 >
   <svg
@@ -65,7 +65,7 @@ exports[`the IconButton matches the snapshot 1`] = `
 
 exports[`the IconButton with text matches the snapshot 1`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH crULWx sc-bdVaJa dHgGrL"
   type="button"
 >
   <svg
@@ -80,7 +80,7 @@ exports[`the IconButton with text matches the snapshot 1`] = `
 
 exports[`the SnippetPreviewButton matches the snapshot 1`] = `
 <button
-  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH rPoSS sc-bdVaJa dHgGrL"
+  className="sc-EHOje FXgKN sc-ifAKCX jUaWfj sc-bxivhb kvsYTM sc-htpNat Opked sc-bwzfXH crULWx sc-bdVaJa dHgGrL"
   type="button"
 >
   ButtonValue

--- a/composites/Plugin/Shared/tests/__snapshots__/LinkButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/LinkButtonTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the BaseLinkButton matches the snapshot 1`] = `
 <a
-  className="sc-iwsKbI cKLwUL sc-dnqmqq cbsuMR sc-htoDjs ispJkh sc-gzVnrw iNlgVk sc-bZQynM hUnLvZ"
+  className="sc-iwsKbI cKLwUL sc-dnqmqq cbsuMR sc-htoDjs ispJkh sc-gzVnrw idLiDE sc-bZQynM hUnLvZ"
 >
   LinkButtonValue
 </a>
@@ -10,7 +10,7 @@ exports[`the BaseLinkButton matches the snapshot 1`] = `
 
 exports[`the LinkButton matches the snapshot 1`] = `
 <a
-  className="sc-gZMcBi hXZHGD sc-iwsKbI cKLwUL sc-dnqmqq cbsuMR sc-htoDjs ispJkh sc-gzVnrw iNlgVk sc-bZQynM hUnLvZ"
+  className="sc-gZMcBi hXZHGD sc-iwsKbI cKLwUL sc-dnqmqq cbsuMR sc-htoDjs ispJkh sc-gzVnrw idLiDE sc-bZQynM hUnLvZ"
 >
   LinkButtonValue
 </a>

--- a/composites/Plugin/Shared/tests/__snapshots__/LinkButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/LinkButtonTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the BaseLinkButton matches the snapshot 1`] = `
 <a
-  className="sc-iwsKbI cKLwUL sc-dnqmqq cbsuMR sc-htoDjs ispJkh sc-gzVnrw fvAesF sc-bZQynM hUnLvZ"
+  className="sc-iwsKbI cKLwUL sc-dnqmqq cbsuMR sc-htoDjs ispJkh sc-gzVnrw iNlgVk sc-bZQynM hUnLvZ"
 >
   LinkButtonValue
 </a>
@@ -10,7 +10,7 @@ exports[`the BaseLinkButton matches the snapshot 1`] = `
 
 exports[`the LinkButton matches the snapshot 1`] = `
 <a
-  className="sc-gZMcBi hXZHGD sc-iwsKbI cKLwUL sc-dnqmqq cbsuMR sc-htoDjs ispJkh sc-gzVnrw fvAesF sc-bZQynM hUnLvZ"
+  className="sc-gZMcBi hXZHGD sc-iwsKbI cKLwUL sc-dnqmqq cbsuMR sc-htoDjs ispJkh sc-gzVnrw iNlgVk sc-bZQynM hUnLvZ"
 >
   LinkButtonValue
 </a>

--- a/composites/Plugin/Shared/tests/__snapshots__/YoastButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/YoastButtonTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the YoastButton executes callback 1`] = `
 <button
-  className="sc-bwzfXH gyLiXM sc-bdVaJa exAxcS"
+  className="sc-bwzfXH eSKdVk sc-bdVaJa exAxcS"
   onClick={[Function]}
   type="button"
 >
@@ -14,7 +14,7 @@ exports[`the YoastButton executes callback 1`] = `
 
 exports[`the YoastButton executes callback 2`] = `
 <button
-  className="sc-bwzfXH gyLiXM sc-bdVaJa exAxcS"
+  className="sc-bwzfXH eSKdVk sc-bdVaJa exAxcS"
   onClick={[Function]}
   type="button"
 >
@@ -26,7 +26,7 @@ exports[`the YoastButton executes callback 2`] = `
 
 exports[`the YoastButton matches the snapshot 1`] = `
 <button
-  className="sc-bwzfXH gyLiXM sc-bdVaJa dNRIPk"
+  className="sc-bwzfXH eSKdVk sc-bdVaJa dNRIPk"
   onClick={undefined}
   type="button"
 >

--- a/composites/Plugin/Shared/tests/__snapshots__/YoastButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/YoastButtonTest.js.snap
@@ -2,29 +2,36 @@
 
 exports[`the YoastButton executes callback 1`] = `
 <button
-  className="sc-bwzfXH dQfeoL sc-bdVaJa exAxcS"
+  className="sc-bwzfXH gyLiXM sc-bdVaJa exAxcS"
   onClick={[Function]}
   type="button"
 >
-  ButtonValue
+  <span>
+    ButtonValue
+  </span>
 </button>
 `;
 
 exports[`the YoastButton executes callback 2`] = `
 <button
-  className="sc-bwzfXH dQfeoL sc-bdVaJa exAxcS"
+  className="sc-bwzfXH gyLiXM sc-bdVaJa exAxcS"
   onClick={[Function]}
   type="button"
 >
-  ButtonValue
+  <span>
+    ButtonValue
+  </span>
 </button>
 `;
 
 exports[`the YoastButton matches the snapshot 1`] = `
 <button
-  className="sc-bwzfXH dQfeoL sc-bdVaJa dNRIPk"
+  className="sc-bwzfXH gyLiXM sc-bdVaJa dNRIPk"
+  onClick={undefined}
   type="button"
 >
-  ButtonValue
+  <span>
+    ButtonValue
+  </span>
 </button>
 `;

--- a/composites/Plugin/Shared/tests/__snapshots__/YoastLinkButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/YoastLinkButtonTest.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the YoastLinkButton matches the snapshot 1`] = `
+<a
+  className="sc-bxivhb kaBAwn sc-htpNat czwPQj"
+>
+  YoastLinkButtonValue
+</a>
+`;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add Yoast Link Button component.

## Relevant technical choices:

* switches everything to `display: inline-flex;`
* adds a `YoastButtonBase` component that is a button with an inner span element to fix a Safari 10 bug, see https://github.com/philipwalton/flexbugs#9-some-html-elements-cant-be-flex-containers

This turned out to be a bit more complicated than expected. Safari 10 doesn't apply correctly flexbox on `<button>` elements. The suggested fix is to add an inner `<span>` and give it the necessary flex properties. I'm styling it inheriting some CSS properties from the parent button. Worth noting this bug seems fixed in Safari Technology Preview so in the future it will be possible to remove the fix: remove `YoastButtonBase` and directly style a button element.

We might consider to apply the same workaround to the normal buttons.

To reproduce the Safari 10 bug, use the Safari 10 inspector and remove the span from the "Test Button".

Not particularly happy with this, please let me know if the workaround is acceptable, any feedback welcome.

## Test instructions

This PR can be tested by following these steps:

* Put this in ContentAnalysis.js, run `yarn start` and go to http://localhost:3333
```
import React from "react";
import styled from "styled-components";
import { BaseButton, Button, IconButton } from "../../Shared/components/Button";
import { YoastButton } from "../../Shared/components/YoastButton";
import { edit } from "../../../../style-guide/svg";
import { BaseLinkButton, LinkButton } from "../../Shared/components/LinkButton";
import { YoastLinkButton } from "../../Shared/components/YoastLinkButton";

export const ContentAnalysisContainer = styled.div`
	min-height: 700px;
	padding: 40px;
	background-color: white;

	button,
	a {
		margin-right: 10px;
	}

	.with-max-width {
		max-width: 152px;
	}

	.test-large-button {
		min-width: 200px;
	}
`;

/**
 * Returns the ContentAnalysis component.
 *
 * @returns {ReactElement} The ContentAnalysis component.
 */
export default function ContentAnalysis() {
	return <ContentAnalysisContainer>
		<h2>Buttons</h2>
		<BaseButton>Base Button</BaseButton>
		<Button>Button</Button>
		<IconButton icon={ edit } iconColor="#c00" aria-label="IconButton with icon only" />
		<IconButton icon={ edit } iconColor="#c00">Icon Button</IconButton>
		<IconButton icon={ edit } iconColor="#c00" className="with-max-width">Icon Button a very long text here bla bla</IconButton>
		<YoastButton onClick={ () => {
			console.log( "hello Button" );
		} }>Yoast Button</YoastButton>
		<YoastButton backgroundColor="lightblue" textColor="#333" withTextShadow={ false }>Yoast Button</YoastButton>
		<YoastButton className="test-large-button">Test Button</YoastButton>
		<h2>Links</h2>
		<BaseLinkButton href="#somewhere1">Base Button</BaseLinkButton>
		<LinkButton href="#somewhere2">Button</LinkButton>
		<YoastLinkButton href="#somewhere3">Yoast Button</YoastLinkButton>
		<YoastLinkButton href="#somewhere4" backgroundColor="lightblue" textColor="#333" withTextShadow={ false }>Yoast Button</YoastLinkButton>
		<YoastLinkButton className="test-large-button" href="#somewhere3">Test Button</YoastLinkButton>
	</ContentAnalysisContainer>;
}
```

Fixes #253 
