### PR TITLE
Implement A11yNotice component

### DIFF
--- a/composites/Plugin/Shared/components/A11yNotice.js
+++ b/composites/Plugin/Shared/components/A11yNotice.js
@@ -1,0 +1,46 @@
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+import colors from "../../../../style-guide/colors.json";
+import { rgba } from "../../../../style-guide/helpers";
+import { addButtonStyles, addFontSizeStyles } from "./Button";
+
+/**
+ * Returns a basic link styled like a button.
+ *
+ * @param {object} props Component props.
+ *
+ * @returns {ReactElement} Styled button.
+ */
+export const BaseLinkButton = addButtonStyles(
+	styled.a`
+		text-decoration: none;
+		color: ${ props => props.textColor };
+		border-color: ${ props => props.borderColor };
+		background: ${ props => props.backgroundColor };
+		box-shadow: 0 1px 0 ${ props => rgba( props.boxShadowColor, 1 ) };
+	`
+);
+
+BaseLinkButton.propTypes = {
+	backgroundColor: PropTypes.string,
+	textColor: PropTypes.string,
+	borderColor: PropTypes.string,
+	boxShadowColor: PropTypes.string,
+};
+
+BaseLinkButton.defaultProps = {
+	backgroundColor: colors.$color_button,
+	textColor: colors.$color_button_text,
+	borderColor: colors.$color_button_border,
+	boxShadowColor: colors.$color_button_border,
+};
+
+/**
+ * Returns a link styled like a button with set font size.
+ *
+ * @param {object} props Component props.
+ *
+ * @returns {ReactElement} Styled link.
+ */
+export const LinkButton = addFontSizeStyles( BaseLinkButton );

--- a/composites/Plugin/Shared/components/A11yNotice.js
+++ b/composites/Plugin/Shared/components/A11yNotice.js
@@ -1,46 +1,19 @@
 import styled from "styled-components";
-import PropTypes from "prop-types";
-
-import colors from "../../../../style-guide/colors.json";
-import { rgba } from "../../../../style-guide/helpers";
-import { addButtonStyles, addFontSizeStyles } from "./Button";
 
 /**
- * Returns a basic link styled like a button.
+ * A span tag invisible to the user, but not to screen readers.
  *
- * @param {object} props Component props.
- *
- * @returns {ReactElement} Styled button.
+ * If you need a different element then a span, you can use styled-component's .withComponent function.
  */
-export const BaseLinkButton = addButtonStyles(
-	styled.a`
-		text-decoration: none;
-		color: ${ props => props.textColor };
-		border-color: ${ props => props.borderColor };
-		background: ${ props => props.backgroundColor };
-		box-shadow: 0 1px 0 ${ props => rgba( props.boxShadowColor, 1 ) };
-	`
-);
-
-BaseLinkButton.propTypes = {
-	backgroundColor: PropTypes.string,
-	textColor: PropTypes.string,
-	borderColor: PropTypes.string,
-	boxShadowColor: PropTypes.string,
-};
-
-BaseLinkButton.defaultProps = {
-	backgroundColor: colors.$color_button,
-	textColor: colors.$color_button_text,
-	borderColor: colors.$color_button_border,
-	boxShadowColor: colors.$color_button_border,
-};
-
-/**
- * Returns a link styled like a button with set font size.
- *
- * @param {object} props Component props.
- *
- * @returns {ReactElement} Styled link.
- */
-export const LinkButton = addFontSizeStyles( BaseLinkButton );
+export const A11yNotice = styled.span`
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute !important;
+	width: 1px;
+	word-wrap: normal !important;
+`;

--- a/composites/Plugin/Shared/tests/A11yNoticeTest.js
+++ b/composites/Plugin/Shared/tests/A11yNoticeTest.js
@@ -1,0 +1,26 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import { A11yNotice } from "../components/A11yNotice";
+
+test( "the A11yNotice matches the snapshot", () => {
+	const component = renderer.create(
+		<A11yNotice>A11yNoticeValue</A11yNotice>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );
+
+
+test( "the A11yNotice can be changed to a different element", () => {
+	const H2A11yNotice = A11yNotice.withComponent( "h2" );
+
+	const component = renderer.create(
+		<H2A11yNotice>H2A11yNoticeValue</H2A11yNotice>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+	expect( tree.type ).toEqual( "h2" );
+} );

--- a/composites/Plugin/Shared/tests/__snapshots__/A11yNoticeTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/A11yNoticeTest.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the A11yNotice can be changed to a different element 1`] = `
+<h2
+  className="sc-bwzfXH imMJZB"
+>
+  H2A11yNoticeValue
+</h2>
+`;
+
+exports[`the A11yNotice matches the snapshot 1`] = `
+<span
+  className="sc-bdVaJa hAyGSm"
+>
+  A11yNoticeValue
+</span>
+`;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds an invisible A11y component for screen readers.

## Relevant technical choices:

* Made the component a `span` element by default, but this can be overwritten with `styled-components`'s [`.withComponent`](https://www.styled-components.com/docs/api#withcomponent) function.

## Test instructions

This PR can be tested by following these steps:

* Copy the following content into `ContentAnalysis.js`:
```js
import React from "react";
import styled from "styled-components";

import { A11yNotice } from "../../Shared/components/A11yNotice";

export const ContentAnalysisContainer = styled.div`
	min-height: 700px;
	width: 100%;
	background-color: white;
`;

/**
 * Returns the ContentAnalysis component.
 *
 * @returns {ReactElement} The ContentAnalysis component.
 */
export default function ContentAnalysis() {
	const H1A11yNotice = A11yNotice.withComponent( "h1" );
	return <ContentAnalysisContainer>
		<p>The following text is invisible:</p>
		<A11yNotice>Invisible text</A11yNotice>
		<p>The following header is invisible:</p>
		<H1A11yNotice>Invisible header</H1A11yNotice>
	</ContentAnalysisContainer>;
}
```
* Inspect the two `p` tags that are displayed and make sure they are followed by a invisible `span` and `h1` element.
* Use a screen reader to make sure the text is read to you.

Fixes #278
