### PR TITLE
Match the tabs underline with the design.

### DIFF
--- a/composites/Plugin/Shared/components/YoastTabs.js
+++ b/composites/Plugin/Shared/components/YoastTabs.js
@@ -16,7 +16,7 @@ const YoastTabsContainer = styled( Tabs )`
 		padding: 0;
 		margin: 0;
 		text-transform: uppercase;
-		border-bottom: 1px solid ${ colors.$color_grey_light };
+		border-bottom: 4px solid ${ colors.$color_grey_light };
 	}
 
 	.react-tabs__tab {
@@ -26,9 +26,10 @@ const YoastTabsContainer = styled( Tabs )`
 		padding: 10px;
 		color: ${ colors.$color_pink_dark };
 		cursor: pointer;
+		margin-bottom: -4px;
 
 		&.react-tabs__tab--selected {
-			box-shadow: inset 0 -5px 0 0 ${ colors.$color_pink_dark };
+			box-shadow: inset 0 -4px 0 0 ${ colors.$color_pink_dark };
 		}
 	}
 

--- a/composites/Plugin/Shared/tests/__snapshots__/YoastTabsTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/YoastTabsTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the YoastTabs matches the snapshot 1`] = `
 <div
-  className="sc-bdVaJa cuBObg"
+  className="sc-bdVaJa bhQcjN"
   data-tabs={true}
   onClick={[Function]}
   onKeyDown={[Function]}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improved design of the Tabs underline.

## Relevant technical choices:

* if I'm not wrong the underline is 4px tall
* the underline now is on top of the border
* to perfectly match the design, there's the need of a new gray in the palette (`#e0e0e0`). Not sure if we should add it just for this unique use case. /cc @hedgefield 

## Test instructions

This PR can be tested by following these steps:

* use the following code in ContentAnalysis
```
import React from "react";
import styled from "styled-components";

import YoastTabs from "../../Shared/components/YoastTabs";

export const ContentAnalysisContainer = styled.div`
	min-height: 700px;
	padding: 40px;
	background-color: white;
`;

let items = [
	{
		id: "tab1",
		label: "video tutorial",
		content: <p>This is some content for tab 1. <a href="#">focusable element 1</a></p>,
	},
	{
		id: "tab2",
		label: "knowledge base",
		content: <p>This is some content for tab 2. <a href="#">focusable element 2</a></p>,
	},
	{
		id: "tab3",
		label: "email support",
		content: <p>This is some content for tab 3. <a href="#">focusable element 3</a></p>,
	},
];

/**
 * Returns the ContentAnalysis component.
 *
 * @returns {ReactElement} The ContentAnalysis component.
 */
export default function ContentAnalysis() {
	return <ContentAnalysisContainer>
		<YoastTabs items={ items } />
	</ContentAnalysisContainer>;
}
```

Screenshot:

<img width="1440" alt="screen shot 2017-09-29 at 15 06 52" src="https://user-images.githubusercontent.com/1682452/31017146-dc9003c0-a527-11e7-8567-7f332fc2cb54.png">

Fixes #322
