### PR TITLE
Add Tabs and SubNavigation components

### DIFF
--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -1,11 +1,36 @@
 import React from "react";
 import styled from "styled-components";
 
+import SubNavigation from "../../../basic/SubNavigation";
+import PreviousTabs from "../../../basic/Tabs";
+import YoastTabs from "../../../basic/YoastTabs";
+
 export const ContentAnalysisContainer = styled.div`
 	min-height: 700px;
-	width: 100%;
+	padding: 40px;
 	background-color: white;
 `;
+
+let items = [
+	{
+		id: "tab1",
+		label: "tab1",
+		url: "http://localhost:3333/tab1",
+		view: <p>This is some content for tab 1. <a href="#">focusable element 1</a></p>,
+	},
+	{
+		id: "tab2",
+		label: "tab2",
+		url: "http://localhost:3333/tab2",
+		view: <p>This is some content for tab 2. <a href="#">focusable element 2</a></p>,
+	},
+	{
+		id: "tab3",
+		label: "tab3",
+		url: "http://localhost:3333/tab3",
+		view: <p>This is some content for tab 3. <a href="#">focusable element 3</a></p>,
+	},
+];
 
 /**
  * Returns the ContentAnalysis component.
@@ -13,5 +38,12 @@ export const ContentAnalysisContainer = styled.div`
  * @returns {ReactElement} The ContentAnalysis component.
  */
 export default function ContentAnalysis() {
-	return <ContentAnalysisContainer/>;
+	return <ContentAnalysisContainer>
+		<h1>Tabs experiments</h1>
+		<h2>Previous implementation</h2>
+		<SubNavigation items={ items } activeTab="http://localhost:3333/tab1" onClick={ () => {} } />
+		<PreviousTabs items={ items } activeTab="http://localhost:3333/tab1" />
+		<h2>Using "react-tabs"</h2>
+		<YoastTabs items={ items } />
+	</ContentAnalysisContainer>;
 }

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -1,36 +1,11 @@
 import React from "react";
 import styled from "styled-components";
 
-import SubNavigation from "../../../basic/SubNavigation";
-import PreviousTabs from "../../../basic/Tabs";
-import YoastTabs from "../../../basic/YoastTabs";
-
 export const ContentAnalysisContainer = styled.div`
 	min-height: 700px;
-	padding: 40px;
+	width: 100%;
 	background-color: white;
 `;
-
-let items = [
-	{
-		id: "tab1",
-		label: "tab1",
-		url: "http://localhost:3333/tab1",
-		view: <p>This is some content for tab 1. <a href="#">focusable element 1</a></p>,
-	},
-	{
-		id: "tab2",
-		label: "tab2",
-		url: "http://localhost:3333/tab2",
-		view: <p>This is some content for tab 2. <a href="#">focusable element 2</a></p>,
-	},
-	{
-		id: "tab3",
-		label: "tab3",
-		url: "http://localhost:3333/tab3",
-		view: <p>This is some content for tab 3. <a href="#">focusable element 3</a></p>,
-	},
-];
 
 /**
  * Returns the ContentAnalysis component.
@@ -38,12 +13,5 @@ let items = [
  * @returns {ReactElement} The ContentAnalysis component.
  */
 export default function ContentAnalysis() {
-	return <ContentAnalysisContainer>
-		<h1>Tabs experiments</h1>
-		<h2>Previous implementation</h2>
-		<SubNavigation items={ items } activeTab="http://localhost:3333/tab1" onClick={ () => {} } />
-		<PreviousTabs items={ items } activeTab="http://localhost:3333/tab1" />
-		<h2>Using "react-tabs"</h2>
-		<YoastTabs items={ items } />
-	</ContentAnalysisContainer>;
+	return <ContentAnalysisContainer/>;
 }

--- a/composites/basic/SubNavigation.js
+++ b/composites/basic/SubNavigation.js
@@ -11,7 +11,7 @@ const SubNavigationElement = styled.nav`
 	font-size: 1em;
 	text-transform: uppercase;
 	display: block;
-	
+
 	ul {
 		display: flex;
 		flex-wrap: wrap;
@@ -21,17 +21,17 @@ const SubNavigationElement = styled.nav`
 	    padding: 0;
 	    margin: 0;
 	}
