### PR TITLE
Improve search results and detail focus management.

### DIFF
--- a/composites/AlgoliaSearch/AlgoliaSearcher.js
+++ b/composites/AlgoliaSearch/AlgoliaSearcher.js
@@ -312,6 +312,9 @@ class AlgoliaSearcher extends React.Component {
 	getSearchView() {
 		return (
 			<AlgoliaSearchWrapper
+				innerRef={ ( el ) => {
+					this.searchViewWrapper = el;
+				} }
 				maxWidth={ this.props.maxWidth }>
 				{ this.createSearchBar() }
 				{ this.determineSearchResultsView() }
@@ -338,6 +341,27 @@ class AlgoliaSearcher extends React.Component {
 	}
 
 	/**
+	 * Move focus back to the clicked link when going back from Detail to Search view.
+	 *
+	 * Call this function on componentDidUpdate() to avoid it runs on first rendering.
+	 *
+	 * @returns {void}
+	 */
+	moveFocusBackToClickedSearchResult() {
+		let clickedLinkIndex = this.state.currentDetailViewIndex;
+		// When is search view and a search results has been previously clicked.
+		if ( this.state.currentView === "SEARCH" && clickedLinkIndex >= 0 ) {
+			let resultLinks = this.searchViewWrapper.querySelectorAll( "ul a" );
+
+			if ( ! resultLinks.length ) {
+				return;
+			}
+
+			resultLinks[ clickedLinkIndex ].focus();
+		}
+	}
+
+	/**
 	 * Renders the React component.
 	 *
 	 * Called upon each state/props change. Determines and renders the view to render.
@@ -351,6 +375,10 @@ class AlgoliaSearcher extends React.Component {
 			case VIEW.DETAIL:
 				return this.getDetailView();
 		}
+	}
+
+	componentDidUpdate() {
+		this.moveFocusBackToClickedSearchResult();
 	}
 }
 

--- a/composites/AlgoliaSearch/SearchResultDetail.js
+++ b/composites/AlgoliaSearch/SearchResultDetail.js
@@ -13,6 +13,10 @@ import breakpoints from "../../style-guide/responsive-breakpoints.json";
 import colors from "../../style-guide/colors.json";
 
 const messages = defineMessages( {
+	searchResult: {
+		id: "searchResultDetail.searchResult",
+		defaultMessage: "Search result",
+	},
 	openButton: {
 		id: "searchResultDetail.openButton",
 		defaultMessage: "View in KB",
@@ -36,6 +40,8 @@ const messages = defineMessages( {
 } );
 
 const Detail = styled.section`
+	outline: none;
+
 	@media screen and ( max-width: ${ breakpoints.mobile } ) {
 		margin: 0 -16px;
 	}
@@ -86,13 +92,31 @@ class SearchResultDetail extends React.Component {
 
 	render() {
 		const formatMessage = this.props.intl.formatMessage;
+		const searchResulLabel = formatMessage( messages.searchResult );
 		const iframeTitle = formatMessage( messages.iframeTitle );
 		return (
-			<Detail>
+			<Detail
+				aria-label={ searchResulLabel }
+				tabIndex="-1"
+				innerRef={ ( el ) => {
+					this.detailWrapper = el;
+				} }
+			>
 				{ this.createNavigation() }
 				<ArticleContent post={ this.props.post } title={ iframeTitle }/>
 			</Detail>
 		);
+	}
+
+	/**
+	 * When the component mounts, set focus on the search detail wrapper.
+	 *
+	 * @returns {void}
+	 */
+	componentDidMount() {
+		if ( this.detailWrapper !== null ) {
+			this.detailWrapper.focus();
+		}
 	}
 }
 

--- a/composites/AlgoliaSearch/SearchResults.js
+++ b/composites/AlgoliaSearch/SearchResults.js
@@ -38,7 +38,7 @@ const SearchResultTitle = styled.p`
 const SearchResultLink = styled.a`
 	color: ${ colors.$color_black };
 	padding: 8px 16px;
-	
+
 	&:hover, &:focus {
 		color: ${ colors.$color_pink_dark };
 	}
@@ -148,8 +148,10 @@ class SearchResults extends React.Component {
 				rowHeight="32px"
 				key={ result.objectID }
 				post={ result }
+				// Note: this passes the onClick but actually also attaches a click event on the LI element.
 				onClick={ ( event ) => {
 					event.preventDefault();
+					event.stopPropagation();
 					this.props.onClick( index );
 				} }
 			/>;

--- a/composites/AlgoliaSearch/tests/__snapshots__/SearchResultDetailTest.js.snap
+++ b/composites/AlgoliaSearch/tests/__snapshots__/SearchResultDetailTest.js.snap
@@ -2,7 +2,9 @@
 
 exports[`the SearchResultDetail component matches the snapshot 1`] = `
 <section
-  className="sc-bZQynM RDELZ"
+  aria-label="Search result"
+  className="sc-bZQynM eYbrpH"
+  tabIndex="-1"
 >
   <nav
     className="sc-gzVnrw hdBCBy"

--- a/composites/AlgoliaSearch/tests/__snapshots__/SearchResultsTest.js.snap
+++ b/composites/AlgoliaSearch/tests/__snapshots__/SearchResultsTest.js.snap
@@ -18,7 +18,7 @@ exports[`the SearchResults component with results matches the snapshot 1`] = `
       onClick={[Function]}
     >
       <a
-        className="sc-ifAKCX iFJkNu"
+        className="sc-ifAKCX hUrDdy"
         href="https://kb.yoast.com/kb/passive-voice/"
         onClick={[Function]}
       >


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improved keyboard focus accessibility in the Knowledge Base search results.

## Relevant technical choices:

Please refer to the issue for the description of a few technical difficulties to face here. Had to use DOM methods, not particularly happy for that, but couldn't find a better way. Happy to rework this if anyone has better ideas.

## Test instructions

This PR can be tested by following these steps:

* using the keyboard to navigate, verify focus is not lost
* when going from the search results to a search details focus should go on the detail wrapper
* when going back, focus should go on the result link that was previously clicked
* use a screen reader to check the aria-label on the detail wrapper

Fixes #338 
