### PR TITLE
Reset outline style on the react tab panels.

### DIFF
--- a/composites/AlgoliaSearch/ArticleContent.js
+++ b/composites/AlgoliaSearch/ArticleContent.js
@@ -36,7 +36,7 @@ class ArticleContent extends React.Component {
 
 ArticleContent.propTypes = {
 	post: PropTypes.object.isRequired,
-	title: PropTypes.string
+	title: PropTypes.string,
 };
 
 ArticleContent.defaultProps = {

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -1,8 +1,6 @@
 import React from "react";
 import styled from "styled-components";
 
-import AlgoliaSearcher from "../../../AlgoliaSearch/AlgoliaSearcher";
-
 export const ContentAnalysisContainer = styled.div`
 	min-height: 700px;
 	width: 100%;
@@ -15,7 +13,5 @@ export const ContentAnalysisContainer = styled.div`
  * @returns {ReactElement} The ContentAnalysis component.
  */
 export default function ContentAnalysis() {
-	return <ContentAnalysisContainer>
-		<AlgoliaSearcher />
-	</ContentAnalysisContainer>;
+	return <ContentAnalysisContainer/>;
 }

--- a/composites/Plugin/Shared/components/YoastTabs.js
+++ b/composites/Plugin/Shared/components/YoastTabs.js
@@ -33,8 +33,12 @@ const YoastTabsContainer = styled( Tabs )`
 	}
 
 	.react-tabs__tab-panel {
-		padding: 18px 20px;
 		display: none;
+		padding: 18px 20px;
+
+		:focus {
+			outline: none;
+		}
 
 		&.react-tabs__tab-panel--selected {
 			display: block;

--- a/composites/Plugin/Shared/tests/__snapshots__/YoastTabsTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/YoastTabsTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the YoastTabs matches the snapshot 1`] = `
 <div
-  className="sc-bdVaJa iynCuu"
+  className="sc-bdVaJa cuBObg"
   data-tabs={true}
   onClick={[Function]}
   onKeyDown={[Function]}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Reset the outline style on the react tab panels

## Test instructions

This PR can be tested by following these steps:

* test with this code in ContentAnalysis, then tab from the tabs to the tabpanels and check they don't display the outline style when focused
```
import React from "react";
import styled from "styled-components";

import YoastTabs from "../../Shared/components/YoastTabs";

export const ContentAnalysisContainer = styled.div`
	min-height: 700px;
	padding: 40px;
	background-color: white;
`;

let items = [
	{
		id: "tab1",
		label: "video tutorial",
		content: <p>This is some content for tab 1. <a href="#">focusable element 1</a></p>,
	},
	{
		id: "tab2",
		label: "knowledge base",
		content: <p>This is some content for tab 2. <a href="#">focusable element 2</a></p>,
	},
	{
		id: "tab3",
		label: "email support",
		content: <p>This is some content for tab 3. <a href="#">focusable element 3</a></p>,
	},
];

/**
 * Returns the ContentAnalysis component.
 *
 * @returns {ReactElement} The ContentAnalysis component.
 */
export default function ContentAnalysis() {
	return <ContentAnalysisContainer>
		<YoastTabs items={ items } />
	</ContentAnalysisContainer>;
}
```

Fixes #312 