-	
+
 	li {
 		display: inline-block;
 	    text-align: center;
 	    margin: 0 30px;
-		
+
 		&.tab-active {
 	        box-shadow: inset 0 -5px 0 0 ${ colors.$color_pink_dark }
 		}
 	}
-	
+
 	a {
 		padding: 10px;
 		display: flex;
@@ -97,7 +97,7 @@ export default class SubNavigation extends React.Component {
 }
 
 SubNavigation.propTypes = {
-	items: PropTypes.Array,
+	items: PropTypes.array,
 	activeTab: PropTypes.string.isRequired,
 	onClick: PropTypes.func.isRequired,
 };

--- a/composites/basic/SubNavigation.js
+++ b/composites/basic/SubNavigation.js
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import colors from "../../style-guide/colors.json";
+import PropTypes from "prop-types";
 
 /**
  * Defines the styling of the SubNavigationElement.
@@ -75,7 +76,7 @@ export default class SubNavigation extends React.Component {
 		return this.items.map( ( item ) => {
 			return (
 				<li key={ item.id } className={ item.url === this.props.activeTab ? "tab-active" : "" }>
-					<Link href={ item.url } onClick={ () => this.props.handler( item.url ) } > { item.label }</Link>
+					<Link href={ item.url } onClick={ () => this.props.onClick( item.url ) } > { item.label }</Link>
 				</li>
 			);
 		} );
@@ -94,3 +95,13 @@ export default class SubNavigation extends React.Component {
 		</SubNavigationElement> );
 	}
 }
+
+SubNavigation.propTypes = {
+	items: PropTypes.Array,
+	activeTab: PropTypes.String.isRequired,
+	onClick: PropTypes.Func.isRequired,
+};
+
+SubNavigation.defaultProps = {
+	items: [],
+};

--- a/composites/basic/SubNavigation.js
+++ b/composites/basic/SubNavigation.js
@@ -98,8 +98,8 @@ export default class SubNavigation extends React.Component {
 
 SubNavigation.propTypes = {
 	items: PropTypes.Array,
-	activeTab: PropTypes.String.isRequired,
-	onClick: PropTypes.Func.isRequired,
+	activeTab: PropTypes.string.isRequired,
+	onClick: PropTypes.func.isRequired,
 };
 
 SubNavigation.defaultProps = {

--- a/composites/basic/SubNavigation.js
+++ b/composites/basic/SubNavigation.js
@@ -1,0 +1,96 @@
+import React from "react";
+import styled from "styled-components";
+import colors from "../../style-guide/colors.json";
+
+/**
+ * Defines the styling of the SubNavigationElement.
+ */
+const SubNavigationElement = styled.nav`
+	border-bottom: 1px solid ${ colors.$color_grey_light };
+	font-size: 1em;
+	text-transform: uppercase;
+	display: block;
+	
+	ul {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		list-style: none;
+	    height: 100%;
+	    padding: 0;
+	    margin: 0;
+	}
+	
+	li {
+		display: inline-block;
+	    text-align: center;
+	    margin: 0 30px;
+		
+		&.tab-active {
+	        box-shadow: inset 0 -5px 0 0 ${ colors.$color_pink_dark }
+		}
+	}
+	
+	a {
+		padding: 10px;
+		display: flex;
+		align-items: flex-start;
+	}
+`;
+
+/**
+ * Defines the style of the Link component.
+ */
+const Link = styled.a`
+	color: ${ colors.$color_pink_dark };
+	text-decoration: none;
+	display: block;
+	padding: 18px 0;
+`;
+
+/**
+ * Creates a SubNavigation component to be used for the navigation between tabs.
+ */
+export default class SubNavigation extends React.Component {
+
+	/**
+	 * Construct the component.
+	 *
+	 * @param {Object} props The props to use within this component.
+	 *
+	 * @constructor
+	 */
+	constructor( props ) {
+		super( props );
+
+		this.items = props.items;
+	}
+
+	/**
+	 * Creates a li element for every menu item passed to the component.
+	 *
+	 * @returns {Array} Array containing the rendered lis.
+	 */
+	renderNavigationItems() {
+		return this.items.map( ( item ) => {
+			return (
+				<li key={ item.id } className={ item.url === this.props.activeTab ? "tab-active" : "" }>
+					<Link href={ item.url } onClick={ () => this.props.handler( item.url ) } > { item.label }</Link>
+				</li>
+			);
+		} );
+	}
+
+	/**
+	 * Renders the SubNavigation component.
+	 *
+	 * @returns {ReactElement} The rendered component.
+	 */
+	render() {
+		return ( <SubNavigationElement>
+			<ul>
+				{ this.renderNavigationItems() }
+			</ul>
+		</SubNavigationElement> );
+	}
+}

--- a/composites/basic/Tabs.js
+++ b/composites/basic/Tabs.js
@@ -61,7 +61,9 @@ class Tabs extends React.Component {
 	 * @returns {ReactElement} The rendered Tab component.
 	 */
 	addTab( id, url, content ) {
-		return <Tab key={ id } className={ url === this.state.activeTab ? "tab-active" : "" }>{ content }</Tab>
+		return <Tab key={ id } className={ url === this.state.activeTab ? "tab-active" : "" }>
+			{ content }
+		</Tab>;
 	}
 
 	/**
@@ -70,15 +72,20 @@ class Tabs extends React.Component {
 	 * @returns {ReactElement} The tabs.
 	 */
 	render() {
-		return <div>{ this.getTabs() }</div>
+		return <div>
+			{ this.getTabs() }
+		</div>;
 	}
 }
 
 Tabs.propTypes = {
+	items: PropTypes.Array,
 	isActive: PropTypes.bool,
+	activeTab: PropTypes.String.isRequired,
 };
 
 Tabs.defaultProps = {
+	items: [],
 	isActive: false,
 };
 

--- a/composites/basic/Tabs.js
+++ b/composites/basic/Tabs.js
@@ -81,7 +81,7 @@ class Tabs extends React.Component {
 Tabs.propTypes = {
 	items: PropTypes.Array,
 	isActive: PropTypes.bool,
-	activeTab: PropTypes.String.isRequired,
+	activeTab: PropTypes.string.isRequired,
 };
 
 Tabs.defaultProps = {

--- a/composites/basic/Tabs.js
+++ b/composites/basic/Tabs.js
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 const Tab = styled.section`
 	padding: 18px 20px;
 	display: none;
-	
+
 	&.tab-active {
 		display: block;
 	}
@@ -79,7 +79,7 @@ class Tabs extends React.Component {
 }
 
 Tabs.propTypes = {
-	items: PropTypes.Array,
+	items: PropTypes.array,
 	isActive: PropTypes.bool,
 	activeTab: PropTypes.string.isRequired,
 };

--- a/composites/basic/Tabs.js
+++ b/composites/basic/Tabs.js
@@ -1,0 +1,85 @@
+import React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+const Tab = styled.section`
+	padding: 18px 20px;
+	display: none;
+	
+	&.tab-active {
+		display: block;
+	}
+`;
+
+/**
+ * Creates a series of tabs.
+ */
+class Tabs extends React.Component {
+	/**
+	 * Constructs the class and sets its initial state.
+	 *
+	 * @param {Object} props The props to use within the component.
+	 *
+	 * @constructor
+	 */
+	constructor( props ) {
+		super( props );
+
+		this.state = { activeTab: this.props.activeTab };
+		this.getTabs();
+	}
+
+	/**
+	 * Checks whether props were changed and applies them to the state to change the currently active tab.
+	 *
+	 * @param {Object} newProps The new props to use.
+	 *
+	 * @returns {void}
+	 */
+	componentWillReceiveProps( newProps ) {
+		this.setState( { activeTab: newProps.activeTab } );
+	}
+
+	/**
+	 * Gets all the defined tabs and returns an array of ReactElements.
+	 *
+	 * @returns {Array} Array containing a Tab component for every defined item found in the props.
+	 */
+	getTabs() {
+		return this.props.items.map( ( item ) => {
+			return this.addTab( item.id, item.url, item.view );
+		} );
+	}
+
+	/**
+	 * Adds the Tab component.
+	 *
+	 * @param {string} id The unique ID for the tab.
+	 * @param {string} url The current URL to check against.
+	 * @param {ReactElement} content The content of the tab.
+	 *
+	 * @returns {ReactElement} The rendered Tab component.
+	 */
+	addTab( id, url, content ) {
+		return <Tab key={ id } className={ url === this.state.activeTab ? "tab-active" : "" }>{ content }</Tab>
+	}
+
+	/**
+	 * Renders out all the tabs.
+	 *
+	 * @returns {ReactElement} The tabs.
+	 */
+	render() {
+		return <div>{ this.getTabs() }</div>
+	}
+}
+
+Tabs.propTypes = {
+	isActive: PropTypes.bool,
+};
+
+Tabs.defaultProps = {
+	isActive: false,
+};
+
+export default Tabs;

--- a/composites/basic/YoastTabs.js
+++ b/composites/basic/YoastTabs.js
@@ -1,0 +1,135 @@
+import React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import { Tabs, TabList, Tab, TabPanel } from "react-tabs";
+
+import colors from "../../style-guide/colors.json";
+
+const YoastTabsContainer = styled.div`
+	border-bottom: 1px solid ${ colors.$color_grey_light };
+	font-size: 1em;
+
+	.react-tabs__tab-list {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		text-transform: uppercase;
+	}
+
+	.react-tabs__tab {
+		display: inline-block;
+		text-align: center;
+		margin: 0 30px;
+		padding: 10px;
+		color: ${ colors.$color_pink_dark };
+		cursor: pointer;
+
+		&.react-tabs__tab--selected {
+			box-shadow: inset 0 -5px 0 0 ${ colors.$color_pink_dark }
+		}
+	}
+
+	.react-tabs__tab-panel {
+		padding: 18px 20px;
+		display: none;
+
+		&.react-tabs__tab-panel--selected {
+			display: block;
+		}
+	}
+`;
+
+/**
+ * Creates a Yoast styled ARIA tabs widget.
+ */
+class YoastTabs extends React.Component {
+	/**
+	 * Constructs the class.
+	 *
+	 * @param {Object} props The props to use within the component.
+	 *
+	 * @constructor
+	 */
+	constructor( props ) {
+		super( props );
+	}
+
+	/**
+	 * Gets all the defined tabs and returns an array of Tab components.
+	 *
+	 * @returns {Array} Array containing a Tab component for each item in the props.
+	 */
+	getTabs() {
+		return this.props.items.map( ( item ) => {
+			return this.addTab( item.id, item.label );
+		} );
+	}
+
+	/**
+	 * Gets all the defined tabpanels and returns an array of TabPanel components.
+	 *
+	 * @returns {Array} Array containing a Tabpanel component for each item in the props.
+	 */
+	getTabPanels() {
+		return this.props.items.map( ( item ) => {
+			return this.addTabPanel( item.id, item.view );
+		} );
+	}
+
+	/**
+	 * Adds the Tab component.
+	 *
+	 * @param {string} id    The unique ID for the tab.
+	 * @param {string} label The tab label.
+	 *
+	 * @returns {ReactElement} The rendered Tab component.
+	 */
+	addTab( id, label ) {
+		return <Tab key={ id }>
+			{ label }
+		</Tab>;
+	}
+
+	/**
+	 * Adds the TabPanel component.
+	 *
+	 * @param {string}       id      The unique ID for the tabpanel.
+	 * @param {ReactElement} content The content of the tabpanel.
+	 *
+	 * @returns {ReactElement} The rendered TabPanel component.
+	 */
+	addTabPanel( id, content ) {
+		return <TabPanel key={ id } tabIndex="0">
+			{ content }
+		</TabPanel>;
+	}
+
+	/**
+	 * Renders the ARIA tabs widget.
+	 *
+	 * @returns {ReactElement} The ARIA tabs widget.
+	 */
+	render() {
+		return <YoastTabsContainer>
+			<Tabs>
+				<TabList>
+					{ this.getTabs() }
+				</TabList>
+				{ this.getTabPanels() }
+			</Tabs>
+		</YoastTabsContainer>;
+	}
+}
+
+YoastTabs.propTypes = {
+	items: PropTypes.array,
+};
+
+YoastTabs.defaultProps = {
+	items: [],
+};
+
+export default YoastTabs;

--- a/composites/basic/tests/SubNavigationTest.js
+++ b/composites/basic/tests/SubNavigationTest.js
@@ -3,12 +3,10 @@ import renderer from "react-test-renderer";
 
 import SubNavigation from "../SubNavigation.js";
 
-let state = { activeTab: "http://example.com/tab1" };
-
 let items = [
 	{ id: "tab1", label: "tab1", url: "http://localhost:3333/tab1", view: <p>This is some content for tab 1</p> },
 	{ id: "tab2", label: "tab2", url: "http://localhost:3333/tab2", view: <p>This is some content for tab 2</p> },
-	{ id: "tab3", label: "tab3", url: "http://localhost:3333/tab3", view: <p>This is some content for tab 3</p> }
+	{ id: "tab3", label: "tab3", url: "http://localhost:3333/tab3", view: <p>This is some content for tab 3</p> },
 ];
 
 test( "the SubNavigation matches the snapshot", () => {

--- a/composites/basic/tests/SubNavigationTest.js
+++ b/composites/basic/tests/SubNavigationTest.js
@@ -1,0 +1,21 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import SubNavigation from "../SubNavigation.js";
+
+let state = { activeTab: "http://example.com/tab1" };
+
+let items = [
+	{ id: "tab1", label: "tab1", url: "http://localhost:3333/tab1", view: <p>This is some content for tab 1</p> },
+	{ id: "tab2", label: "tab2", url: "http://localhost:3333/tab2", view: <p>This is some content for tab 2</p> },
+	{ id: "tab3", label: "tab3", url: "http://localhost:3333/tab3", view: <p>This is some content for tab 3</p> }
+];
+
+test( "the SubNavigation matches the snapshot", () => {
+	const component = renderer.create(
+		<SubNavigation items={ items } activeTab="http://localhost:3333/tab1"/>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );

--- a/composites/basic/tests/SubNavigationTest.js
+++ b/composites/basic/tests/SubNavigationTest.js
@@ -11,7 +11,7 @@ let items = [
 
 test( "the SubNavigation matches the snapshot", () => {
 	const component = renderer.create(
-		<SubNavigation items={ items } activeTab="http://localhost:3333/tab1"/>
+		<SubNavigation items={ items } activeTab="http://localhost:3333/tab1" onClick={ () => {} }/>
 	);
 
 	let tree = component.toJSON();

--- a/composites/basic/tests/TabsTest.js
+++ b/composites/basic/tests/TabsTest.js
@@ -1,0 +1,19 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import Tabs from "../Tabs.js";
+
+let items = [
+	{ id: "tab1", url: "http://example.com/tab1", view: <p>This is some content</p> },
+	{ id: "tab2", url: "http://example.com/tab2", view: <p>This is some content</p> },
+	{ id: "tab3", url: "http://example.com/tab3", view: <p>This is some content</p> }
+];
+
+test( "the SubNavigation with active first tab matches the snapshot", () => {
+	const component = renderer.create(
+	<Tabs items={ items } activeTab="http://example.com/tab1"/>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );

--- a/composites/basic/tests/TabsTest.js
+++ b/composites/basic/tests/TabsTest.js
@@ -6,7 +6,7 @@ import Tabs from "../Tabs.js";
 let items = [
 	{ id: "tab1", url: "http://example.com/tab1", view: <p>This is some content</p> },
 	{ id: "tab2", url: "http://example.com/tab2", view: <p>This is some content</p> },
-	{ id: "tab3", url: "http://example.com/tab3", view: <p>This is some content</p> }
+	{ id: "tab3", url: "http://example.com/tab3", view: <p>This is some content</p> },
 ];
 
 test( "the SubNavigation with active first tab matches the snapshot", () => {

--- a/composites/basic/tests/__snapshots__/SubNavigationTest.js.snap
+++ b/composites/basic/tests/__snapshots__/SubNavigationTest.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the SubNavigation matches the snapshot 1`] = `
+<nav
+  className="sc-bdVaJa isMQIV"
+>
+  <ul>
+    <li
+      className="tab-active"
+    >
+      <a
+        className="sc-bwzfXH hqQtJX"
+        href="http://localhost:3333/tab1"
+        onClick={[Function]}
+      >
+         
+        tab1
+      </a>
+    </li>
+    <li
+      className=""
+    >
+      <a
+        className="sc-bwzfXH hqQtJX"
+        href="http://localhost:3333/tab2"
+        onClick={[Function]}
+      >
+         
+        tab2
+      </a>
+    </li>
+    <li
+      className=""
+    >
+      <a
+        className="sc-bwzfXH hqQtJX"
+        href="http://localhost:3333/tab3"
+        onClick={[Function]}
+      >
+         
+        tab3
+      </a>
+    </li>
+  </ul>
+</nav>
+`;

--- a/composites/basic/tests/__snapshots__/SubNavigationTest.js.snap
+++ b/composites/basic/tests/__snapshots__/SubNavigationTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the SubNavigation matches the snapshot 1`] = `
 <nav
-  className="sc-bdVaJa isMQIV"
+  className="sc-bdVaJa cnsjKO"
 >
   <ul>
     <li

--- a/composites/basic/tests/__snapshots__/TabsTest.js.snap
+++ b/composites/basic/tests/__snapshots__/TabsTest.js.snap
@@ -3,21 +3,21 @@
 exports[`the SubNavigation with active first tab matches the snapshot 1`] = `
 <div>
   <section
-    className="tab-active sc-bdVaJa hboHnN"
+    className="tab-active sc-bdVaJa hknTxb"
   >
     <p>
       This is some content
     </p>
   </section>
   <section
-    className="sc-bdVaJa hboHnN"
+    className="sc-bdVaJa hknTxb"
   >
     <p>
       This is some content
     </p>
   </section>
   <section
-    className="sc-bdVaJa hboHnN"
+    className="sc-bdVaJa hknTxb"
   >
     <p>
       This is some content

--- a/composites/basic/tests/__snapshots__/TabsTest.js.snap
+++ b/composites/basic/tests/__snapshots__/TabsTest.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the SubNavigation with active first tab matches the snapshot 1`] = `
+<div>
+  <section
+    className="tab-active sc-bdVaJa hboHnN"
+  >
+    <p>
+      This is some content
+    </p>
+  </section>
+  <section
+    className="sc-bdVaJa hboHnN"
+  >
+    <p>
+      This is some content
+    </p>
+  </section>
+  <section
+    className="sc-bdVaJa hboHnN"
+  >
+    <p>
+      This is some content
+    </p>
+  </section>
+</div>
+`;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
     "react-redux": "^5.0.6",
+    "react-tabs": "^2.0.0",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
     "striptags": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,6 +1209,10 @@ circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
 
+classnames@^2.2.0:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -4619,7 +4623,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8:
+prop-types@^15.0.0, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -4805,6 +4809,13 @@ react-redux@^5.0.6:
     lodash-es "^4.2.0"
     loose-envify "^1.1.0"
     prop-types "^15.5.10"
+
+react-tabs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-2.0.0.tgz#ec793dd5589d731a8d34cfd1b5938b594e3167d8"
+  dependencies:
+    classnames "^2.2.0"
+    prop-types "^15.5.0"
 
 react-tap-event-plugin@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds Tabs and SubNavigation components

## Relevant technical choices:

* I've moved these files to the basic folder and made the name more generic than in @jcomack's original PR.

## Test instructions

Copy this to ContentAnalysis.js:

````js
import React from "react";
import styled from "styled-components";

import SubNavigation from "../../../basic/SubNavigation";
import PreviousTabs from "../../../basic/Tabs";
import YoastTabs from "../../../basic/YoastTabs";

export const ContentAnalysisContainer = styled.div`
	min-height: 700px;
	padding: 40px;
	background-color: white;
`;

let items = [
	{
		id: "tab1",
		label: "tab1",
		url: "http://localhost:3333/tab1",
		view: <p>This is some content for tab 1. <a href="#">focusable element 1</a></p>,
	},
	{
		id: "tab2",
		label: "tab2",
		url: "http://localhost:3333/tab2",
		view: <p>This is some content for tab 2. <a href="#">focusable element 2</a></p>,
	},
	{
		id: "tab3",
		label: "tab3",
		url: "http://localhost:3333/tab3",
		view: <p>This is some content for tab 3. <a href="#">focusable element 3</a></p>,
	},
];

/**
 * Returns the ContentAnalysis component.
 *
 * @returns {ReactElement} The ContentAnalysis component.
 */
export default function ContentAnalysis() {
	return <ContentAnalysisContainer>
		<h1>Tabs experiments</h1>
		<h2>Previous implementation</h2>
		<SubNavigation items={ items } activeTab="http://localhost:3333/tab1" onClick={ () => {} } />
		<PreviousTabs items={ items } activeTab="http://localhost:3333/tab1" />
		<h2>Using "react-tabs"</h2>
		<YoastTabs items={ items } />
	</ContentAnalysisContainer>;
}
````

Fixes #215
Fixes #216
