### PR TITLE
Add classes to provide the ability to override styles

### DIFF
--- a/composites/HelpCenter/views/VideoTutorial.js
+++ b/composites/HelpCenter/views/VideoTutorial.js
@@ -97,7 +97,7 @@ VideoDescriptionItem.propTypes = {
  */
 export default function VideoTutorial( props ) {
 	return (
-			<VideoTutorialContainer className={ `${ props.className }__container` }>
+		<VideoTutorialContainer className={ `${ props.className }__container` }>
 			<VideoContainer className={ `${ props.className }__video` }>
 				<YouTubeVideo
 					src={ props.src }

--- a/composites/HelpCenter/views/VideoTutorial.js
+++ b/composites/HelpCenter/views/VideoTutorial.js
@@ -96,13 +96,13 @@ VideoDescriptionItem.propTypes = {
  */
 export default function VideoTutorial( props ) {
 	return (
-		<VideoTutorialContainer>
-			<VideoContainer>
+		<VideoTutorialContainer className="video-tutorial__container">
+			<VideoContainer className="video-tutorial__video">
 				<YouTubeVideo
 					src={ props.src }
 					title={ props.title } />
 			</VideoContainer>
-			<VideoDescriptions>
+			<VideoDescriptions className="video-tutorial__descriptions">
 				{ props.paragraphs.map( paragraph => {
 					return (
 						<VideoDescriptionItem

--- a/composites/HelpCenter/views/VideoTutorial.js
+++ b/composites/HelpCenter/views/VideoTutorial.js
@@ -63,7 +63,7 @@ const VideoDescriptionLink = makeOutboundLink( styled.a`
  */
 const VideoDescriptionItem = ( props ) => {
 	return (
-		<VideoDescription>
+		<VideoDescription className={ props.className }>
 			<VideoDescriptionTitle>
 				{ props.title }
 			</VideoDescriptionTitle>
@@ -82,6 +82,7 @@ VideoDescriptionItem.propTypes = {
 	description: PropTypes.string.isRequired,
 	link: PropTypes.string.isRequired,
 	linkText: PropTypes.string.isRequired,
+	className: PropTypes.string.isRequired,
 };
 
 /**
@@ -96,16 +97,16 @@ VideoDescriptionItem.propTypes = {
  */
 export default function VideoTutorial( props ) {
 	return (
-		<VideoTutorialContainer className="video-tutorial__container">
-			<VideoContainer className="video-tutorial__video">
+			<VideoTutorialContainer className={ `${ props.className }__container` }>
+			<VideoContainer className={ `${ props.className }__video` }>
 				<YouTubeVideo
 					src={ props.src }
 					title={ props.title } />
 			</VideoContainer>
-			<VideoDescriptions className="video-tutorial__descriptions">
+			<VideoDescriptions className={ `${ props.className }__descriptions` }>
 				{ props.paragraphs.map( paragraph => {
 					return (
-						<VideoDescriptionItem
+						<VideoDescriptionItem className={ `${ props.className }__description` }
 							key={ paragraph.link }
 							{ ...paragraph } />
 					);
@@ -123,4 +124,9 @@ VideoTutorial.propTypes = {
 			VideoDescriptionItem.propTypes
 		)
 	).isRequired,
+	className: PropTypes.string,
+};
+
+VideoTutorial.defaultProps = {
+	className: "yoast-video-tutorial",
 };

--- a/composites/HelpCenter/views/VideoTutorial.js
+++ b/composites/HelpCenter/views/VideoTutorial.js
@@ -98,7 +98,7 @@ VideoDescriptionItem.propTypes = {
 export default function VideoTutorial( props ) {
 	return (
 		<VideoTutorialContainer className={ `${ props.className }__container` }>
-			<VideoContainer className={ `${ props.className }__video` }>
+			<VideoContainer className={ `${ props.className }__video-container` }>
 				<YouTubeVideo
 					src={ props.src }
 					title={ props.title } />

--- a/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
+++ b/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
@@ -2,10 +2,10 @@
 
 exports[`the VideoTutorial component matches the snapshot 1`] = `
 <div
-  className="sc-htpNat jdWHiT"
+  className="yoast-video-tutorial__container sc-htpNat jdWHiT"
 >
   <div
-    className="sc-bxivhb dVPPrD"
+    className="yoast-video-tutorial__video sc-bxivhb dVPPrD"
   >
     <div
       className="sc-bdVaJa fpzLVP"
@@ -21,10 +21,10 @@ exports[`the VideoTutorial component matches the snapshot 1`] = `
     </div>
   </div>
   <div
-    className="sc-ifAKCX iimhyI"
+    className="yoast-video-tutorial__descriptions sc-ifAKCX iimhyI"
   >
     <div
-      className="sc-EHOje cCZqWy"
+      className="yoast-video-tutorial__description sc-EHOje cCZqWy"
     >
       <p
         className="sc-bZQynM gSmTMg"
@@ -49,7 +49,7 @@ exports[`the VideoTutorial component matches the snapshot 1`] = `
       </a>
     </div>
     <div
-      className="sc-EHOje cCZqWy"
+      className="yoast-video-tutorial__description sc-EHOje cCZqWy"
     >
       <p
         className="sc-bZQynM gSmTMg"

--- a/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
+++ b/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
@@ -5,7 +5,7 @@ exports[`the VideoTutorial component matches the snapshot 1`] = `
   className="yoast-video-tutorial__container sc-htpNat jdWHiT"
 >
   <div
-    className="yoast-video-tutorial__video sc-bxivhb dVPPrD"
+    className="yoast-video-tutorial__video-container sc-bxivhb dVPPrD"
   >
     <div
       className="sc-bdVaJa fpzLVP"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Adds classes to the video-tutorial elements.

## Relevant technical choices:

* Added classes to the specific elements of the video tutorial to allow overriding behaviour on specific implementations.

Testing:
Verify the snapshots contain the class names.

Related https://github.com/Yoast/wordpress-seo/issues/8039
