### PR TITLE
A11yNotice

### DIFF
--- a/composites/HelpCenter/views/VideoTutorial.js
+++ b/composites/HelpCenter/views/VideoTutorial.js
@@ -1,0 +1,48 @@
+import React from "react";
+import styled from "styled-components";
+import YouTubeVideo from "../../basic/YouTubeVideo";
+import PropTypes from "prop-types";
+
+const Section = styled.section`
+	display: flex;
+	padding: 1em;
+`;
+
+const VideoTutorialPlaceholder = styled( Section )`
+	flex-wrap: wrap;
+`;
+
+const VideoTextPanel = styled( Section )`
+	min-width: 220px;
+	max-width: 550px;
+	flex: 50% 0;
+`;
+
+const StyledYouTubeVideo = styled( YouTubeVideo )`
+	flex: 50% 0;
+`;
+
+/**
+ * Creates a VideoTutorial component that displays a YouTube video.
+ *
+ * @param {Object} props The props to use for the component.
+ * @returns {ReactElement} The rendered VideoTutorial component.
+ *
+ * @constructor
+ */
+export default function VideoTutorial( props ) {
+	return (
+		<VideoTutorialPlaceholder>
+			<StyledYouTubeVideo	src={ props.src } title={ props.title } />
+			<VideoTextPanel>
+				{ props.description }
+			</VideoTextPanel>
+		</VideoTutorialPlaceholder>
+	);
+}
+
+VideoTutorial.propTypes = {
+	src: PropTypes.string.isRequired,
+	title: PropTypes.string.isRequired,
+	description: PropTypes.string.isRequired,
+};

