### PR TITLE
Introduce react-tabs for the Help Center tabs.

### DIFF
--- a/composites/Plugin/Shared/components/YoastTabs.js
+++ b/composites/Plugin/Shared/components/YoastTabs.js
@@ -5,7 +5,7 @@ import { Tabs, TabList, Tab, TabPanel } from "react-tabs";
 
 import colors from "../../../../style-guide/colors.json";
 
-const YoastTabsContainer = styled.div`
+const YoastTabsContainer = styled( Tabs )`
 	border-bottom: 1px solid ${ colors.$color_grey_light };
 	font-size: 1em;
 
@@ -64,7 +64,13 @@ class YoastTabs extends React.Component {
 	 */
 	getTabPanels() {
 		return this.props.items.map( ( item ) => {
-			return <TabPanel key={ item.id } tabIndex="0">{ item.content }</TabPanel>;
+			return(
+				<TabPanel
+					key={ item.id }
+					tabIndex="0">
+					{ item.content }
+				</TabPanel>
+			);
 		} );
 	}
 
@@ -74,14 +80,14 @@ class YoastTabs extends React.Component {
 	 * @returns {ReactElement} The ARIA tabs widget.
 	 */
 	render() {
-		return <YoastTabsContainer>
-			<Tabs>
+		return(
+			<YoastTabsContainer>
 				<TabList>
 					{ this.getTabs() }
 				</TabList>
 				{ this.getTabPanels() }
-			</Tabs>
-		</YoastTabsContainer>;
+			</YoastTabsContainer>
+		);
 	}
 }
 

--- a/composites/Plugin/Shared/components/YoastTabs.js
+++ b/composites/Plugin/Shared/components/YoastTabs.js
@@ -28,7 +28,7 @@ const YoastTabsContainer = styled( Tabs )`
 		cursor: pointer;
 
 		&.react-tabs__tab--selected {
-			box-shadow: inset 0 -5px 0 0 ${ colors.$color_pink_dark }
+			box-shadow: inset 0 -5px 0 0 ${ colors.$color_pink_dark };
 		}
 	}
 

--- a/composites/Plugin/Shared/components/YoastTabs.js
+++ b/composites/Plugin/Shared/components/YoastTabs.js
@@ -6,7 +6,6 @@ import { Tabs, TabList, Tab, TabPanel } from "react-tabs";
 import colors from "../../../../style-guide/colors.json";
 
 const YoastTabsContainer = styled( Tabs )`
-	border-bottom: 1px solid ${ colors.$color_grey_light };
 	font-size: 1em;
 
 	.react-tabs__tab-list {
@@ -17,6 +16,7 @@ const YoastTabsContainer = styled( Tabs )`
 		padding: 0;
 		margin: 0;
 		text-transform: uppercase;
+		border-bottom: 1px solid ${ colors.$color_grey_light };
 	}
 
 	.react-tabs__tab {

--- a/composites/Plugin/Shared/components/YoastTabs.js
+++ b/composites/Plugin/Shared/components/YoastTabs.js
@@ -1,0 +1,102 @@
+import React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import { Tabs, TabList, Tab, TabPanel } from "react-tabs";
+
+import colors from "../../../../style-guide/colors.json";
+
+const YoastTabsContainer = styled.div`
+	border-bottom: 1px solid ${ colors.$color_grey_light };
+	font-size: 1em;
+
+	.react-tabs__tab-list {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		text-transform: uppercase;
+	}
+
+	.react-tabs__tab {
+		display: inline-block;
+		text-align: center;
+		margin: 0 30px;
+		padding: 10px;
+		color: ${ colors.$color_pink_dark };
+		cursor: pointer;
+
+		&.react-tabs__tab--selected {
+			box-shadow: inset 0 -5px 0 0 ${ colors.$color_pink_dark }
+		}
+	}
+
+	.react-tabs__tab-panel {
+		padding: 18px 20px;
+		display: none;
+
+		&.react-tabs__tab-panel--selected {
+			display: block;
+		}
+	}
+`;
+
+/**
+ * Creates a Yoast styled ARIA tabs widget.
+ */
+class YoastTabs extends React.Component {
+	/**
+	 * Gets all the defined tabs and returns an array of Tab components.
+	 *
+	 * @returns {Array} Array containing a Tab component for each item in the props.
+	 */
+	getTabs() {
+		return this.props.items.map( ( item ) => {
+			return <Tab key={ item.id }>{ item.label }</Tab>;
+		} );
+	}
+
+	/**
+	 * Gets all the defined tabpanels and returns an array of TabPanel components.
+	 *
+	 * @returns {Array} Array containing a Tabpanel component for each item in the props.
+	 */
+	getTabPanels() {
+		return this.props.items.map( ( item ) => {
+			return <TabPanel key={ item.id } tabIndex="0">{ item.view }</TabPanel>;
+		} );
+	}
+
+	/**
+	 * Renders the ARIA tabs widget.
+	 *
+	 * @returns {ReactElement} The ARIA tabs widget.
+	 */
+	render() {
+		return <YoastTabsContainer>
+			<Tabs>
+				<TabList>
+					{ this.getTabs() }
+				</TabList>
+				{ this.getTabPanels() }
+			</Tabs>
+		</YoastTabsContainer>;
+	}
+}
+
+YoastTabs.propTypes = {
+	items: PropTypes.arrayOf(
+		PropTypes.shape( {
+			id: PropTypes.string.isRequired,
+			label: PropTypes.string.isRequired,
+			view: PropTypes.object.isRequired,
+		} )
+	),
+};
+
+YoastTabs.defaultProps = {
+	items: [],
+};
+
+export default YoastTabs;

--- a/composites/Plugin/Shared/components/YoastTabs.js
+++ b/composites/Plugin/Shared/components/YoastTabs.js
@@ -64,7 +64,7 @@ class YoastTabs extends React.Component {
 	 */
 	getTabPanels() {
 		return this.props.items.map( ( item ) => {
-			return <TabPanel key={ item.id } tabIndex="0">{ item.view }</TabPanel>;
+			return <TabPanel key={ item.id } tabIndex="0">{ item.content }</TabPanel>;
 		} );
 	}
 
@@ -90,7 +90,7 @@ YoastTabs.propTypes = {
 		PropTypes.shape( {
 			id: PropTypes.string.isRequired,
 			label: PropTypes.string.isRequired,
-			view: PropTypes.object.isRequired,
+			content: PropTypes.object.isRequired,
 		} )
 	),
 };

--- a/composites/Plugin/Shared/tests/YoastTabsTest.js
+++ b/composites/Plugin/Shared/tests/YoastTabsTest.js
@@ -1,0 +1,31 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import YoastTabs from "../components/YoastTabs";
+
+test( "the YoastTabs matches the snapshot", () => {
+	const items = [
+		{
+			id: "tab1",
+			label: "tab1",
+			view: <p>This is some content for tab 1. <a href="#">focusable element 1</a></p>,
+		},
+		{
+			id: "tab2",
+			label: "tab2",
+			view: <p>This is some content for tab 2. <a href="#">focusable element 2</a></p>,
+		},
+		{
+			id: "tab3",
+			label: "tab3",
+			view: <p>This is some content for tab 3. <a href="#">focusable element 3</a></p>,
+		},
+	];
+
+	const component = renderer.create(
+		<YoastTabs items={ items } />
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );

--- a/composites/Plugin/Shared/tests/YoastTabsTest.js
+++ b/composites/Plugin/Shared/tests/YoastTabsTest.js
@@ -8,17 +8,17 @@ test( "the YoastTabs matches the snapshot", () => {
 		{
 			id: "tab1",
 			label: "tab1",
-			view: <p>This is some content for tab 1. <a href="#">focusable element 1</a></p>,
+			content: <p>This is some content for tab 1. <a href="#">focusable element 1</a></p>,
 		},
 		{
 			id: "tab2",
 			label: "tab2",
-			view: <p>This is some content for tab 2. <a href="#">focusable element 2</a></p>,
+			content: <p>This is some content for tab 2. <a href="#">focusable element 2</a></p>,
 		},
 		{
 			id: "tab3",
 			label: "tab3",
-			view: <p>This is some content for tab 3. <a href="#">focusable element 3</a></p>,
+			content: <p>This is some content for tab 3. <a href="#">focusable element 3</a></p>,
 		},
 	];
 

--- a/composites/Plugin/Shared/tests/__snapshots__/YoastTabsTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/YoastTabsTest.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the YoastTabs matches the snapshot 1`] = `
+<div
+  className="sc-bdVaJa kXyDjN"
+>
+  <div
+    className="react-tabs"
+    data-tabs={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+  >
+    <ul
+      className="react-tabs__tab-list"
+      role="tablist"
+    >
+      <li
+        aria-controls="react-tabs-1"
+        aria-disabled="false"
+        aria-selected="true"
+        className="react-tabs__tab react-tabs__tab--selected"
+        id="react-tabs-0"
+        role="tab"
+        tabIndex="0"
+      >
+        tab1
+      </li>
+      <li
+        aria-controls="react-tabs-3"
+        aria-disabled="false"
+        aria-selected="false"
+        className="react-tabs__tab"
+        id="react-tabs-2"
+        role="tab"
+        tabIndex={null}
+      >
+        tab2
+      </li>
+      <li
+        aria-controls="react-tabs-5"
+        aria-disabled="false"
+        aria-selected="false"
+        className="react-tabs__tab"
+        id="react-tabs-4"
+        role="tab"
+        tabIndex={null}
+      >
+        tab3
+      </li>
+    </ul>
+    <div
+      aria-labelledby="react-tabs-0"
+      className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+      id="react-tabs-1"
+      role="tabpanel"
+      style={Object {}}
+      tabIndex="0"
+    >
+      <p>
+        This is some content for tab 1. 
+        <a
+          href="#"
+        >
+          focusable element 1
+        </a>
+      </p>
+    </div>
+    <div
+      aria-labelledby="react-tabs-2"
+      className="react-tabs__tab-panel"
+      id="react-tabs-3"
+      role="tabpanel"
+      style={Object {}}
+      tabIndex="0"
+    />
+    <div
+      aria-labelledby="react-tabs-4"
+      className="react-tabs__tab-panel"
+      id="react-tabs-5"
+      role="tabpanel"
+      style={Object {}}
+      tabIndex="0"
+    />
+  </div>
+</div>
+`;

--- a/composites/Plugin/Shared/tests/__snapshots__/YoastTabsTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/YoastTabsTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the YoastTabs matches the snapshot 1`] = `
 <div
-  className="sc-bdVaJa ereLAB"
+  className="sc-bdVaJa iynCuu"
   data-tabs={true}
   onClick={[Function]}
   onKeyDown={[Function]}

--- a/composites/Plugin/Shared/tests/__snapshots__/YoastTabsTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/YoastTabsTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the YoastTabs matches the snapshot 1`] = `
 <div
-  className="sc-bdVaJa kXyDjN"
+  className="sc-bdVaJa ereLAB"
   data-tabs={true}
   onClick={[Function]}
   onKeyDown={[Function]}

--- a/composites/Plugin/Shared/tests/__snapshots__/YoastTabsTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/YoastTabsTest.js.snap
@@ -3,84 +3,80 @@
 exports[`the YoastTabs matches the snapshot 1`] = `
 <div
   className="sc-bdVaJa kXyDjN"
+  data-tabs={true}
+  onClick={[Function]}
+  onKeyDown={[Function]}
 >
-  <div
-    className="react-tabs"
-    data-tabs={true}
-    onClick={[Function]}
-    onKeyDown={[Function]}
+  <ul
+    className="react-tabs__tab-list"
+    role="tablist"
   >
-    <ul
-      className="react-tabs__tab-list"
-      role="tablist"
-    >
-      <li
-        aria-controls="react-tabs-1"
-        aria-disabled="false"
-        aria-selected="true"
-        className="react-tabs__tab react-tabs__tab--selected"
-        id="react-tabs-0"
-        role="tab"
-        tabIndex="0"
-      >
-        tab1
-      </li>
-      <li
-        aria-controls="react-tabs-3"
-        aria-disabled="false"
-        aria-selected="false"
-        className="react-tabs__tab"
-        id="react-tabs-2"
-        role="tab"
-        tabIndex={null}
-      >
-        tab2
-      </li>
-      <li
-        aria-controls="react-tabs-5"
-        aria-disabled="false"
-        aria-selected="false"
-        className="react-tabs__tab"
-        id="react-tabs-4"
-        role="tab"
-        tabIndex={null}
-      >
-        tab3
-      </li>
-    </ul>
-    <div
-      aria-labelledby="react-tabs-0"
-      className="react-tabs__tab-panel react-tabs__tab-panel--selected"
-      id="react-tabs-1"
-      role="tabpanel"
-      style={Object {}}
+    <li
+      aria-controls="react-tabs-1"
+      aria-disabled="false"
+      aria-selected="true"
+      className="react-tabs__tab react-tabs__tab--selected"
+      id="react-tabs-0"
+      role="tab"
       tabIndex="0"
     >
-      <p>
-        This is some content for tab 1. 
-        <a
-          href="#"
-        >
-          focusable element 1
-        </a>
-      </p>
-    </div>
-    <div
-      aria-labelledby="react-tabs-2"
-      className="react-tabs__tab-panel"
-      id="react-tabs-3"
-      role="tabpanel"
-      style={Object {}}
-      tabIndex="0"
-    />
-    <div
-      aria-labelledby="react-tabs-4"
-      className="react-tabs__tab-panel"
-      id="react-tabs-5"
-      role="tabpanel"
-      style={Object {}}
-      tabIndex="0"
-    />
+      tab1
+    </li>
+    <li
+      aria-controls="react-tabs-3"
+      aria-disabled="false"
+      aria-selected="false"
+      className="react-tabs__tab"
+      id="react-tabs-2"
+      role="tab"
+      tabIndex={null}
+    >
+      tab2
+    </li>
+    <li
+      aria-controls="react-tabs-5"
+      aria-disabled="false"
+      aria-selected="false"
+      className="react-tabs__tab"
+      id="react-tabs-4"
+      role="tab"
+      tabIndex={null}
+    >
+      tab3
+    </li>
+  </ul>
+  <div
+    aria-labelledby="react-tabs-0"
+    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    id="react-tabs-1"
+    role="tabpanel"
+    style={Object {}}
+    tabIndex="0"
+  >
+    <p>
+      This is some content for tab 1. 
+      <a
+        href="#"
+      >
+        focusable element 1
+      </a>
+    </p>
   </div>
+  <div
+    aria-labelledby="react-tabs-2"
+    className="react-tabs__tab-panel"
+    id="react-tabs-3"
+    role="tabpanel"
+    style={Object {}}
+    tabIndex="0"
+  />
+  <div
+    aria-labelledby="react-tabs-4"
+    className="react-tabs__tab-panel"
+    id="react-tabs-5"
+    role="tabpanel"
+    style={Object {}}
+    tabIndex="0"
+  />
 </div>
 `;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
     "react-redux": "^5.0.6",
+    "react-tabs": "^2.0.0",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
     "striptags": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,6 +1209,10 @@ circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
 
+classnames@^2.2.0:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -4619,7 +4623,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8:
+prop-types@^15.0.0, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -4805,6 +4809,13 @@ react-redux@^5.0.6:
     lodash-es "^4.2.0"
     loose-envify "^1.1.0"
     prop-types "^15.5.10"
+
+react-tabs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-2.0.0.tgz#ec793dd5589d731a8d34cfd1b5938b594e3167d8"
+  dependencies:
+    classnames "^2.2.0"
+    prop-types "^15.5.0"
 
 react-tap-event-plugin@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds the Help Center ARIA tabs widget component

## Relevant technical choices:

* Introduces `react-tabs`

## Test instructions

This PR can be tested by following these steps:

* use the following code in ContentAnalysis
```
import React from "react";
import styled from "styled-components";

import YoastTabs from "../../Shared/components/YoastTabs";

export const ContentAnalysisContainer = styled.div`
	min-height: 700px;
	padding: 40px;
	background-color: white;
`;

let items = [
	{
		id: "tab1",
		label: "video tutorial",
		content: <p>This is some content for tab 1. <a href="#">focusable element 1</a></p>,
	},
	{
		id: "tab2",
		label: "knowledge base",
		content: <p>This is some content for tab 2. <a href="#">focusable element 2</a></p>,
	},
	{
		id: "tab3",
		label: "email support",
		content: <p>This is some content for tab 3. <a href="#">focusable element 3</a></p>,
	},
];

/**
 * Returns the ContentAnalysis component.
 *
 * @returns {ReactElement} The ContentAnalysis component.
 */
export default function ContentAnalysis() {
	return <ContentAnalysisContainer>
		<h2>Using "react-tabs"</h2>
		<YoastTabs items={ items } />
	</ContentAnalysisContainer>;
}
```

Questions:
- does `view` need to be named `view`? for consistency with the ScoreAssessments, `html` would be better or, maybe, `content` even better
- does it needs to be passed as html object (as implemented in the original PR see #294) or as string? In the second case, I guess it should use `dangerouslySetInnerHTML` ...

Fixes #216
