### PR TITLE
Add Help Center to index

### DIFF
--- a/App.js
+++ b/App.js
@@ -46,7 +46,7 @@ const components = [
 	{
 		id: "help-center",
 		name: "Help center",
-		component: <HelpCenterWrapper items={ [] }/>,
+		component: <HelpCenterWrapper />,
 	},
 ];
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Title</title>
+    <title>Yoast Components</title>
     <link rel="stylesheet" href="dist/yoast-components-standalone.min.css" />
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/draft-js/0.7.0/Draft.min.css">
 </head>

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import Section from "./forms/Section";
 import Textarea from "./forms/Textarea";
 import OnboardingWizard from "./composites/OnboardingWizard/OnboardingWizard";
 import AlgoliaSearcher from "./composites/AlgoliaSearch/AlgoliaSearcher";
+import HelpCenter from "./composites/Plugin/HelpCenter/HelpCenter.js";
 import MessageBox from "./composites/OnboardingWizard/MessageBox";
 
 export {
@@ -19,5 +20,6 @@ export {
 	Textarea,
 	OnboardingWizard,
 	AlgoliaSearcher,
-	MessageBox
+	MessageBox,
+	HelpCenter,
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add HelpCenter to index.js

## Relevant technical choices:

* Add HelpCenter to index.js
* Remove unused props from HelpCenterWrapper implementation
* Change title in the index.html to 'Yoast Components'

Last part of the implementation of #203 

Fixes #203 