### PR TITLE
AlgoliaSearcher and VideoTutorial CSS adjustments.

### DIFF
--- a/app/HelpCenterWrapper.js
+++ b/app/HelpCenterWrapper.js
@@ -27,7 +27,7 @@ export default function HelpCenterWrapper() {
 					[
 						{
 							title: "Need some help?",
-							description: "Go Premium and our experts will be there for you to answer any questions you" +
+							description: "Go Premium and our experts will be there for you to answer any questions you " +
 							"might have about the setup and use of the plugin.",
 							link: "#1",
 							linkText: "Get Yoast SEO Premium now »",

--- a/composites/AlgoliaSearch/AlgoliaSearcher.js
+++ b/composites/AlgoliaSearch/AlgoliaSearcher.js
@@ -18,7 +18,7 @@ const AlgoliaSearchWrapper = styled.div`
 `;
 
 AlgoliaSearchWrapper.propTypes = {
-	maxWidth: PropTypes.string.isRequired,
+	maxWidth: PropTypes.string,
 };
 
 const messages = defineMessages( {
@@ -368,7 +368,7 @@ AlgoliaSearcher.defaultProps = {
 	algoliaApplicationId: "RC8G2UCWJK",
 	algoliaApiKey: "459903434a7963f83e7d4cd9bfe89c0d",
 	algoliaIndexName: "knowledge_base_all",
-	maxWidth: "800px",
+	maxWidth: "900px",
 	enableLiveSearch: false,
 };
 

--- a/composites/AlgoliaSearch/SearchBar.js
+++ b/composites/AlgoliaSearch/SearchBar.js
@@ -54,7 +54,7 @@ const SearchHeading = styled.h2`
 
 const SearchLabel = styled.label`
 	flex: 0 0 42px;
-	height: 3em;
+	height: 48px;
 	// This label is already a flex item to be aligned with its siblings.
 	// By making it also a flex container, we can align the SVG icon.
 	display: inline-flex;
@@ -64,7 +64,7 @@ const SearchLabel = styled.label`
 const SearchBarInput = styled.input`
 	flex: 1 1 auto;
 	box-sizing: border-box;
-	height: 3em;
+	height: 48px;
 	box-shadow: inset 0 2px 8px 0px rgba( 0, 0, 0, 0.3 );
 	background: ${ colors.$color_grey_light };
 	border: 0;

--- a/composites/AlgoliaSearch/SearchResultDetail.js
+++ b/composites/AlgoliaSearch/SearchResultDetail.js
@@ -42,7 +42,7 @@ const Detail = styled.section`
 `;
 
 const Nav = styled.nav`
-	padding: 8px 16px;
+	padding: 0 16px 16px;
 `;
 
 const RightYoastLinkButton = makeOutboundLink( styled( YoastLinkButton )`

--- a/composites/AlgoliaSearch/tests/__snapshots__/AlgoliaSearcherTest.js.snap
+++ b/composites/AlgoliaSearch/tests/__snapshots__/AlgoliaSearcherTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the AlgoliaSearcher component with headingText matches the snapshot 1`] = `
 <div
-  className="sc-kgoBCf ijaDUj"
+  className="sc-kgoBCf dRcYum"
 >
   <div
     className="sc-htpNat jAVOHt"
@@ -17,7 +17,7 @@ exports[`the AlgoliaSearcher component with headingText matches the snapshot 1`]
       onSubmit={[Function]}
     >
       <label
-        className="sc-ifAKCX XUhcY"
+        className="sc-ifAKCX jpZkXH"
         htmlFor="kb-search-input"
       >
         <svg
@@ -36,7 +36,7 @@ exports[`the AlgoliaSearcher component with headingText matches the snapshot 1`]
         autoCapitalize="off"
         autoComplete="off"
         autoCorrect="off"
-        className="sc-EHOje bPRVQk"
+        className="sc-EHOje guPefA"
         defaultValue=""
         id="kb-search-input"
         name="search-input"

--- a/composites/AlgoliaSearch/tests/__snapshots__/SearchBarTest.js.snap
+++ b/composites/AlgoliaSearch/tests/__snapshots__/SearchBarTest.js.snap
@@ -14,7 +14,7 @@ exports[`the SearchBar component with headingText matches the snapshot 1`] = `
     onSubmit={[Function]}
   >
     <label
-      className="sc-ifAKCX XUhcY"
+      className="sc-ifAKCX jpZkXH"
       htmlFor="kb-search-input"
     >
       <svg
@@ -33,7 +33,7 @@ exports[`the SearchBar component with headingText matches the snapshot 1`] = `
       autoCapitalize="off"
       autoComplete="off"
       autoCorrect="off"
-      className="sc-EHOje bPRVQk"
+      className="sc-EHOje guPefA"
       defaultValue=""
       id="kb-search-input"
       name="search-input"
@@ -70,7 +70,7 @@ exports[`the SearchBar component without headingText matches the snapshot 1`] = 
     onSubmit={[Function]}
   >
     <label
-      className="sc-ifAKCX XUhcY"
+      className="sc-ifAKCX jpZkXH"
       htmlFor="kb-search-input"
     >
       <svg
@@ -89,7 +89,7 @@ exports[`the SearchBar component without headingText matches the snapshot 1`] = 
       autoCapitalize="off"
       autoComplete="off"
       autoCorrect="off"
-      className="sc-EHOje bPRVQk"
+      className="sc-EHOje guPefA"
       defaultValue=""
       id="kb-search-input"
       name="search-input"

--- a/composites/AlgoliaSearch/tests/__snapshots__/SearchResultDetailTest.js.snap
+++ b/composites/AlgoliaSearch/tests/__snapshots__/SearchResultDetailTest.js.snap
@@ -5,7 +5,7 @@ exports[`the SearchResultDetail component matches the snapshot 1`] = `
   className="sc-bZQynM RDELZ"
 >
   <nav
-    className="sc-gzVnrw kJqUwD"
+    className="sc-gzVnrw hdBCBy"
   >
     <button
       aria-expanded={undefined}

--- a/composites/HelpCenter/views/VideoTutorial.js
+++ b/composites/HelpCenter/views/VideoTutorial.js
@@ -12,6 +12,8 @@ const VIDEO_WIDTH = "560px";
 
 const VideoTutorialContainer = styled.div`
 	overflow: hidden;
+	max-width: 900px;
+	margin: 0 auto;
 `;
 
 const VideoContainer = styled.div`
@@ -38,7 +40,6 @@ const VideoDescriptions = styled.div`
 
 const VideoDescription = styled.div`
 	padding: 16px 0;
-	box-sizing: border-box;
 
 	:not( :last-child ) {
 		border-bottom: 2px solid ${ colors.$color_grey };

--- a/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
+++ b/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the VideoTutorial component matches the snapshot 1`] = `
 <div
-  className="sc-htpNat jdWHiT"
+  className="sc-htpNat klmSNG"
 >
   <div
     className="sc-bxivhb dVPPrD"
@@ -24,7 +24,7 @@ exports[`the VideoTutorial component matches the snapshot 1`] = `
     className="sc-ifAKCX iimhyI"
   >
     <div
-      className="sc-EHOje hWqomB"
+      className="sc-EHOje cCZqWy"
     >
       <p
         className="sc-bZQynM gSmTMg"
@@ -49,7 +49,7 @@ exports[`the VideoTutorial component matches the snapshot 1`] = `
       </a>
     </div>
     <div
-      className="sc-EHOje hWqomB"
+      className="sc-EHOje cCZqWy"
     >
       <p
         className="sc-bZQynM gSmTMg"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Better match the design specs

- AlgoliaSearcher: make the prop maxWidth not required and set it to 900px
- SearchBar: make the search field (and label, the lens icon) height 48px so it doesn't depend on the inherited font-size
- SearchResultDetail: improve a bit the top buttons position
- VideoTutorial: set max-width 900px
