### PR TITLE
Fixed StepButton prop types error

### DIFF
--- a/composites/OnboardingWizard/StepIndicator.js
+++ b/composites/OnboardingWizard/StepIndicator.js
@@ -64,19 +64,15 @@ class StepIndicator extends React.Component {
 				// Return a custom step button, without a label for non-active steps.
 				let className = this.getStepButtonClass( key, amountOfSteps );
 
-				button = new CustomStepButton( {
-					index: stepNumber,
-					tooltip: currentField.title,
-					ariaLabel: ariaLabel,
-					className,
-					// See github.com/Yoast/wordpress-seo/issues/5530.
-					tooltipStyles: {
-						userSelect: "auto",
-					},
-					onClick: ( evt ) => {
+				button = <CustomStepButton
+					index={ stepNumber.toString() }
+					tooltip={ currentField.title }
+					ariaLabel={ ariaLabel }
+					className={ className }
+					tooltipStyles={ { userSelect: "auto" } }
+					onClick={ ( evt ) => {
 						this.props.onClick( name, evt );
-					},
-				} );
+					} } />;
 			}
 			return React.createElement( Step, { key: "step-indicator-" + key }, button );
 		} );


### PR DESCRIPTION
## Summary
Fun fact: I have no idea how this fixes the error.

This PR can be summarized in the following changelog entry:

* Fixes react prop types console error in Onboarding Wizard.

## Test instructions

This PR can be tested by following these steps:

* Open the onboarding wizard
* Notice that the error is no longer there

Fixes #180
