### PR TITLE
Set default classname

### DIFF
--- a/composites/HelpCenter/views/VideoTutorial.js
+++ b/composites/HelpCenter/views/VideoTutorial.js
@@ -82,7 +82,11 @@ VideoDescriptionItem.propTypes = {
 	description: PropTypes.string.isRequired,
 	link: PropTypes.string.isRequired,
 	linkText: PropTypes.string.isRequired,
-	className: PropTypes.string.isRequired,
+	className: PropTypes.string,
+};
+
+VideoDescriptionItem.defaultProps = {
+	className: "yoast-video-tutorial",
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add default classname `yoast-video-tutorial` to the VideoDescriptionItem.

## Relevant technical choices:

* Set the same default classname as in the video tutorial component.

## Test instructions

This PR can be tested by following these steps:
* Run yarn test and check whether the warning is gone.

Fixes #357
