### PR TITLE
 Add extra test for keywordResultsReducer

### DIFF
--- a/composites/Plugin/ContentAnalysis/reducers/tests/keywordResultsReducerTest.js
+++ b/composites/Plugin/ContentAnalysis/reducers/tests/keywordResultsReducerTest.js
@@ -118,6 +118,65 @@ describe( "SET_SEO_RESULTS_FOR_KEYWORD action", () => {
 	} );
 } );
 
+describe( "SET_SEO_RESULTS_FOR_KEYWORD action", () => {
+	it( "overwrites seo results for a single keyword when there are already results for that keyword", () => {
+		const state = {
+			thisIsMyKeyword: [
+				{
+					id: "resultId",
+					score: 3,
+					description: "This is a bad score!",
+					markingIsActive: false,
+				},
+				{
+					id: "resultId2",
+					score: 6,
+					description: "This is a mediocre score!",
+					markingIsActive: false,
+				},
+			],
+		};
+		const action = {
+			type: SET_SEO_RESULTS_FOR_KEYWORD,
+			keyword: "thisIsMyKeyword",
+			results: [
+				{
+					id: "resultId",
+					score: 6,
+					description: "This is a mediocre score!",
+					markingIsActive: false,
+				},
+				{
+					id: "resultId2",
+					score: 9,
+					description: "This is a good score!",
+					markingIsActive: false,
+				},
+			],
+		};
+		const expected = {
+			thisIsMyKeyword: [
+				{
+					id: "resultId",
+					score: 6,
+					description: "This is a mediocre score!",
+					markingIsActive: false,
+				},
+				{
+					id: "resultId2",
+					score: 9,
+					description: "This is a good score!",
+					markingIsActive: false,
+				},
+			],
+		};
+
+		const actual = keywordResultsReducer( state, action );
+
+		expect( actual ).toEqual( expected );
+	} );
+} );
+
 describe( "SET_SEO_RESULTS action", () => {
 	it( "sets seo results for a single keyword in an empty state", () => {
 		const state = {};


### PR DESCRIPTION
## Summary

Adds an extra test for keywordResultsReducer to test if it overwrites seo results for a single keyword when there are already results for that keyword.

## Testing
* Run `yarn test`.