### PR TITLE
Help center css tweaks

### DIFF
--- a/composites/AlgoliaSearch/AlgoliaSearcher.js
+++ b/composites/AlgoliaSearch/AlgoliaSearcher.js
@@ -12,14 +12,9 @@ import SearchResultDetail from "./SearchResultDetail";
 import SearchResults from "./SearchResults";
 
 const AlgoliaSearchWrapper = styled.div`
-	max-width: ${ props => props.maxWidth };
 	margin: 0 auto 20px auto;
 	box-sizing: border-box;
 `;
-
-AlgoliaSearchWrapper.propTypes = {
-	maxWidth: PropTypes.string,
-};
 
 const messages = defineMessages( {
 	loadingPlaceholder: {
@@ -311,8 +306,7 @@ class AlgoliaSearcher extends React.Component {
 	 */
 	getSearchView() {
 		return (
-			<AlgoliaSearchWrapper
-				maxWidth={ this.props.maxWidth }>
+			<AlgoliaSearchWrapper>
 				{ this.createSearchBar() }
 				{ this.determineSearchResultsView() }
 			</AlgoliaSearchWrapper>
@@ -326,8 +320,7 @@ class AlgoliaSearcher extends React.Component {
 	 */
 	getDetailView() {
 		return (
-			<AlgoliaSearchWrapper
-				maxWidth={ this.props.maxWidth }>
+			<AlgoliaSearchWrapper>
 				<SearchResultDetail
 					{ ...this.props }
 					post={ this.getPostFromResults( this.state.currentDetailViewIndex ) }
@@ -358,7 +351,6 @@ AlgoliaSearcher.propTypes = {
 	algoliaApplicationId: PropTypes.string,
 	algoliaApiKey: PropTypes.string,
 	algoliaIndexName: PropTypes.string,
-	maxWidth: PropTypes.string,
 	onQueryChange: PropTypes.func,
 	intl: intlShape.isRequired,
 	enableLiveSearch: PropTypes.bool,
@@ -368,7 +360,6 @@ AlgoliaSearcher.defaultProps = {
 	algoliaApplicationId: "RC8G2UCWJK",
 	algoliaApiKey: "459903434a7963f83e7d4cd9bfe89c0d",
 	algoliaIndexName: "knowledge_base_all",
-	maxWidth: "900px",
 	enableLiveSearch: false,
 };
 

--- a/composites/AlgoliaSearch/SearchBar.js
+++ b/composites/AlgoliaSearch/SearchBar.js
@@ -44,8 +44,11 @@ const SearchBarWrapper = styled.div`
 `;
 
 const SearchHeading = styled.h2`
-	font-size: 1em;
-	margin: 0.5em 0 0.5em 58px;
+	// !important to override WP rules.
+	font-size: 1em !important;
+	margin: 0.5em 0 0.5em 58px !important;
+	padding: 0 !important;
+	font-weight: 600 !important;
 
 	@media screen and ( max-width: ${ breakpoints.mobile } ) {
 		margin-left: 0;
@@ -62,18 +65,27 @@ const SearchLabel = styled.label`
 `;
 
 const SearchBarInput = styled.input`
-	flex: 1 1 auto;
-	box-sizing: border-box;
-	height: 48px;
-	box-shadow: inset 0 2px 8px 0px rgba( 0, 0, 0, 0.3 );
-	background: ${ colors.$color_grey_light };
-	border: 0;
-	font-size: 1em;
-	margin-right: 24px;
-	padding: 0 8px 0 16px;
+	// Increase specificity to override WP rules.
+	&& {
+		flex: 1 1 auto;
+		box-sizing: border-box;
+		height: 48px;
+		box-shadow: inset 0 2px 8px 0px rgba( 0, 0, 0, 0.3 );
+		background: ${ colors.$color_grey_light };
+		border: 1px solid transparent;
+		font-size: 1em;
+		margin-right: 24px;
+		padding: 0 8px 0 16px;
 
-	@media screen and ( max-width: ${ breakpoints.mobile } ) {
-		margin-right: 0;
+		:focus {
+			box-shadow:
+				inset 0 2px 8px 0px rgba( 0, 0, 0, 0.3 ),
+				0 0 2px rgba( 30, 140, 190, 0.8 );
+		}
+
+		@media screen and ( max-width: ${ breakpoints.mobile } ) {
+			margin-right: 0;
+		}
 	}
 `;
 

--- a/composites/AlgoliaSearch/tests/__snapshots__/AlgoliaSearcherTest.js.snap
+++ b/composites/AlgoliaSearch/tests/__snapshots__/AlgoliaSearcherTest.js.snap
@@ -2,14 +2,14 @@
 
 exports[`the AlgoliaSearcher component with headingText matches the snapshot 1`] = `
 <div
-  className="sc-kgoBCf dRcYum"
+  className="sc-kgoBCf YQFzU"
 >
   <div
     className="sc-htpNat jAVOHt"
     role="search"
   >
     <h2
-      className="sc-bxivhb fBtvqs"
+      className="sc-bxivhb fMWLJS"
     >
       Search the Yoast knowledge base
     </h2>
@@ -36,7 +36,7 @@ exports[`the AlgoliaSearcher component with headingText matches the snapshot 1`]
         autoCapitalize="off"
         autoComplete="off"
         autoCorrect="off"
-        className="sc-EHOje guPefA"
+        className="sc-EHOje hhGWKG"
         defaultValue=""
         id="kb-search-input"
         name="search-input"

--- a/composites/AlgoliaSearch/tests/__snapshots__/SearchBarTest.js.snap
+++ b/composites/AlgoliaSearch/tests/__snapshots__/SearchBarTest.js.snap
@@ -6,7 +6,7 @@ exports[`the SearchBar component with headingText matches the snapshot 1`] = `
   role="search"
 >
   <h2
-    className="sc-bxivhb fBtvqs"
+    className="sc-bxivhb fMWLJS"
   >
     Search the Yoast knowledge base
   </h2>
@@ -33,7 +33,7 @@ exports[`the SearchBar component with headingText matches the snapshot 1`] = `
       autoCapitalize="off"
       autoComplete="off"
       autoCorrect="off"
-      className="sc-EHOje guPefA"
+      className="sc-EHOje hhGWKG"
       defaultValue=""
       id="kb-search-input"
       name="search-input"
@@ -62,7 +62,7 @@ exports[`the SearchBar component without headingText matches the snapshot 1`] = 
   role="search"
 >
   <h2
-    className="sc-bxivhb fBtvqs"
+    className="sc-bxivhb fMWLJS"
   >
     Search the Yoast knowledge base
   </h2>
@@ -89,7 +89,7 @@ exports[`the SearchBar component without headingText matches the snapshot 1`] = 
       autoCapitalize="off"
       autoComplete="off"
       autoCorrect="off"
-      className="sc-EHOje guPefA"
+      className="sc-EHOje hhGWKG"
       defaultValue=""
       id="kb-search-input"
       name="search-input"

--- a/composites/HelpCenter/views/VideoTutorial.js
+++ b/composites/HelpCenter/views/VideoTutorial.js
@@ -12,8 +12,6 @@ const VIDEO_WIDTH = "560px";
 
 const VideoTutorialContainer = styled.div`
 	overflow: hidden;
-	max-width: 900px;
-	margin: 0 auto;
 `;
 
 const VideoContainer = styled.div`

--- a/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
+++ b/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the VideoTutorial component matches the snapshot 1`] = `
 <div
-  className="sc-htpNat klmSNG"
+  className="sc-htpNat jdWHiT"
 >
   <div
     className="sc-bxivhb dVPPrD"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adjusted Help Center styling for integration in WordPress.

## Relevant technical choices:

- need to increase the specificity of some CSS selectors to avoid conflicts with rules inherited from WordPress. However, styled components don't allow to increase specificity easily other than:
  - using `!important`
  - using `&&` to double the generated class selector, see https://github.com/Yoast/yoast-components/issues/343#issuecomment-334737666 
- removes the maxWidth prop form the components used in the Yoast tabs

## Test instructions

This PR can be tested by following these steps:

* Please see testing instructions on the related Plugin's PR

Fixes #329
