### PR TITLE
Improve yoast button link hover style

### DIFF
--- a/composites/AlgoliaSearch/tests/__snapshots__/AlgoliaSearcherTest.js.snap
+++ b/composites/AlgoliaSearch/tests/__snapshots__/AlgoliaSearcherTest.js.snap
@@ -47,7 +47,7 @@ exports[`the AlgoliaSearcher component with headingText matches the snapshot 1`]
       />
       <button
         aria-expanded={undefined}
-        className="sc-bwzfXH bMXkXR sc-bdVaJa bsIiYo"
+        className="sc-bwzfXH jWIihg sc-bdVaJa bsIiYo"
         onClick={undefined}
         type="submit"
       >

--- a/composites/AlgoliaSearch/tests/__snapshots__/SearchBarTest.js.snap
+++ b/composites/AlgoliaSearch/tests/__snapshots__/SearchBarTest.js.snap
@@ -44,7 +44,7 @@ exports[`the SearchBar component with headingText matches the snapshot 1`] = `
     />
     <button
       aria-expanded={undefined}
-      className="sc-bwzfXH bMXkXR sc-bdVaJa bsIiYo"
+      className="sc-bwzfXH jWIihg sc-bdVaJa bsIiYo"
       onClick={undefined}
       type="submit"
     >
@@ -100,7 +100,7 @@ exports[`the SearchBar component without headingText matches the snapshot 1`] = 
     />
     <button
       aria-expanded={undefined}
-      className="sc-bwzfXH bMXkXR sc-bdVaJa bsIiYo"
+      className="sc-bwzfXH jWIihg sc-bdVaJa bsIiYo"
       onClick={undefined}
       type="submit"
     >

--- a/composites/AlgoliaSearch/tests/__snapshots__/SearchResultDetailTest.js.snap
+++ b/composites/AlgoliaSearch/tests/__snapshots__/SearchResultDetailTest.js.snap
@@ -9,7 +9,7 @@ exports[`the SearchResultDetail component matches the snapshot 1`] = `
   >
     <button
       aria-expanded={undefined}
-      className="sc-htpNat jjDFDi sc-bwzfXH dIZeqH"
+      className="sc-htpNat jsmbHK sc-bwzfXH dIZeqH"
       onClick={[Function]}
       type="button"
     >
@@ -25,7 +25,7 @@ exports[`the SearchResultDetail component matches the snapshot 1`] = `
     </button>
     <a
       aria-label="Open the knowledge base article in a new window or read it in the iframe below"
-      className="sc-htoDjs hpJeHy sc-ifAKCX hUQGAF sc-bxivhb ccVExY"
+      className="sc-htoDjs hpJeHy sc-ifAKCX keDKTL sc-bxivhb ccVExY"
       href="https://kb.yoast.com/kb/passive-voice/"
       rel="noopener noreferrer"
       target="_blank"

--- a/composites/Plugin/HelpCenter/tests/__snapshots__/HelpCenterTest.js.snap
+++ b/composites/Plugin/HelpCenter/tests/__snapshots__/HelpCenterTest.js.snap
@@ -6,7 +6,7 @@ exports[`the HelpCenter matches the snapshot 1`] = `
 >
   <button
     aria-expanded={false}
-    className="sc-htpNat gBIKzG sc-bwzfXH bMXkXR sc-bdVaJa bsIiYo"
+    className="sc-htpNat gBIKzG sc-bwzfXH jWIihg sc-bdVaJa bsIiYo"
     onClick={[Function]}
     type="button"
   >
@@ -35,7 +35,7 @@ exports[`the HelpCenter with props matches the snapshot 1`] = `
 >
   <button
     aria-expanded={false}
-    className="sc-htpNat gBIKzG sc-bwzfXH bMXkXR sc-bdVaJa iWweBU"
+    className="sc-htpNat gBIKzG sc-bwzfXH jWIihg sc-bdVaJa iWweBU"
     onClick={[Function]}
     type="button"
   >

--- a/composites/Plugin/Shared/components/YoastButton.js
+++ b/composites/Plugin/Shared/components/YoastButton.js
@@ -42,10 +42,12 @@ export function addButtonStyles( component ) {
 		transition: box-shadow 150ms ease-out;
 
 		&:hover,
-		&:focus {
+		&:focus,
+		&:active {
 			box-shadow:
 				0 4px 10px 0 ${ rgba( colors.$color_black, 0.2 ) },
 				inset 0 0 0 100px ${ rgba( colors.$color_black, 0.1 ) };
+			color: ${ props => props.textColor };
 		}
 
 		&:active {

--- a/composites/Plugin/Shared/tests/__snapshots__/HelpCenterButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/HelpCenterButtonTest.js.snap
@@ -3,7 +3,7 @@
 exports[`the HelpCenterButton matches the snapshot 1`] = `
 <button
   aria-expanded={false}
-  className="sc-htpNat gBIKzG sc-bwzfXH bMXkXR sc-bdVaJa bsIiYo"
+  className="sc-htpNat gBIKzG sc-bwzfXH jWIihg sc-bdVaJa bsIiYo"
   onClick={undefined}
   type="button"
 >

--- a/composites/Plugin/Shared/tests/__snapshots__/YoastButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/YoastButtonTest.js.snap
@@ -3,7 +3,7 @@
 exports[`the YoastButton executes callback 1`] = `
 <button
   aria-expanded={undefined}
-  className="sc-bwzfXH bMXkXR sc-bdVaJa bsIiYo"
+  className="sc-bwzfXH jWIihg sc-bdVaJa bsIiYo"
   onClick={[Function]}
   type="button"
 >
@@ -16,7 +16,7 @@ exports[`the YoastButton executes callback 1`] = `
 exports[`the YoastButton executes callback 2`] = `
 <button
   aria-expanded={undefined}
-  className="sc-bwzfXH bMXkXR sc-bdVaJa bsIiYo"
+  className="sc-bwzfXH jWIihg sc-bdVaJa bsIiYo"
   onClick={[Function]}
   type="button"
 >
@@ -29,7 +29,7 @@ exports[`the YoastButton executes callback 2`] = `
 exports[`the YoastButton matches the snapshot 1`] = `
 <button
   aria-expanded={undefined}
-  className="sc-bwzfXH bMXkXR sc-bdVaJa IFELj"
+  className="sc-bwzfXH jWIihg sc-bdVaJa IFELj"
   onClick={undefined}
   type="button"
 >

--- a/composites/Plugin/Shared/tests/__snapshots__/YoastLinkButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/YoastLinkButtonTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the YoastLinkButton matches the snapshot 1`] = `
 <a
-  className="sc-bxivhb bdggRU sc-htpNat czwPQj"
+  className="sc-bxivhb eKOFJS sc-htpNat czwPQj"
 >
   YoastLinkButtonValue
 </a>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improved Yoast Button hover/focus/active style.

## Relevant technical choices:

* explicitly sets the `color` property on the Yoast Buttons for hover/focus/style so it's inherited also by the Yoast Link Buttons and avoids inheritance from the WP rules 

## Test instructions

This PR can be tested by following these steps:

* Test in the WP integration, the Algolia search "View in KB" link button on hover and focus: color should stay white

Fixes #326