--- a/composites/HelpCenter/views/tests/VideoTutorialTest.js
+++ b/composites/HelpCenter/views/tests/VideoTutorialTest.js
@@ -1,0 +1,14 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import VideoTutorial from "../VideoTutorial.js";
+
+test( "the VideoTutorial component matches the snapshot", () => {
+	const component = renderer.create(
+		<VideoTutorial src="https:/www.youtube.com/embed/bIgcj_pPIbw" title="Video title" description="Video description"/>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );
+

--- a/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
+++ b/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the VideoTutorial component matches the snapshot 1`] = `
+<section
+  className="sc-htpNat hqgsEe sc-bwzfXH gwKLSd"
+>
+  <iframe
+    allowFullScreen={true}
+    className="sc-bdVaJa bDWFJH"
+    frameBorder={0}
+    height={315}
+    src="https:/www.youtube.com/embed/bIgcj_pPIbw"
+    title="Video title"
+    width={560}
+  />
+  <section
+    className="sc-bxivhb foTyhW sc-bwzfXH gwKLSd"
+  >
+    Video description
+  </section>
+</section>
+`;

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -1,6 +1,5 @@
 import React from "react";
 import styled from "styled-components";
-import VideoTutorial from "../../../HelpCenter/views/VideoTutorial.js";
 
 export const ContentAnalysisContainer = styled.div`
 	min-height: 700px;
@@ -14,7 +13,5 @@ export const ContentAnalysisContainer = styled.div`
  * @returns {ReactElement} The ContentAnalysis component.
  */
 export default function ContentAnalysis() {
-	return <ContentAnalysisContainer>
-		<VideoTutorial src="https:/www.youtube.com/embed/bIgcj_pPIbw" title="Video title" description="Video description"/>
-	</ContentAnalysisContainer>;
+	return <ContentAnalysisContainer/>;
 }

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import VideoTutorial from "../../../HelpCenter/views/VideoTutorial.js";
 
 export const ContentAnalysisContainer = styled.div`
 	min-height: 700px;
@@ -13,5 +14,7 @@ export const ContentAnalysisContainer = styled.div`
  * @returns {ReactElement} The ContentAnalysis component.
  */
 export default function ContentAnalysis() {
-	return <ContentAnalysisContainer/>;
+	return <ContentAnalysisContainer>
+		<VideoTutorial src="https:/www.youtube.com/embed/bIgcj_pPIbw" title="Video title" description="Video description"/>
+	</ContentAnalysisContainer>;
 }

--- a/composites/Plugin/Shared/components/A11yNotice.js
+++ b/composites/Plugin/Shared/components/A11yNotice.js
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+
+/**
+ * A paragraph tag invisible to the user, but not to screen readers.
+ *
+ * If you need a different element then a paragraph, you can use styled-component's .withComponent function.
+ */
+export const A11yNotice = styled.p`
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute !important;
+	width: 1px;
+	word-wrap: normal !important;
+`;

--- a/composites/Plugin/Shared/components/A11yNotice.js
+++ b/composites/Plugin/Shared/components/A11yNotice.js
@@ -1,11 +1,11 @@
 import styled from "styled-components";
 
 /**
- * A paragraph tag invisible to the user, but not to screen readers.
+ * A span tag invisible to the user, but not to screen readers.
  *
- * If you need a different element then a paragraph, you can use styled-component's .withComponent function.
+ * If you need a different element then a span, you can use styled-component's .withComponent function.
  */
-export const A11yNotice = styled.p`
+export const A11yNotice = styled.span`
 	border: 0;
 	clip: rect(1px, 1px, 1px, 1px);
 	clip-path: inset(50%);

--- a/composites/Plugin/Shared/tests/A11yNoticeTest.js
+++ b/composites/Plugin/Shared/tests/A11yNoticeTest.js
@@ -1,0 +1,26 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import { A11yNotice } from "../components/A11yNotice";
+
+test( "the A11yNotice matches the snapshot", () => {
+	const component = renderer.create(
+		<A11yNotice>A11yNoticeValue</A11yNotice>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );
+
+
+test( "the A11yNotice can be changed to a different element", () => {
+	const H2A11yNotice = A11yNotice.withComponent( "h2" );
+
+	const component = renderer.create(
+		<H2A11yNotice>H2A11yNoticeValue</H2A11yNotice>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+	expect( tree.type ).toEqual( "h2" );
+} );

--- a/composites/Plugin/Shared/tests/__snapshots__/A11yNoticeTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/A11yNoticeTest.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the A11yNotice can be changed to a different element 1`] = `
+<h2
+  className="sc-bwzfXH imMJZB"
+>
+  H2A11yNoticeValue
+</h2>
+`;
+
+exports[`the A11yNotice matches the snapshot 1`] = `
+<p
+  className="sc-bdVaJa hAyGSm"
+>
+  A11yNoticeValue
+</p>
+`;

--- a/composites/Plugin/Shared/tests/__snapshots__/A11yNoticeTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/A11yNoticeTest.js.snap
@@ -9,9 +9,9 @@ exports[`the A11yNotice can be changed to a different element 1`] = `
 `;
 
 exports[`the A11yNotice matches the snapshot 1`] = `
-<p
+<span
   className="sc-bdVaJa hAyGSm"
 >
   A11yNoticeValue
-</p>
+</span>
 `;

--- a/composites/basic/IFrame.js
+++ b/composites/basic/IFrame.js
@@ -10,5 +10,5 @@ import * as React from "react";
  * @constructor
  */
 export default function IFrame( props ) {
-	return ( <iframe {...props} />	);
+	return ( <iframe { ...props } />	);
 }

--- a/composites/basic/YouTubeVideo.js
+++ b/composites/basic/YouTubeVideo.js
@@ -1,0 +1,44 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import IFrame from "../../composites/basic/IFrame";
+
+const StyledIFrame = styled( IFrame )``;
+
+/**
+ * Creates a YouTubeVideo component.
+ *
+ * @param {Object} props The props to use for the component.
+ *
+ * @returns {ReactElement} The YouTubeVideo component.
+ *
+ * @constructor
+ */
+export default function YouTubeVideo( props ) {
+	return (
+		<StyledIFrame
+			width={ props.width }
+			height={ props.height }
+			src={ props.src }
+			title={ props.title }
+		    frameBorder={ props.frameBorder }
+		    allowFullScreen={ props.allowFullScreen }
+		/>
+	);
+}
+
+YouTubeVideo.propTypes = {
+	width: PropTypes.number,
+	height: PropTypes.number,
+	src: PropTypes.string.isRequired,
+	title: PropTypes.string.isRequired,
+	frameBorder: PropTypes.number,
+	allowFullScreen: PropTypes.bool,
+};
+
+YouTubeVideo.defaultProps = {
+	width: 560,
+	height: 315,
+	frameBorder: 0,
+	allowFullScreen: true,
+};

--- a/composites/basic/tests/YouTubeVideoTest.js
+++ b/composites/basic/tests/YouTubeVideoTest.js
@@ -1,0 +1,13 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import YouTubeVideo from "../YouTubeVideo.js";
+
+test( "the YouTubeVideo component matches the snapshot", () => {
+	const component = renderer.create(
+		<YouTubeVideo src="https:/www.youtube.com/embed/bIgcj_pPIbw" title="Video title"/>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );

--- a/composites/basic/tests/__snapshots__/YouTubeVideoTest.js.snap
+++ b/composites/basic/tests/__snapshots__/YouTubeVideoTest.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the YouTubeVideo component matches the snapshot 1`] = `
+<iframe
+  allowFullScreen={true}
+  className="sc-bdVaJa bDWFJH"
+  frameBorder={0}
+  height={315}
+  src="https:/www.youtube.com/embed/bIgcj_pPIbw"
+  title="Video title"
+  width={560}
+/>
+`;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds an invisible A11y component for screen readers.

## Relevant technical choices:

* Made the component a `span` element by default, but this can be overwritten with `styled-components`'s [`.withComponent`](https://www.styled-components.com/docs/api#withcomponent) function.

## Test instructions

This PR can be tested by following these steps:

* Copy the following content into `ContentAnalysis.js`:
```js
import React from "react";
import styled from "styled-components";

import { A11yNotice } from "../../Shared/components/A11yNotice";

export const ContentAnalysisContainer = styled.div`
	min-height: 700px;
	width: 100%;
	background-color: white;
`;

/**
 * Returns the ContentAnalysis component.
 *
 * @returns {ReactElement} The ContentAnalysis component.
 */
export default function ContentAnalysis() {
	const H1A11yNotice = A11yNotice.withComponent( "h1" );
	return <ContentAnalysisContainer>
		<p>The following text is invisible:</p>
		<A11yNotice>Invisible text</A11yNotice>
		<p>The following header is invisible:</p>
		<H1A11yNotice>Invisible header</H1A11yNotice>
	</ContentAnalysisContainer>;
}
```
* Inspect the two `p` tags that are displayed and make sure they are followed by a invisible `span` and `h1` element.
* Use a screen reader to make sure the text is read to you.

Fixes #278
