### PR TITLE
Fix justify-content & z-index prop warning on LoadingIndicator component

### DIFF
--- a/composites/OnboardingWizard/LoadingIndicator.js
+++ b/composites/OnboardingWizard/LoadingIndicator.js
@@ -10,8 +10,6 @@ const style = {
 	refresh: {
 		display: "inline-block",
 		position: "relative",
-		zIndex: 11,
-		justifyContent: "center",
 	},
 };
 

--- a/composites/OnboardingWizard/LoadingIndicator.js
+++ b/composites/OnboardingWizard/LoadingIndicator.js
@@ -10,6 +10,8 @@ const style = {
 	refresh: {
 		display: "inline-block",
 		position: "relative",
+		zIndex: 11,
+		justifyContent: "center",
 	},
 };
 
@@ -26,8 +28,6 @@ const LoadingIndicator = () => (
 			top={100}
 			status="loading"
 			style={style.refresh}
-			justify-content= "center"
-			z-index={11}
 		/>
 	</div>
 );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a console error when switching pages in the Onboarding wizard.

## Test instructions

This PR can be tested by following these steps:

### To check that the prop warnings are gone
1. Open the OnboardingWizard and go to the next step.
2. Verify that the prop warning is no longer showing up in the console.

### To check that the props are properly applied as styles
1. Place `debugger;` as the first line in the `handleSuccessful` function in `OnboardingWizard.js`.
2. Open the OnboardingWizard and make sure you have the chrome debug tools open.
3. Go to the next step. Wait for the code execution to be paused by the `debugger` statement.
4. Search for the div where the loading indicator is rendered. It's **inside** a div with the class `"yoast-wizard-overlay-loader"`. Verify that the styles have been applied to this div.

```css
justify-content: "center";
z-index: 11;
```

Fixes #292
