### PR TITLE
Implement content analysis component

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,7 +3,7 @@ import { IntlProvider } from "react-intl";
 
 import SearchResultsEditor from "./composites/SearchResultEditor/SearchResultEditor";
 import SnippetPreview from "./composites/Plugin/SnippetPreview/components/SnippetPreview";
-import ContentAnalysis from "./composites/Plugin/ContentAnalysis/components/ContentAnalysis";
+import ContentAnalysis from "./app/ContentAnalysisWrapper";
 import Wizard from "./app/WizardWrapper";
 import DashboardWidget from "./app/DashboardWidgetWrapper";
 import Loader from "./composites/basic/Loader";
@@ -58,7 +58,7 @@ class App extends React.Component {
 		injectTapEventPlugin();
 
 		this.state = {
-			activeComponent: "help-center",
+			activeComponent: "content-analysis",
 		};
 	}
 
@@ -71,7 +71,7 @@ class App extends React.Component {
 		}
 	}
 
-	navigate( activeComponent, event ) {
+	navigate( activeComponent ) {
 		this.setState( {
 			activeComponent: activeComponent,
 		} );

--- a/app/ContentAnalysisWrapper.js
+++ b/app/ContentAnalysisWrapper.js
@@ -1,0 +1,195 @@
+import React from "react";
+import styled from "styled-components";
+
+import ContentAnalysis from "../composites/Plugin/ContentAnalysis/components/ContentAnalysis";
+
+/**
+ * Returns the HelpCenterWrapper component.
+ *
+ * @returns {ReactElement} The HelpCenterWrapper component.
+ */
+export default function HelpCenterWrapper() {
+	const problemsResults = {
+		results: [
+			{
+				text: "Short text.",
+				id: "1",
+				rating: "bad",
+				hasMarks: false,
+			},
+			{
+				text: "Longer text. No meta description has been specified. Search engines will display copy from the page instead. " +
+				"No meta description has been specified. Search engines will display copy from the page instead.",
+				id: "2",
+				rating: "bad",
+				hasMarks: true,
+			},
+			{
+				text: "No meta description has been specified. Search engines will display copy from the page instead.",
+				id: "3",
+				rating: "bad",
+				hasMarks: true,
+			},
+		],
+		heading: "Problems",
+		initialIsOpen: true,
+	};
+
+	const goodResults = {
+		results: [
+			{
+				text: "Short text.",
+				id: "17",
+				rating: "good",
+				hasMarks: false,
+			},
+			{
+				text: "Longer text. No meta description has been specified. Search engines will display copy from the page instead. " +
+				"No meta description has been specified. Search engines will display copy from the page instead.",
+				id: "18",
+				rating: "good",
+				hasMarks: true,
+			},
+			{
+				text: "No meta description has been specified. Search engines will display copy from the page instead.",
+				id: "29",
+				rating: "good",
+				hasMarks: true,
+			},
+			{
+				text: "Not applicable result.",
+				id: "20",
+				rating: "good",
+				hasMarks: false,
+			},
+			{
+				text: "Not applicable result.",
+				id: "4",
+				rating: "good",
+				hasMarks: false,
+			},
+		],
+		heading: "Good",
+		initialIsOpen: false,
+	};
+
+	const improvementsResults = {
+		results: [
+			{
+				text: "Short text.",
+				id: "5",
+				rating: "OK",
+				hasMarks: false,
+			},
+			{
+				text: "Longer text. No meta description has been specified. Search engines will display copy from the page instead. " +
+				"No meta description has been specified. Search engines will display copy from the page instead.",
+				id: "6",
+				rating: "OK",
+				hasMarks: true,
+			},
+		],
+		heading: "Improvements",
+		initialIsOpen: false,
+	};
+
+	const errorsResults = {
+		results: [
+			{
+				text: "Short text.",
+				id: "9",
+				rating: "feedback",
+				hasMarks: false,
+			},
+			{
+				text: "Longer text. No meta description has been specified. Search engines will display copy from the page instead. " +
+				"No meta description has been specified. Search engines will display copy from the page instead.",
+				id: "10",
+				rating: "feedback",
+				hasMarks: true,
+			},
+			{
+				text: "No meta description has been specified. Search engines will display copy from the page instead.",
+				id: "11",
+				rating: "feedback",
+				hasMarks: true,
+			},
+			{
+				text: "Not applicable result.",
+				id: "12",
+				rating: "feedback",
+				hasMarks: false,
+			},
+		],
+		heading: "Errors",
+		initialIsOpen: false,
+	};
+
+	const considerationsResults = {
+		results: [
+			{
+				text: "Short text.",
+				id: "13",
+				rating: "feedback",
+				hasMarks: false,
+			},
+			{
+				text: "Longer text. No meta description has been specified. Search engines will display copy from the page instead. " +
+				"No meta description has been specified. Search engines will display copy from the page instead.",
+				id: "14",
+				rating: "feedback",
+				hasMarks: true,
+			},
+			{
+				text: "No meta description has been specified. Search engines will display copy from the page instead.",
+				id: "15",
+				rating: "feedback",
+				hasMarks: true,
+			},
+			{
+				text: "Not applicable result.",
+				id: "16",
+				rating: "feedback",
+				hasMarks: false,
+			},
+			{
+				text: "Short text.",
+				id: "21",
+				rating: "feedback",
+				hasMarks: false,
+			},
+			{
+				text: "Longer text. No meta description has been specified. Search engines will display copy from the page instead. " +
+				"No meta description has been specified. Search engines will display copy from the page instead.",
+				id: "22",
+				rating: "feedback",
+				hasMarks: true,
+			},
+			{
+				text: "No meta description has been specified. Search engines will display copy from the page instead.",
+				id: "23",
+				rating: "feedback",
+				hasMarks: true,
+			},
+			{
+				text: "Not applicable result.",
+				id: "24",
+				rating: "feedback",
+				hasMarks: false,
+			},
+		],
+		heading: "Considerations",
+		initialIsOpen: false,
+	};
+
+	const leeg = [];
+
+	return (
+		<ContentAnalysis
+			problemsResults={ problemsResults }
+			improvementsResults={ improvementsResults }
+			goodResults={ goodResults }
+			considerationsResults={ considerationsResults }
+			errorsResults={ errorsResults }/>
+	);
+}

--- a/app/ContentAnalysisWrapper.js
+++ b/app/ContentAnalysisWrapper.js
@@ -66,7 +66,7 @@ export default function HelpCenterWrapper() {
 			goodResults={ goodResults }
 			considerationsResults={ considerationsResults }
 			errorsResults={ errorsResults }
-			changeLanguageLink={ "#" }
+			changeLanguageLink="#"
 			language="English"
 		/>
 	);

--- a/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
@@ -68,9 +68,12 @@ const AnalysisList = styled.ul`
 `;
 
 /**
- * @param Component
- * @param headingLevel
- * @returns {XML}
+ * Wrap a component in a header element with a defined heading level.
+ *
+ * @param {ReactElement} Component The component to wrap.
+ * @param {int} headingLevel       The heading level.
+ *
+ * @returns {ReactElement} The wrapped component.
  */
 function wrapInHeading( Component, headingLevel ) {
 	const Heading = `h${ headingLevel }`;

--- a/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
@@ -11,7 +11,7 @@ import { IconButton } from "../../Shared/components/Button";
  * Container for the Collapsible header and its content.
  */
 const AnalysisHeaderContainer = styled.div`
-	margin: 8px 0;
+	margin: 4px 0 8px 0;
 	background-color: ${ colors.$color_white };
 `;
 
@@ -25,21 +25,24 @@ const AnalysisHeaderButton = styled( IconButton )`
 	border-color: transparent;
 	border-radius: 0;
 	outline: none;
+	justify-content: left;
 	box-shadow: none;
 	// When clicking, the button text disappears in Safari 10 because of color: activebuttontext.
 	color: ${ colors.$color_blue };
 
 	:hover {
 		border-color: transparent;
+		color: ${ colors.$color_blue };
 	}
 
 	:active {
 		box-shadow: none;
 		background-color: ${ colors.$color_white };
+		color: ${ colors.$color_blue };
 	}
 
 	svg {
-		margin: 0 10px;
+		margin: 0 8px;
 		width: 20px;
 		height: 20px;
 	}
@@ -61,7 +64,7 @@ const AnalysisTitle = styled.span`
 const AnalysisList = styled.ul`
 	margin: 0;
 	list-style: none;
-	padding: 8px 16px;
+	padding: 0 16px 0 13px;
 `;
 
 /**

--- a/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
@@ -25,7 +25,7 @@ const AnalysisHeaderButton = styled( IconButton )`
 	border-color: transparent;
 	border-radius: 0;
 	outline: none;
-	justify-content: left;
+	justify-content: flex-start;
 	box-shadow: none;
 	// When clicking, the button text disappears in Safari 10 because of color: activebuttontext.
 	color: ${ colors.$color_blue };

--- a/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
@@ -59,6 +59,16 @@ const AnalysisTitle = styled.span`
 `;
 
 /**
+ * The analysis H2 text.
+ */
+const AnalysisTitleH2 = styled.h2`
+	margin: 8px 0;
+	word-wrap: break-word;
+	font-size: 1.25em;
+	line-height: 1.25;
+`;
+
+/**
  * Analysis items list.
  */
 const AnalysisList = styled.ul`
@@ -77,17 +87,28 @@ const AnalysisList = styled.ul`
 export const AnalysisCollapsibleStateless = ( props ) => {
 	let title = props.title;
 	let count = getChildrenCount( props.children );
+	const Heading = `h${ props.headerLevel }`;
 
 	return (
 		<AnalysisHeaderContainer>
-			<AnalysisHeaderButton
-				aria-expanded={ props.isOpen }
-				onClick={ props.onToggle }
-				icon={ props.isOpen ? angleUp : angleDown }
-				iconColor={ colors.$color_grey_dark }
-			>
-				<AnalysisTitle>{ `${ title } (${ count })` }</AnalysisTitle>
-			</AnalysisHeaderButton>
+			{ props.needsHeaderTag
+				? <Heading><AnalysisHeaderButton
+					aria-expanded={ props.isOpen }
+					onClick={ props.onToggle }
+					icon={ props.isOpen ? angleUp : angleDown }
+					iconColor={ colors.$color_grey_dark }
+				>
+					<AnalysisTitle>{ `${ title } (${ count })` }</AnalysisTitle>
+				</AnalysisHeaderButton></Heading>
+				: <AnalysisHeaderButton
+					aria-expanded={ props.isOpen }
+					onClick={ props.onToggle }
+					icon={ props.isOpen ? angleUp : angleDown }
+					iconColor={ colors.$color_grey_dark }
+				>
+					<AnalysisTitle>{ `${ title } (${ count })` }</AnalysisTitle>
+				</AnalysisHeaderButton>
+			}
 			{
 				props.isOpen && props.children
 					? <AnalysisList role="list">{ props.children }</AnalysisList>
@@ -100,11 +121,18 @@ export const AnalysisCollapsibleStateless = ( props ) => {
 AnalysisCollapsibleStateless.propTypes = {
 	title: PropTypes.string.isRequired,
 	isOpen: PropTypes.bool.isRequired,
+	needsHeaderTag: PropTypes.bool,
+	headerLevel: PropTypes.string,
 	onToggle: PropTypes.func.isRequired,
 	children: PropTypes.oneOfType( [
 		PropTypes.arrayOf( PropTypes.node ),
 		PropTypes.node,
 	] ),
+};
+
+AnalysisCollapsibleStateless.defaultProps = {
+	needsHeaderTag: false,
+	headerLevel: "H2",
 };
 
 export class AnalysisCollapsible extends React.Component {
@@ -145,6 +173,8 @@ export class AnalysisCollapsible extends React.Component {
 				title={ this.props.title }
 				onToggle={ this.toggleOpen.bind( this ) }
 				isOpen={ this.state.isOpen }
+				needsHeaderTag={ this.props.needsHeaderTag }
+				headerLevel={ this.props.headerLevel }
 			>
 				{ this.props.children }
 			</AnalysisCollapsibleStateless>
@@ -155,6 +185,8 @@ export class AnalysisCollapsible extends React.Component {
 AnalysisCollapsible.propTypes = {
 	title: PropTypes.string.isRequired,
 	initialIsOpen: PropTypes.bool,
+	needsHeaderTag: PropTypes.bool,
+	headerLevel: PropTypes.string,
 	children: PropTypes.oneOfType( [
 		PropTypes.arrayOf( PropTypes.node ),
 		PropTypes.node,
@@ -163,6 +195,8 @@ AnalysisCollapsible.propTypes = {
 
 AnalysisCollapsible.defaultProps = {
 	initialIsOpen: false,
+	needsHeaderTag: false,
+	headerLevel: "H2",
 };
 
 export default AnalysisCollapsible;

--- a/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
@@ -68,6 +68,28 @@ const AnalysisList = styled.ul`
 `;
 
 /**
+ * @param Component
+ * @param headingLevel
+ * @returns {XML}
+ */
+function wrapInHeading( Component, headingLevel ) {
+	const Heading = `h${ headingLevel }`;
+	const StyledHeading = styled( Heading )`
+		margin: 0;
+		font-weight: normal;
+    `;
+
+	return function Wrapped( props ) {
+		return (
+			<StyledHeading>
+				<Component { ...props } />
+			</StyledHeading>
+		);
+	};
+}
+
+
+/**
  * A collapsible header used to show sets of analysis results. Expects list items as children.
  * Optionally has a heading around the button.
  *
@@ -78,33 +100,18 @@ const AnalysisList = styled.ul`
 export const AnalysisCollapsibleStateless = ( props ) => {
 	let title = props.title;
 	let count = getChildrenCount( props.children );
-	const Heading = `h${ props.headingLevel }`;
 
-	const StyledHeading = styled( Heading )`
-		margin: 0;
-		font-weight: normal;
-    `;
+	const Button = props.hasHeading ? wrapInHeading( AnalysisHeaderButton, 2 ) : AnalysisHeaderButton;
 
 	return (
 		<AnalysisHeaderContainer>
-			{ props.hasHeading
-				? <StyledHeading><AnalysisHeaderButton
-					aria-expanded={ props.isOpen }
-					onClick={ props.onToggle }
-					icon={ props.isOpen ? angleUp : angleDown }
-					iconColor={ colors.$color_grey_dark }
-				>
-					<AnalysisTitle>{ `${ title } (${ count })` }</AnalysisTitle>
-				</AnalysisHeaderButton></StyledHeading>
-				: <AnalysisHeaderButton
-					aria-expanded={ props.isOpen }
-					onClick={ props.onToggle }
-					icon={ props.isOpen ? angleUp : angleDown }
-					iconColor={ colors.$color_grey_dark }
-				>
-					<AnalysisTitle>{ `${ title } (${ count })` }</AnalysisTitle>
-				</AnalysisHeaderButton>
-			}
+			<Button
+				aria-expanded={ props.isOpen }
+				onClick={ props.onToggle }
+				icon={ props.isOpen ? angleUp : angleDown }
+				iconColor={ colors.$color_grey_dark } >
+				<AnalysisTitle>{ `${ title } (${ count })` }</AnalysisTitle>
+			</Button>
 			{
 				props.isOpen && props.children
 					? <AnalysisList role="list">{ props.children }</AnalysisList>

--- a/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
@@ -104,7 +104,7 @@ export const AnalysisCollapsibleStateless = ( props ) => {
 	let title = props.title;
 	let count = getChildrenCount( props.children );
 
-	const Button = props.hasHeading ? wrapInHeading( AnalysisHeaderButton, 2 ) : AnalysisHeaderButton;
+	const Button = props.hasHeading ? wrapInHeading( AnalysisHeaderButton, props.headingLevel ) : AnalysisHeaderButton;
 
 	return (
 		<AnalysisHeaderContainer>

--- a/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
@@ -7,17 +7,11 @@ import { angleUp, angleDown } from "../../../../style-guide/svg";
 import colors from "../../../../style-guide/colors.json";
 import { IconButton } from "../../Shared/components/Button";
 
-/**
- * Container for the Collapsible header and its content.
- */
 const AnalysisHeaderContainer = styled.div`
 	margin: 4px 0 8px 0;
 	background-color: ${ colors.$color_white };
 `;
 
-/**
- * The clickable component of the analysis header.
- */
 const AnalysisHeaderButton = styled( IconButton )`
 	width: 100%;
 	background-color: ${ colors.$color_white };
@@ -48,9 +42,6 @@ const AnalysisHeaderButton = styled( IconButton )`
 	}
 `;
 
-/**
- * The analysis header text.
- */
 const AnalysisTitle = styled.span`
 	margin: 8px 0;
 	word-wrap: break-word;
@@ -58,9 +49,6 @@ const AnalysisTitle = styled.span`
 	line-height: 1.25;
 `;
 
-/**
- * Analysis items list.
- */
 const AnalysisList = styled.ul`
 	margin: 0;
 	list-style: none;
@@ -68,10 +56,10 @@ const AnalysisList = styled.ul`
 `;
 
 /**
- * Wrap a component in a header element with a defined heading level.
+ * Wraps a component in a heading element with a defined heading level.
  *
- * @param {ReactElement} Component The component to wrap.
- * @param {int} headingLevel       The heading level.
+ * @param {ReactElement} Component    The component to wrap.
+ * @param {int}          headingLevel The heading level.
  *
  * @returns {ReactElement} The wrapped component.
  */
@@ -80,7 +68,7 @@ function wrapInHeading( Component, headingLevel ) {
 	const StyledHeading = styled( Heading )`
 		margin: 0;
 		font-weight: normal;
-    `;
+	`;
 
 	return function Wrapped( props ) {
 		return (
@@ -90,7 +78,6 @@ function wrapInHeading( Component, headingLevel ) {
 		);
 	};
 }
-
 
 /**
  * A collapsible header used to show sets of analysis results. Expects list items as children.

--- a/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
@@ -59,16 +59,6 @@ const AnalysisTitle = styled.span`
 `;
 
 /**
- * The analysis H2 text.
- */
-const AnalysisTitleH2 = styled.h2`
-	margin: 8px 0;
-	word-wrap: break-word;
-	font-size: 1.25em;
-	line-height: 1.25;
-`;
-
-/**
  * Analysis items list.
  */
 const AnalysisList = styled.ul`
@@ -79,6 +69,7 @@ const AnalysisList = styled.ul`
 
 /**
  * A collapsible header used to show sets of analysis results. Expects list items as children.
+ * Optionally has a heading around the button.
  *
  * @param {object} props The properties for the component.
  *
@@ -89,17 +80,22 @@ export const AnalysisCollapsibleStateless = ( props ) => {
 	let count = getChildrenCount( props.children );
 	const Heading = `h${ props.headerLevel }`;
 
+	const StyledHeading = styled( Heading )`
+		margin: 0;
+		font-weight: normal;
+    `;
+
 	return (
 		<AnalysisHeaderContainer>
-			{ props.needsHeaderTag
-				? <Heading><AnalysisHeaderButton
+			{ props.hasHeading
+				? <StyledHeading><AnalysisHeaderButton
 					aria-expanded={ props.isOpen }
 					onClick={ props.onToggle }
 					icon={ props.isOpen ? angleUp : angleDown }
 					iconColor={ colors.$color_grey_dark }
 				>
 					<AnalysisTitle>{ `${ title } (${ count })` }</AnalysisTitle>
-				</AnalysisHeaderButton></Heading>
+				</AnalysisHeaderButton></StyledHeading>
 				: <AnalysisHeaderButton
 					aria-expanded={ props.isOpen }
 					onClick={ props.onToggle }
@@ -121,7 +117,7 @@ export const AnalysisCollapsibleStateless = ( props ) => {
 AnalysisCollapsibleStateless.propTypes = {
 	title: PropTypes.string.isRequired,
 	isOpen: PropTypes.bool.isRequired,
-	needsHeaderTag: PropTypes.bool,
+	hasHeading: PropTypes.bool,
 	headerLevel: PropTypes.string,
 	onToggle: PropTypes.func.isRequired,
 	children: PropTypes.oneOfType( [
@@ -131,8 +127,8 @@ AnalysisCollapsibleStateless.propTypes = {
 };
 
 AnalysisCollapsibleStateless.defaultProps = {
-	needsHeaderTag: false,
-	headerLevel: "H2",
+	hasHeading: false,
+	headerLevel: 2,
 };
 
 export class AnalysisCollapsible extends React.Component {
@@ -173,8 +169,8 @@ export class AnalysisCollapsible extends React.Component {
 				title={ this.props.title }
 				onToggle={ this.toggleOpen.bind( this ) }
 				isOpen={ this.state.isOpen }
-				needsHeaderTag={ this.props.needsHeaderTag }
-				headerLevel={ this.props.headerLevel }
+				needsHeaderTag={ this.props.hasHeading }
+				headerLevel={ this.props.headingLevel }
 			>
 				{ this.props.children }
 			</AnalysisCollapsibleStateless>
@@ -185,8 +181,8 @@ export class AnalysisCollapsible extends React.Component {
 AnalysisCollapsible.propTypes = {
 	title: PropTypes.string.isRequired,
 	initialIsOpen: PropTypes.bool,
-	needsHeaderTag: PropTypes.bool,
-	headerLevel: PropTypes.string,
+	hasHeading: PropTypes.bool,
+	headingLevel: PropTypes.string,
 	children: PropTypes.oneOfType( [
 		PropTypes.arrayOf( PropTypes.node ),
 		PropTypes.node,
@@ -195,8 +191,8 @@ AnalysisCollapsible.propTypes = {
 
 AnalysisCollapsible.defaultProps = {
 	initialIsOpen: false,
-	needsHeaderTag: false,
-	headerLevel: "H2",
+	hasHeading: false,
+	headingLevel: 2,
 };
 
 export default AnalysisCollapsible;

--- a/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
@@ -78,7 +78,7 @@ const AnalysisList = styled.ul`
 export const AnalysisCollapsibleStateless = ( props ) => {
 	let title = props.title;
 	let count = getChildrenCount( props.children );
-	const Heading = `h${ props.headerLevel }`;
+	const Heading = `h${ props.headingLevel }`;
 
 	const StyledHeading = styled( Heading )`
 		margin: 0;
@@ -118,7 +118,7 @@ AnalysisCollapsibleStateless.propTypes = {
 	title: PropTypes.string.isRequired,
 	isOpen: PropTypes.bool.isRequired,
 	hasHeading: PropTypes.bool,
-	headerLevel: PropTypes.string,
+	headingLevel: PropTypes.number,
 	onToggle: PropTypes.func.isRequired,
 	children: PropTypes.oneOfType( [
 		PropTypes.arrayOf( PropTypes.node ),
@@ -128,7 +128,7 @@ AnalysisCollapsibleStateless.propTypes = {
 
 AnalysisCollapsibleStateless.defaultProps = {
 	hasHeading: false,
-	headerLevel: 2,
+	headingLevel: 2,
 };
 
 export class AnalysisCollapsible extends React.Component {
@@ -169,8 +169,8 @@ export class AnalysisCollapsible extends React.Component {
 				title={ this.props.title }
 				onToggle={ this.toggleOpen.bind( this ) }
 				isOpen={ this.state.isOpen }
-				needsHeaderTag={ this.props.hasHeading }
-				headerLevel={ this.props.headingLevel }
+				hasHeading={ this.props.hasHeading }
+				headingLevel={ this.props.headingLevel }
 			>
 				{ this.props.children }
 			</AnalysisCollapsibleStateless>
@@ -182,7 +182,7 @@ AnalysisCollapsible.propTypes = {
 	title: PropTypes.string.isRequired,
 	initialIsOpen: PropTypes.bool,
 	hasHeading: PropTypes.bool,
-	headingLevel: PropTypes.string,
+	headingLevel: PropTypes.number,
 	children: PropTypes.oneOfType( [
 		PropTypes.arrayOf( PropTypes.node ),
 		PropTypes.node,

--- a/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
@@ -10,7 +10,7 @@ import IconButtonToggle from "../../Shared/components/IconButtonToggle.js";
 const AnalysisResultBase = styled.li`
 	// This is the height of the IconButtonToggle.
 	min-height: 24px;
-	padding: 4px;
+	padding: 8px 4px 8px 0;
 	display: flex;
 	align-items: flex-start;
 `;
@@ -20,7 +20,7 @@ const ScoreIcon = styled( Icon )`
 `;
 
 const AnalysisResultText = styled.p`
-	margin: 0 8px;
+	margin: 0 10px;
 	flex: 1 1 auto;
 `;
 

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -66,6 +66,13 @@ const messages = defineMessages( {
  * @returns {ReactElement} The ContentAnalysis component.
  */
 class ContentAnalysis extends React.Component {
+	/**
+	 * The constructor
+	 *
+	 * @param {object} props The component props.
+	 *
+	 * @returns {void}
+	 */
 	constructor( props ) {
 		super( props );
 
@@ -74,6 +81,13 @@ class ContentAnalysis extends React.Component {
 		};
 	}
 
+	/**
+	 * Handles button clicks. Makes sure no more than one button can be active at the same time.
+	 *
+	 * @param {string} id The button id.
+	 *
+	 * @returns {void}
+	 */
 	handleClick( id ) {
 		if ( id === this.state.checked ) {
 			this.setState( {
@@ -87,6 +101,13 @@ class ContentAnalysis extends React.Component {
 		} );
 	}
 
+	/**
+	 * Gets the color for the bullet, based on the rating.
+	 *
+	 * @param {string} rating The rating of the result.
+	 *
+	 * @returns {string} The color for the bullet.
+	 */
 	getColor( rating ) {
 		switch ( rating ) {
 			case "good":
@@ -100,6 +121,13 @@ class ContentAnalysis extends React.Component {
 		}
 	}
 
+	/**
+	 * Returns an AnalysisResult component for each result.
+	 *
+	 * @param {array} results The analysis results.
+	 *
+	 * @returns {array} A list of AnalysisResult components.
+	 */
 	getResults( results ) {
 		return results.map( ( result ) => {
 			let color = this.getColor( result.rating );
@@ -116,6 +144,11 @@ class ContentAnalysis extends React.Component {
 		} );
 	}
 
+	/**
+	 * Renders a ContentAnalysis component.
+	 *
+	 * @returns {ReactElement} The rendered ContentAnalysis component.
+	 */
 	render() {
 		let problemsResults = this.props.problemsResults;
 		let improvementsResults = this.props.improvementsResults;

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -1,7 +1,11 @@
 import React from "react";
 import styled from "styled-components";
 import colors from "../../../../style-guide/colors.json";
+import PropTypes from "prop-types";
+import util from "util";
 
+import { FormattedMessage, injectIntl, intlShape, defineMessages } from "react-intl";
+import { makeOutboundLink } from "../../../../utils/makeOutboundLink";
 import AnalysisResult from "../components/AnalysisResult.js";
 import AnalysisCollapsible from "../components/AnalysisCollapsible.js";
 
@@ -13,17 +17,60 @@ export const ContentAnalysisContainer = styled.div`
 	margin: 0 auto;
 `;
 
+const LanguageNotice = styled.div`
+	height: 24px;
+	width: 100%;
+	padding-top: 8px;
+	margin-left: 36px;
+`;
+
+const ChangeLanguageLink = makeOutboundLink( styled.a`
+	color: ${ colors.$color_blue };
+	margin-left: 4px;
+` );
+
+const messages = defineMessages( {
+	languageNotice: {
+		id: "content-analysis.language-notice",
+		defaultMessage: "Your site language is set to %s.",
+	},
+	languageNoticeLink: {
+		id: "content-analysis.language-notice-link",
+		defaultMessage:	"Change language",
+	},
+	errorsHeader: {
+		id: "content-analysis.errors",
+		defaultMessage: "Errors",
+	},
+	problemsHeader: {
+		id: "content-analysis.problems",
+		defaultMessage: "Problems",
+	},
+	improvementsHeader: {
+		id: "content-analysis.improvements",
+		defaultMessage: "Improvements",
+	},
+	considerationsHeader: {
+		id: "content-analysis.considerations",
+		defaultMessage: "Considerations",
+	},
+	goodHeader: {
+		id: "content-analysis.good",
+		defaultMessage: "Good",
+	},
+} );
+
 /**
  * Returns the ContentAnalysis component.
  *
  * @returns {ReactElement} The ContentAnalysis component.
  */
-export default class ContentAnalysis extends React.Component {
+class ContentAnalysis extends React.Component {
 	constructor( props ) {
 		super( props );
 
 		this.state = {
-			checked: "2",
+			checked: "1",
 		};
 	}
 
@@ -56,7 +103,6 @@ export default class ContentAnalysis extends React.Component {
 	getResults( results ) {
 		return results.map( ( result ) => {
 			let color = this.getColor( result.rating );
-
 			return <AnalysisResult
 				key={ result.id }
 				text={ result.text }
@@ -71,24 +117,68 @@ export default class ContentAnalysis extends React.Component {
 	}
 
 	render() {
+		let problemsResults = this.props.problemsResults;
+		let improvementsResults = this.props.improvementsResults;
+		let goodResults = this.props.goodResults;
+		let considerationsResults = this.props.considerationsResults;
+		let errorsResults = this.props.errorsResults;
+
+		// Analysis collapsibles are only rendered when there is at least one analysis result for that category present.
 		return (
 			<ContentAnalysisContainer>
-				{ this.props.problemsResults.results.length > 0 ? <AnalysisCollapsible initialIsOpen={ this.props.problemsResults.initialIsOpen } title= { this.props.problemsResults.heading }>
-					{ this.getResults( this.props.problemsResults.results ) }
-				</AnalysisCollapsible> : null }
-				{ this.props.improvementsResults.results.length > 0 ? <AnalysisCollapsible initialIsOpen={ this.props.improvementsResults.initialIsOpen } title= { this.props.improvementsResults.heading }>
-					{ this.getResults( this.props.improvementsResults.results ) }
-				</AnalysisCollapsible> : null }
-				{ this.props.goodResults.results.length > 0 ? <AnalysisCollapsible initialIsOpen={ this.props.goodResults.initialIsOpen } title= { this.props.goodResults.heading }>
-					{ this.getResults( this.props.goodResults.results ) }
-				</AnalysisCollapsible> : null }
-				{ this.props.considerationsResults.results.length > 0 ? <AnalysisCollapsible initialIsOpen={ this.props.considerationsResults.initialIsOpen } title= { this.props.considerationsResults.heading }>
-					{ this.getResults( this.props.considerationsResults.results ) }
-				</AnalysisCollapsible> : null }
-				{ this.props.errorsResults.results.length > 0 ? <AnalysisCollapsible initialIsOpen={ this.props.errorsResults.initialIsOpen } title= { this.props.errorsResults.heading }>
-					{ this.getResults( this.props.errorsResults.results ) }
-				</AnalysisCollapsible> : null }
+				<LanguageNotice>
+					{ util.format( this.props.intl.formatMessage( messages.languageNotice ), this.props.language ) }
+					<ChangeLanguageLink href={ this.props.changeLanguageLink }>
+						{ this.props.intl.formatMessage( messages.languageNoticeLink ) }
+					</ChangeLanguageLink>
+				</LanguageNotice>
+				{ errorsResults.length > 0
+					? <AnalysisCollapsible initialIsOpen={ true } title={ this.props.intl.formatMessage( messages.errorsHeader ) }>
+						{ this.getResults( errorsResults ) }
+					</AnalysisCollapsible>
+					: null }
+				{ problemsResults.length > 0
+					? <AnalysisCollapsible initialIsOpen={ true } title={ this.props.intl.formatMessage( messages.problemsHeader ) }>
+						{ this.getResults( problemsResults ) }
+					</AnalysisCollapsible>
+					: null }
+				{ improvementsResults.length > 0
+					? <AnalysisCollapsible title= { this.props.intl.formatMessage( messages.improvementsHeader ) }>
+						{ this.getResults( improvementsResults ) }
+					</AnalysisCollapsible>
+					: null }
+				{ considerationsResults.length > 0
+					? <AnalysisCollapsible title= { this.props.intl.formatMessage( messages.considerationsHeader ) }>
+						{ this.getResults( considerationsResults ) }
+					</AnalysisCollapsible>
+					: null }
+				{ goodResults.length > 0
+					? <AnalysisCollapsible title= {this.props.intl.formatMessage( messages.goodHeader ) }>
+						{ this.getResults( goodResults ) }
+					</AnalysisCollapsible>
+					: null }
 			</ContentAnalysisContainer>
 		);
 	}
 }
+
+ContentAnalysis.propTypes = {
+	problemsResults: PropTypes.array,
+	improvementsResults: PropTypes.array,
+	goodResults: PropTypes.array,
+	considerationsResults: PropTypes.array,
+	errorsResults: PropTypes.array,
+	changeLanguageLink: PropTypes.string.isRequired,
+	language: PropTypes.string.isRequired,
+	intl: intlShape.isRequired,
+};
+
+ContentAnalysis.defaultProps = {
+	problemsResults: [],
+	improvementsResults: [],
+	goodResults: false,
+	considerationsResults: false,
+	errorsResults: false,
+};
+
+export default injectIntl( ContentAnalysis );

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -1,10 +1,16 @@
 import React from "react";
 import styled from "styled-components";
+import colors from "../../../../style-guide/colors.json";
+
+import AnalysisResult from "../components/AnalysisResult.js";
+import AnalysisCollapsible from "../components/AnalysisCollapsible.js";
 
 export const ContentAnalysisContainer = styled.div`
 	min-height: 700px;
 	width: 100%;
 	background-color: white;
+	max-width: 800px;
+	margin: 0 auto;
 `;
 
 /**
@@ -12,6 +18,77 @@ export const ContentAnalysisContainer = styled.div`
  *
  * @returns {ReactElement} The ContentAnalysis component.
  */
-export default function ContentAnalysis() {
-	return <ContentAnalysisContainer/>;
+export default class ContentAnalysis extends React.Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			checked: "2",
+		};
+	}
+
+	handleClick( id ) {
+		if ( id === this.state.checked ) {
+			this.setState( {
+				checked: "-1",
+			} );
+			return;
+		}
+
+		this.setState( {
+			checked: id,
+		} );
+	}
+
+	getColor( rating ) {
+		switch ( rating ) {
+			case "good":
+				return colors.$color_good;
+			case "OK":
+				return colors.$color_ok;
+			case "bad":
+				return colors.$color_bad;
+			default:
+				return colors.$color_score_icon;
+		}
+	}
+
+	getResults( results ) {
+		return results.map( ( result ) => {
+			let color = this.getColor( result.rating );
+
+			return <AnalysisResult
+				key={ result.id }
+				text={ result.text }
+				bulletColor={ color }
+				hasMarksButton={ result.hasMarks }
+				ariaLabel="highlight this result in the text"
+				pressed={ result.id === this.state.checked }
+				buttonId={ result.id }
+				onButtonClick={ this.handleClick.bind( this, result.id ) }
+			/>;
+		} );
+	}
+
+	render() {
+		return (
+			<ContentAnalysisContainer>
+				{ this.props.problemsResults.results.length > 0 ? <AnalysisCollapsible initialIsOpen={ this.props.problemsResults.initialIsOpen } title= { this.props.problemsResults.heading }>
+					{ this.getResults( this.props.problemsResults.results ) }
+				</AnalysisCollapsible> : null }
+				{ this.props.improvementsResults.results.length > 0 ? <AnalysisCollapsible initialIsOpen={ this.props.improvementsResults.initialIsOpen } title= { this.props.improvementsResults.heading }>
+					{ this.getResults( this.props.improvementsResults.results ) }
+				</AnalysisCollapsible> : null }
+				{ this.props.goodResults.results.length > 0 ? <AnalysisCollapsible initialIsOpen={ this.props.goodResults.initialIsOpen } title= { this.props.goodResults.heading }>
+					{ this.getResults( this.props.goodResults.results ) }
+				</AnalysisCollapsible> : null }
+				{ this.props.considerationsResults.results.length > 0 ? <AnalysisCollapsible initialIsOpen={ this.props.considerationsResults.initialIsOpen } title= { this.props.considerationsResults.heading }>
+					{ this.getResults( this.props.considerationsResults.results ) }
+				</AnalysisCollapsible> : null }
+				{ this.props.errorsResults.results.length > 0 ? <AnalysisCollapsible initialIsOpen={ this.props.errorsResults.initialIsOpen } title= { this.props.errorsResults.heading }>
+					{ this.getResults( this.props.errorsResults.results ) }
+				</AnalysisCollapsible> : null }
+			</ContentAnalysisContainer>
+		);
+	}
 }

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -70,14 +70,14 @@ class ContentAnalysis extends React.Component {
 		super( props );
 
 		this.state = {
-			checked: "1",
+			checked: "",
 		};
 	}
 
 	handleClick( id ) {
 		if ( id === this.state.checked ) {
 			this.setState( {
-				checked: "-1",
+				checked: "",
 			} );
 			return;
 		}

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -65,7 +65,7 @@ const messages = defineMessages( {
  */
 class ContentAnalysis extends React.Component {
 	/**
-	 * The constructor
+	 * The constructor.
 	 *
 	 * @param {object} props The component props.
 	 *
@@ -200,7 +200,7 @@ class ContentAnalysis extends React.Component {
 					>
 						{ this.getResults( considerationsResults ) }
 					</AnalysisCollapsible> }
-				{ goodResults.length > 0  &&
+				{ goodResults.length > 0 &&
 					<AnalysisCollapsible
 						hasHeading={ true }
 						headingLevel={ 2 }

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -179,17 +179,17 @@ class ContentAnalysis extends React.Component {
 					</AnalysisCollapsible>
 					: null }
 				{ improvementsResults.length > 0
-					? <AnalysisCollapsible title= { this.props.intl.formatMessage( messages.improvementsHeader ) }>
+					? <AnalysisCollapsible title={ this.props.intl.formatMessage( messages.improvementsHeader ) }>
 						{ this.getResults( improvementsResults ) }
 					</AnalysisCollapsible>
 					: null }
 				{ considerationsResults.length > 0
-					? <AnalysisCollapsible title= { this.props.intl.formatMessage( messages.considerationsHeader ) }>
+					? <AnalysisCollapsible title={ this.props.intl.formatMessage( messages.considerationsHeader ) }>
 						{ this.getResults( considerationsResults ) }
 					</AnalysisCollapsible>
 					: null }
 				{ goodResults.length > 0
-					? <AnalysisCollapsible title= {this.props.intl.formatMessage( messages.goodHeader ) }>
+					? <AnalysisCollapsible title={this.props.intl.formatMessage( messages.goodHeader ) }>
 						{ this.getResults( goodResults ) }
 					</AnalysisCollapsible>
 					: null }
@@ -212,9 +212,9 @@ ContentAnalysis.propTypes = {
 ContentAnalysis.defaultProps = {
 	problemsResults: [],
 	improvementsResults: [],
-	goodResults: false,
-	considerationsResults: false,
-	errorsResults: false,
+	goodResults: [],
+	considerationsResults: [],
+	errorsResults: [],
 };
 
 export default injectIntl( ContentAnalysis );

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -18,8 +18,8 @@ export const ContentAnalysisContainer = styled.div`
 `;
 
 const LanguageNotice = styled.div`
-	height: 24px;
-	width: 100%;
+	min-height: 24px;
+	width: calc(100% - 48px);
 	padding-top: 8px;
 	margin-left: 36px;
 `;

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -4,7 +4,7 @@ import colors from "../../../../style-guide/colors.json";
 import PropTypes from "prop-types";
 import util from "util";
 
-import { FormattedMessage, injectIntl, intlShape, defineMessages } from "react-intl";
+import { injectIntl, intlShape, defineMessages } from "react-intl";
 import { makeOutboundLink } from "../../../../utils/makeOutboundLink";
 import AnalysisResult from "../components/AnalysisResult.js";
 import AnalysisCollapsible from "../components/AnalysisCollapsible.js";

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -4,7 +4,7 @@ import colors from "../../../../style-guide/colors.json";
 import PropTypes from "prop-types";
 import util from "util";
 
-import { injectIntl, intlShape, defineMessages } from "react-intl";
+import { injectIntl, intlShape, defineMessages, FormattedMessage } from "react-intl";
 import { makeOutboundLink } from "../../../../utils/makeOutboundLink";
 import AnalysisResult from "../components/AnalysisResult.js";
 import AnalysisCollapsible from "../components/AnalysisCollapsible.js";
@@ -32,7 +32,7 @@ const ChangeLanguageLink = makeOutboundLink( styled.a`
 const messages = defineMessages( {
 	languageNotice: {
 		id: "content-analysis.language-notice",
-		defaultMessage: "Your site language is set to %s.",
+		defaultMessage: "Your site language is set to {language}.",
 	},
 	languageNoticeLink: {
 		id: "content-analysis.language-notice-link",
@@ -160,7 +160,10 @@ class ContentAnalysis extends React.Component {
 		return (
 			<ContentAnalysisContainer>
 				<LanguageNotice>
-					{ util.format( this.props.intl.formatMessage( messages.languageNotice ), this.props.language ) }
+					<FormattedMessage
+						id={ messages.languageNotice.id }
+						defaultMessage={ messages.languageNotice.defaultMessage }
+						values={ { language: <strong>{ this.props.language }</strong> } }/>
 					<ChangeLanguageLink href={ this.props.changeLanguageLink }>
 						{ this.props.intl.formatMessage( messages.languageNoticeLink ) }
 					</ChangeLanguageLink>

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -29,10 +29,6 @@ const ChangeLanguageLink = makeOutboundLink( styled.a`
 ` );
 
 const messages = defineMessages( {
-	languageNotice: {
-		id: "content-analysis.language-notice",
-		defaultMessage: "Your site language is set to {language}.",
-	},
 	languageNoticeLink: {
 		id: "content-analysis.language-notice-link",
 		defaultMessage:	"Change language",
@@ -160,9 +156,9 @@ class ContentAnalysis extends React.Component {
 			<ContentAnalysisContainer>
 				<LanguageNotice>
 					<FormattedMessage
-						id={ messages.languageNotice.id }
-						defaultMessage={ messages.languageNotice.defaultMessage }
-						values={ { language: <strong>{ this.props.language }</strong> } }/>
+						id="content-analysis.language-notice"
+						defaultMessage="Your site language is set to {language}."
+						values={ { language: <strong>{ this.props.language }</strong> } } />
 					<ChangeLanguageLink href={ this.props.changeLanguageLink }>
 						{ this.props.intl.formatMessage( messages.languageNoticeLink ) }
 					</ChangeLanguageLink>

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -16,7 +16,7 @@ export const ContentAnalysisContainer = styled.div`
 	margin: 0 auto;
 `;
 
-const LanguageNotice = styled.div`
+const LanguageNotice = styled.p`
 	min-height: 24px;
 	padding-top: 8px;
 	margin-left: 36px;
@@ -51,6 +51,10 @@ const messages = defineMessages( {
 	goodHeader: {
 		id: "content-analysis.good",
 		defaultMessage: "Good",
+	},
+	highlight: {
+		id: "content-analysis.highlight",
+		defaultMessage: "Highlight this result in the text",
 	},
 } );
 
@@ -130,7 +134,7 @@ class ContentAnalysis extends React.Component {
 				text={ result.text }
 				bulletColor={ color }
 				hasMarksButton={ result.hasMarks }
-				ariaLabel="highlight this result in the text"
+				ariaLabel={ this.props.intl.formatMessage( messages.highlight ) }
 				pressed={ result.id === this.state.checked }
 				buttonId={ result.id }
 				onButtonClick={ this.handleClick.bind( this, result.id ) }

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -167,27 +167,49 @@ class ContentAnalysis extends React.Component {
 					</ChangeLanguageLink>
 				</LanguageNotice>
 				{ errorsResults.length > 0
-					? <AnalysisCollapsible needsHeaderTag={ true } headerLevel={ 2 } initialIsOpen={ true } title={ this.props.intl.formatMessage( messages.errorsHeader ) }>
+					? <AnalysisCollapsible
+						hasHeading={ true }
+						headingLevel={ 2 }
+						initialIsOpen={ true }
+						title={ this.props.intl.formatMessage( messages.errorsHeader ) }
+					>
 						{ this.getResults( errorsResults ) }
 					</AnalysisCollapsible>
 					: null }
 				{ problemsResults.length > 0
-					? <AnalysisCollapsible needsHeaderTag={ true } headerLevel={ 2 } initialIsOpen={ true } title={ this.props.intl.formatMessage( messages.problemsHeader ) }>
+					? <AnalysisCollapsible
+						hasHeading={ true }
+						headingLevel={ 2 }
+						initialIsOpen={ true }
+						title={ this.props.intl.formatMessage( messages.problemsHeader ) }
+					>
 						{ this.getResults( problemsResults ) }
 					</AnalysisCollapsible>
 					: null }
 				{ improvementsResults.length > 0
-					? <AnalysisCollapsible needsHeaderTag={ true } headerLevel={ 2 } title={ this.props.intl.formatMessage( messages.improvementsHeader ) }>
+					? <AnalysisCollapsible
+						hasHeading={ true }
+						headingLevel={ 2 }
+						title={ this.props.intl.formatMessage( messages.improvementsHeader ) }
+					>
 						{ this.getResults( improvementsResults ) }
 					</AnalysisCollapsible>
 					: null }
 				{ considerationsResults.length > 0
-					? <AnalysisCollapsible needsHeaderTag={ true } headerLevel={ 2 } title={ this.props.intl.formatMessage( messages.considerationsHeader ) }>
+					? <AnalysisCollapsible
+						hasHeading={ true }
+						headingLevel={ 2 }
+						title={ this.props.intl.formatMessage( messages.considerationsHeader ) }
+					>
 						{ this.getResults( considerationsResults ) }
 					</AnalysisCollapsible>
 					: null }
 				{ goodResults.length > 0
-					? <AnalysisCollapsible needsHeaderTag={ true } headerLevel={ 2 } title={this.props.intl.formatMessage( messages.goodHeader ) }>
+					? <AnalysisCollapsible
+						hasHeading={ true }
+						headingLevel={ 2 }
+						title={this.props.intl.formatMessage( messages.goodHeader ) }
+					>
 						{ this.getResults( goodResults ) }
 					</AnalysisCollapsible>
 					: null }

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -2,7 +2,6 @@ import React from "react";
 import styled from "styled-components";
 import colors from "../../../../style-guide/colors.json";
 import PropTypes from "prop-types";
-import util from "util";
 
 import { injectIntl, intlShape, defineMessages, FormattedMessage } from "react-intl";
 import { makeOutboundLink } from "../../../../utils/makeOutboundLink";

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -18,7 +18,6 @@ export const ContentAnalysisContainer = styled.div`
 
 const LanguageNotice = styled.div`
 	min-height: 24px;
-	width: calc(100% - 48px);
 	padding-top: 8px;
 	margin-left: 36px;
 `;

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -167,27 +167,27 @@ class ContentAnalysis extends React.Component {
 					</ChangeLanguageLink>
 				</LanguageNotice>
 				{ errorsResults.length > 0
-					? <AnalysisCollapsible initialIsOpen={ true } title={ this.props.intl.formatMessage( messages.errorsHeader ) }>
+					? <AnalysisCollapsible needsHeaderTag={ true } headerLevel={ 2 } initialIsOpen={ true } title={ this.props.intl.formatMessage( messages.errorsHeader ) }>
 						{ this.getResults( errorsResults ) }
 					</AnalysisCollapsible>
 					: null }
 				{ problemsResults.length > 0
-					? <AnalysisCollapsible initialIsOpen={ true } title={ this.props.intl.formatMessage( messages.problemsHeader ) }>
+					? <AnalysisCollapsible needsHeaderTag={ true } headerLevel={ 2 } initialIsOpen={ true } title={ this.props.intl.formatMessage( messages.problemsHeader ) }>
 						{ this.getResults( problemsResults ) }
 					</AnalysisCollapsible>
 					: null }
 				{ improvementsResults.length > 0
-					? <AnalysisCollapsible title={ this.props.intl.formatMessage( messages.improvementsHeader ) }>
+					? <AnalysisCollapsible needsHeaderTag={ true } headerLevel={ 2 } title={ this.props.intl.formatMessage( messages.improvementsHeader ) }>
 						{ this.getResults( improvementsResults ) }
 					</AnalysisCollapsible>
 					: null }
 				{ considerationsResults.length > 0
-					? <AnalysisCollapsible title={ this.props.intl.formatMessage( messages.considerationsHeader ) }>
+					? <AnalysisCollapsible needsHeaderTag={ true } headerLevel={ 2 } title={ this.props.intl.formatMessage( messages.considerationsHeader ) }>
 						{ this.getResults( considerationsResults ) }
 					</AnalysisCollapsible>
 					: null }
 				{ goodResults.length > 0
-					? <AnalysisCollapsible title={this.props.intl.formatMessage( messages.goodHeader ) }>
+					? <AnalysisCollapsible needsHeaderTag={ true } headerLevel={ 2 } title={this.props.intl.formatMessage( messages.goodHeader ) }>
 						{ this.getResults( goodResults ) }
 					</AnalysisCollapsible>
 					: null }

--- a/composites/Plugin/ContentAnalysis/tests/AnalysisCollapsibleTest.js
+++ b/composites/Plugin/ContentAnalysis/tests/AnalysisCollapsibleTest.js
@@ -16,6 +16,20 @@ test( "the default AnalysisCollapsible matches the snapshot", () => {
 	expect( tree ).toMatchSnapshot();
 } );
 
+test( "the AnalysisCollapsible with a heading matches the snapshot", () => {
+	const component = renderer.create(
+		<AnalysisCollapsible title="Problems" hasHeading={ true }>
+			<li> First item </li>
+			<li> Second item </li>
+			<li> Third item </li>
+			<li> Fourth item </li>
+		</AnalysisCollapsible>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );
+
 test( "the AnalysisCollapsible in opened state matches the snapshot", () => {
 	const component = renderer.create(
 		<AnalysisCollapsible title="Problems" initialIsOpen={ true }>

--- a/composites/Plugin/ContentAnalysis/tests/ContentAnalysisTest.js
+++ b/composites/Plugin/ContentAnalysis/tests/ContentAnalysisTest.js
@@ -2,7 +2,7 @@ import React from "react";
 import { createComponentWithIntl } from "../../../../utils/intlProvider";
 import ContentAnalysis from "../components/ContentAnalysis.js";
 
-test( "the AnalysisResult component matches the snapshot", () => {
+test( "the ContentAnalysis component matches the snapshot", () => {
 	const problemsResults = [
 		{
 			text: "Your text is bad, and you should feel bad.",

--- a/composites/Plugin/ContentAnalysis/tests/ContentAnalysisTest.js
+++ b/composites/Plugin/ContentAnalysis/tests/ContentAnalysisTest.js
@@ -1,13 +1,8 @@
 import React from "react";
+import { createComponentWithIntl } from "../../../../utils/intlProvider";
+import ContentAnalysis from "../components/ContentAnalysis.js";
 
-import ContentAnalysis from "../composites/Plugin/ContentAnalysis/components/ContentAnalysis";
-
-/**
- * Returns the HelpCenterWrapper component.
- *
- * @returns {ReactElement} The HelpCenterWrapper component.
- */
-export default function HelpCenterWrapper() {
+test( "the AnalysisResult component matches the snapshot", () => {
 	const problemsResults = [
 		{
 			text: "Your text is bad, and you should feel bad.",
@@ -59,7 +54,7 @@ export default function HelpCenterWrapper() {
 		},
 	];
 
-	return (
+	const component = createComponentWithIntl(
 		<ContentAnalysis
 			problemsResults={ problemsResults }
 			improvementsResults={ improvementsResults }
@@ -70,4 +65,7 @@ export default function HelpCenterWrapper() {
 			language="English"
 		/>
 	);
-}
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
@@ -12,7 +12,7 @@ exports[`the AnalysisCollapsible in opened state matches the snapshot 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="sc-gqjmRU dRmBjb sc-VigVT hHVnzr"
+      className="sc-cSHVUG jEEyiP sc-kAzzGY gDMXWb"
       focusable="false"
       role="img"
     />
@@ -42,6 +42,31 @@ exports[`the AnalysisCollapsible in opened state matches the snapshot 1`] = `
 </div>
 `;
 
+exports[`the AnalysisCollapsible with a heading matches the snapshot 1`] = `
+<div
+  className="sc-bZQynM iXyxsW"
+>
+  <button
+    aria-expanded={false}
+    className="sc-gzVnrw ixBHgh sc-EHOje FXgKN sc-ifAKCX emueJE sc-bxivhb kceQSo sc-htpNat eydFZn sc-bwzfXH eFAXpn sc-bdVaJa dHgGrL"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="sc-jTzLTM hwiuqB sc-fjdhpX YZzdr"
+      focusable="false"
+      role="img"
+    />
+    <span
+      className="sc-htoDjs grDYmx"
+    >
+      Problems (4)
+    </span>
+  </button>
+</div>
+`;
+
 exports[`the default AnalysisCollapsible matches the snapshot 1`] = `
 <div
   className="sc-bZQynM iXyxsW"
@@ -54,7 +79,7 @@ exports[`the default AnalysisCollapsible matches the snapshot 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="sc-iwsKbI iENOxB sc-gZMcBi eILSAm"
+      className="sc-gZMcBi gxyQpB sc-gqjmRU gfvlk"
       focusable="false"
       role="img"
     />

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
@@ -46,24 +46,28 @@ exports[`the AnalysisCollapsible with a heading matches the snapshot 1`] = `
 <div
   className="sc-bZQynM iXyxsW"
 >
-  <button
-    aria-expanded={false}
-    className="sc-gzVnrw ixBHgh sc-EHOje FXgKN sc-ifAKCX emueJE sc-bxivhb kceQSo sc-htpNat eydFZn sc-bwzfXH eFAXpn sc-bdVaJa dHgGrL"
-    onClick={[Function]}
-    type="button"
+  <h2
+    className="sc-VigVT ehrPw"
   >
-    <svg
-      aria-hidden="true"
-      className="sc-jTzLTM hwiuqB sc-fjdhpX YZzdr"
-      focusable="false"
-      role="img"
-    />
-    <span
-      className="sc-htoDjs grDYmx"
+    <button
+      aria-expanded={false}
+      className="sc-gzVnrw ixBHgh sc-EHOje FXgKN sc-ifAKCX emueJE sc-bxivhb kceQSo sc-htpNat eydFZn sc-bwzfXH eFAXpn sc-bdVaJa dHgGrL"
+      onClick={[Function]}
+      type="button"
     >
-      Problems (4)
-    </span>
-  </button>
+      <svg
+        aria-hidden="true"
+        className="sc-jTzLTM hwiuqB sc-fjdhpX YZzdr"
+        focusable="false"
+        role="img"
+      />
+      <span
+        className="sc-htoDjs grDYmx"
+      >
+        Problems (4)
+      </span>
+    </button>
+  </h2>
 </div>
 `;
 

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
@@ -12,7 +12,7 @@ exports[`the AnalysisCollapsible in opened state matches the snapshot 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="sc-cSHVUG jEEyiP sc-kAzzGY gDMXWb"
+      className="sc-fjdhpX fadKJT sc-jzJRlG bTTrWz"
       focusable="false"
       role="img"
     />
@@ -47,7 +47,7 @@ exports[`the AnalysisCollapsible with a heading matches the snapshot 1`] = `
   className="sc-bZQynM iXyxsW"
 >
   <h2
-    className="sc-VigVT ehrPw"
+    className="sc-gqjmRU ksuUKe"
   >
     <button
       aria-expanded={false}
@@ -57,7 +57,7 @@ exports[`the AnalysisCollapsible with a heading matches the snapshot 1`] = `
     >
       <svg
         aria-hidden="true"
-        className="sc-jTzLTM hwiuqB sc-fjdhpX YZzdr"
+        className="sc-VigVT errXbw sc-jTzLTM haBLZ"
         focusable="false"
         role="img"
       />
@@ -83,7 +83,7 @@ exports[`the default AnalysisCollapsible matches the snapshot 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="sc-gZMcBi gxyQpB sc-gqjmRU gfvlk"
+      className="sc-iwsKbI iENOxB sc-gZMcBi eILSAm"
       focusable="false"
       role="img"
     />

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
@@ -6,7 +6,7 @@ exports[`the AnalysisCollapsible in opened state matches the snapshot 1`] = `
 >
   <button
     aria-expanded={true}
-    className="sc-gzVnrw TjGgw sc-EHOje FXgKN sc-ifAKCX emueJE sc-bxivhb kceQSo sc-htpNat eydFZn sc-bwzfXH eFAXpn sc-bdVaJa dHgGrL"
+    className="sc-gzVnrw ixBHgh sc-EHOje FXgKN sc-ifAKCX emueJE sc-bxivhb kceQSo sc-htpNat eydFZn sc-bwzfXH eFAXpn sc-bdVaJa dHgGrL"
     onClick={[Function]}
     type="button"
   >
@@ -48,7 +48,7 @@ exports[`the default AnalysisCollapsible matches the snapshot 1`] = `
 >
   <button
     aria-expanded={false}
-    className="sc-gzVnrw TjGgw sc-EHOje FXgKN sc-ifAKCX emueJE sc-bxivhb kceQSo sc-htpNat eydFZn sc-bwzfXH eFAXpn sc-bdVaJa dHgGrL"
+    className="sc-gzVnrw ixBHgh sc-EHOje FXgKN sc-ifAKCX emueJE sc-bxivhb kceQSo sc-htpNat eydFZn sc-bwzfXH eFAXpn sc-bdVaJa dHgGrL"
     onClick={[Function]}
     type="button"
   >

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
@@ -47,7 +47,7 @@ exports[`the AnalysisCollapsible with a heading matches the snapshot 1`] = `
   className="sc-bZQynM iXyxsW"
 >
   <h2
-    className="sc-gqjmRU ksuUKe"
+    className="sc-gqjmRU kWAqZI"
   >
     <button
       aria-expanded={false}

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
@@ -2,11 +2,11 @@
 
 exports[`the AnalysisCollapsible in opened state matches the snapshot 1`] = `
 <div
-  className="sc-bZQynM fwTBJs"
+  className="sc-bZQynM iXyxsW"
 >
   <button
     aria-expanded={true}
-    className="sc-gzVnrw dLFwSb sc-EHOje FXgKN sc-ifAKCX emueJE sc-bxivhb kceQSo sc-htpNat eydFZn sc-bwzfXH eFAXpn sc-bdVaJa dHgGrL"
+    className="sc-gzVnrw TjGgw sc-EHOje FXgKN sc-ifAKCX emueJE sc-bxivhb kceQSo sc-htpNat eydFZn sc-bwzfXH eFAXpn sc-bdVaJa dHgGrL"
     onClick={[Function]}
     type="button"
   >
@@ -23,7 +23,7 @@ exports[`the AnalysisCollapsible in opened state matches the snapshot 1`] = `
     </span>
   </button>
   <ul
-    className="sc-dnqmqq fMZGyT"
+    className="sc-dnqmqq gRQMRU"
     role="list"
   >
     <li>
@@ -44,11 +44,11 @@ exports[`the AnalysisCollapsible in opened state matches the snapshot 1`] = `
 
 exports[`the default AnalysisCollapsible matches the snapshot 1`] = `
 <div
-  className="sc-bZQynM fwTBJs"
+  className="sc-bZQynM iXyxsW"
 >
   <button
     aria-expanded={false}
-    className="sc-gzVnrw dLFwSb sc-EHOje FXgKN sc-ifAKCX emueJE sc-bxivhb kceQSo sc-htpNat eydFZn sc-bwzfXH eFAXpn sc-bdVaJa dHgGrL"
+    className="sc-gzVnrw TjGgw sc-EHOje FXgKN sc-ifAKCX emueJE sc-bxivhb kceQSo sc-htpNat eydFZn sc-bwzfXH eFAXpn sc-bdVaJa dHgGrL"
     onClick={[Function]}
     type="button"
   >

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisResultTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisResultTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the AnalysisResult component matches the snapshot 1`] = `
 <li
-  className="sc-bwzfXH hyoGES"
+  className="sc-bwzfXH kGIHaC"
 >
   <svg
     aria-hidden="true"
@@ -11,7 +11,7 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
     role="img"
   />
   <p
-    className="sc-bxivhb ejHQXZ"
+    className="sc-bxivhb aWDuI"
   >
     You're doing great!
   </p>

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -105,14 +105,14 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
         </p>
         <button
           aria-label="highlight this result in the text"
-          aria-pressed={true}
-          className="sc-bwzfXH fRSVfl"
+          aria-pressed={false}
+          className="sc-bwzfXH iSOXYD"
           id="1"
           onClick={[Function]}
         >
           <svg
             aria-hidden="true"
-            className="sc-ckVGcZ bEepzL"
+            className="sc-ckVGcZ fSBahx"
             focusable="false"
             role="img"
           />

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -39,7 +39,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
     >
       <svg
         aria-hidden="true"
-        className="sc-kAzzGY ibpeNC sc-chPdSV coNTRN"
+        className="sc-chPdSV hbfLss sc-kgoBCf ePqMlV"
         focusable="false"
         role="img"
       />
@@ -58,7 +58,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
       >
         <svg
           aria-hidden="true"
-          className="sc-bxivhb icogks sc-kgoBCf hlIUOu"
+          className="sc-bxivhb icogks sc-kGXeez dycyvO"
           focusable="false"
           role="img"
         />
@@ -81,7 +81,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
     >
       <svg
         aria-hidden="true"
-        className="sc-kGXeez jtnyJj sc-kpOJdX hmYSjx"
+        className="sc-dxgOiQ kJTTdB sc-ckVGcZ kpGfBi"
         focusable="false"
         role="img"
       />
@@ -100,7 +100,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
       >
         <svg
           aria-hidden="true"
-          className="sc-bxivhb icogks sc-dxgOiQ ctIQJE"
+          className="sc-bxivhb icogks sc-jKJlTe iWijFp"
           focusable="false"
           role="img"
         />
@@ -118,7 +118,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="sc-ckVGcZ fSBahx"
+            className="sc-eNQAEJ hrsyaF"
             focusable="false"
             role="img"
           />
@@ -137,7 +137,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
     >
       <svg
         aria-hidden="true"
-        className="sc-jKJlTe fTuuZL sc-eNQAEJ bmrIlx"
+        className="sc-kEYyzF jvMdMW sc-kkGfuU hUQWkd"
         focusable="false"
         role="img"
       />
@@ -159,7 +159,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
     >
       <svg
         aria-hidden="true"
-        className="sc-hMqMXs gteQSO sc-kEYyzF kVGrFb"
+        className="sc-hSdWYo kTOVeH sc-eHgmQL gJqaLD"
         focusable="false"
         role="img"
       />
@@ -181,7 +181,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
     >
       <svg
         aria-hidden="true"
-        className="sc-kkGfuU bhfWur sc-iAyFgw eGHSYb"
+        className="sc-jWBwVP fFdKzu sc-brqgnP bdBJhJ"
         focusable="false"
         role="img"
       />

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -7,7 +7,13 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
   <div
     className="sc-jzJRlG ibMVYq"
   >
-    Your site language is set to English.
+    <span>
+      Your site language is set to 
+      <strong>
+        English
+      </strong>
+      .
+    </span>
     <a
       className="sc-cSHVUG fzxnjC"
       href="#"

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -1,0 +1,190 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the AnalysisResult component matches the snapshot 1`] = `
+<div
+  className="sc-fjdhpX ekEfiG"
+>
+  <div
+    className="sc-jzJRlG kTKuEa"
+  >
+    Your site language is set to English.
+    <a
+      className="sc-cSHVUG fzxnjC"
+      href="#"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Change language
+      <span
+        className="sc-bdVaJa hrXKaN"
+      >
+        (Opens in a new browser tab)
+      </span>
+    </a>
+  </div>
+  <div
+    className="sc-gZMcBi liHqSy"
+  >
+    <button
+      aria-expanded={true}
+      className="sc-gqjmRU nPXTt sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="sc-kAzzGY ibpeNC sc-chPdSV coNTRN"
+        focusable="false"
+        role="img"
+      />
+      <span
+        className="sc-VigVT bGMrIs"
+      >
+        Errors (1)
+      </span>
+    </button>
+    <ul
+      className="sc-jTzLTM cTbfwU"
+      role="list"
+    >
+      <li
+        className="sc-htpNat gcbOOr"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-bxivhb icogks sc-kgoBCf hlIUOu"
+          focusable="false"
+          role="img"
+        />
+        <p
+          className="sc-ifAKCX cHWEpb"
+        >
+          Error: Analysis not loaded
+        </p>
+      </li>
+    </ul>
+  </div>
+  <div
+    className="sc-gZMcBi liHqSy"
+  >
+    <button
+      aria-expanded={true}
+      className="sc-gqjmRU nPXTt sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="sc-kGXeez jtnyJj sc-kpOJdX hmYSjx"
+        focusable="false"
+        role="img"
+      />
+      <span
+        className="sc-VigVT bGMrIs"
+      >
+        Problems (1)
+      </span>
+    </button>
+    <ul
+      className="sc-jTzLTM cTbfwU"
+      role="list"
+    >
+      <li
+        className="sc-htpNat gcbOOr"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-bxivhb icogks sc-dxgOiQ ctIQJE"
+          focusable="false"
+          role="img"
+        />
+        <p
+          className="sc-ifAKCX cHWEpb"
+        >
+          Your text is bad, and you should feel bad.
+        </p>
+        <button
+          aria-label="highlight this result in the text"
+          aria-pressed={true}
+          className="sc-bwzfXH fRSVfl"
+          id="1"
+          onClick={[Function]}
+        >
+          <svg
+            aria-hidden="true"
+            className="sc-ckVGcZ bEepzL"
+            focusable="false"
+            role="img"
+          />
+        </button>
+      </li>
+    </ul>
+  </div>
+  <div
+    className="sc-gZMcBi liHqSy"
+  >
+    <button
+      aria-expanded={false}
+      className="sc-gqjmRU nPXTt sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="sc-jKJlTe fTuuZL sc-eNQAEJ bmrIlx"
+        focusable="false"
+        role="img"
+      />
+      <span
+        className="sc-VigVT bGMrIs"
+      >
+        Improvements (1)
+      </span>
+    </button>
+  </div>
+  <div
+    className="sc-gZMcBi liHqSy"
+  >
+    <button
+      aria-expanded={false}
+      className="sc-gqjmRU nPXTt sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="sc-hMqMXs gteQSO sc-kEYyzF kVGrFb"
+        focusable="false"
+        role="img"
+      />
+      <span
+        className="sc-VigVT bGMrIs"
+      >
+        Considerations (1)
+      </span>
+    </button>
+  </div>
+  <div
+    className="sc-gZMcBi liHqSy"
+  >
+    <button
+      aria-expanded={false}
+      className="sc-gqjmRU nPXTt sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="sc-kkGfuU bhfWur sc-iAyFgw eGHSYb"
+        focusable="false"
+        role="img"
+      />
+      <span
+        className="sc-VigVT bGMrIs"
+      >
+        Good (2)
+      </span>
+    </button>
+  </div>
+</div>
+`;

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -4,7 +4,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
 <div
   className="sc-fjdhpX ekEfiG"
 >
-  <div
+  <p
     className="sc-jzJRlG klMrMa"
   >
     <span>
@@ -27,13 +27,13 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
         (Opens in a new browser tab)
       </span>
     </a>
-  </div>
+  </p>
   <div
     className="sc-gZMcBi liHqSy"
   >
     <button
       aria-expanded={true}
-      className="sc-gqjmRU nPXTt sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+      className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
       onClick={[Function]}
       type="button"
     >
@@ -75,7 +75,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
   >
     <button
       aria-expanded={true}
-      className="sc-gqjmRU nPXTt sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+      className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
       onClick={[Function]}
       type="button"
     >
@@ -110,7 +110,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
           Your text is bad, and you should feel bad.
         </p>
         <button
-          aria-label="highlight this result in the text"
+          aria-label="Highlight this result in the text"
           aria-pressed={false}
           className="sc-bwzfXH iSOXYD"
           id="1"
@@ -131,7 +131,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
   >
     <button
       aria-expanded={false}
-      className="sc-gqjmRU nPXTt sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+      className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
       onClick={[Function]}
       type="button"
     >
@@ -153,7 +153,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
   >
     <button
       aria-expanded={false}
-      className="sc-gqjmRU nPXTt sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+      className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
       onClick={[Function]}
       type="button"
     >
@@ -175,7 +175,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
   >
     <button
       aria-expanded={false}
-      className="sc-gqjmRU nPXTt sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+      className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
       onClick={[Function]}
       type="button"
     >

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -32,7 +32,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
     className="sc-gZMcBi liHqSy"
   >
     <h2
-      className="sc-kAzzGY jfssM"
+      className="sc-kAzzGY cJSrb"
     >
       <button
         aria-expanded={true}
@@ -78,7 +78,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
     className="sc-gZMcBi liHqSy"
   >
     <h2
-      className="sc-kpOJdX frsbin"
+      className="sc-kpOJdX iIoguF"
     >
       <button
         aria-expanded={true}
@@ -138,7 +138,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
     className="sc-gZMcBi liHqSy"
   >
     <h2
-      className="sc-hMqMXs cGcDev"
+      className="sc-hMqMXs ecLisl"
     >
       <button
         aria-expanded={false}
@@ -164,7 +164,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
     className="sc-gZMcBi liHqSy"
   >
     <h2
-      className="sc-iAyFgw edUwHZ"
+      className="sc-iAyFgw hdFflt"
     >
       <button
         aria-expanded={false}
@@ -190,7 +190,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
     className="sc-gZMcBi liHqSy"
   >
     <h2
-      className="sc-cvbbAY jRiSTg"
+      className="sc-cvbbAY gpNEXt"
     >
       <button
         aria-expanded={false}

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -5,7 +5,7 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
   className="sc-fjdhpX ekEfiG"
 >
   <div
-    className="sc-jzJRlG ibMVYq"
+    className="sc-jzJRlG klMrMa"
   >
     <span>
       Your site language is set to 

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -31,24 +31,28 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
   <div
     className="sc-gZMcBi liHqSy"
   >
-    <button
-      aria-expanded={true}
-      className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
-      onClick={[Function]}
-      type="button"
+    <h2
+      className="sc-kAzzGY jfssM"
     >
-      <svg
-        aria-hidden="true"
-        className="sc-chPdSV hbfLss sc-kgoBCf ePqMlV"
-        focusable="false"
-        role="img"
-      />
-      <span
-        className="sc-VigVT bGMrIs"
+      <button
+        aria-expanded={true}
+        className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
       >
-        Errors (1)
-      </span>
-    </button>
+        <svg
+          aria-hidden="true"
+          className="sc-chPdSV hbfLss sc-kgoBCf ePqMlV"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Errors (1)
+        </span>
+      </button>
+    </h2>
     <ul
       className="sc-jTzLTM cTbfwU"
       role="list"
@@ -73,24 +77,28 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
   <div
     className="sc-gZMcBi liHqSy"
   >
-    <button
-      aria-expanded={true}
-      className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
-      onClick={[Function]}
-      type="button"
+    <h2
+      className="sc-kpOJdX frsbin"
     >
-      <svg
-        aria-hidden="true"
-        className="sc-dxgOiQ kJTTdB sc-ckVGcZ kpGfBi"
-        focusable="false"
-        role="img"
-      />
-      <span
-        className="sc-VigVT bGMrIs"
+      <button
+        aria-expanded={true}
+        className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
       >
-        Problems (1)
-      </span>
-    </button>
+        <svg
+          aria-hidden="true"
+          className="sc-dxgOiQ kJTTdB sc-ckVGcZ kpGfBi"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Problems (1)
+        </span>
+      </button>
+    </h2>
     <ul
       className="sc-jTzLTM cTbfwU"
       role="list"
@@ -129,68 +137,80 @@ exports[`the ContentAnalysis component matches the snapshot 1`] = `
   <div
     className="sc-gZMcBi liHqSy"
   >
-    <button
-      aria-expanded={false}
-      className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
-      onClick={[Function]}
-      type="button"
+    <h2
+      className="sc-hMqMXs cGcDev"
     >
-      <svg
-        aria-hidden="true"
-        className="sc-kEYyzF jvMdMW sc-kkGfuU hUQWkd"
-        focusable="false"
-        role="img"
-      />
-      <span
-        className="sc-VigVT bGMrIs"
+      <button
+        aria-expanded={false}
+        className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
       >
-        Improvements (1)
-      </span>
-    </button>
+        <svg
+          aria-hidden="true"
+          className="sc-kEYyzF jvMdMW sc-kkGfuU hUQWkd"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Improvements (1)
+        </span>
+      </button>
+    </h2>
   </div>
   <div
     className="sc-gZMcBi liHqSy"
   >
-    <button
-      aria-expanded={false}
-      className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
-      onClick={[Function]}
-      type="button"
+    <h2
+      className="sc-iAyFgw edUwHZ"
     >
-      <svg
-        aria-hidden="true"
-        className="sc-hSdWYo kTOVeH sc-eHgmQL gJqaLD"
-        focusable="false"
-        role="img"
-      />
-      <span
-        className="sc-VigVT bGMrIs"
+      <button
+        aria-expanded={false}
+        className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
       >
-        Considerations (1)
-      </span>
-    </button>
+        <svg
+          aria-hidden="true"
+          className="sc-hSdWYo kTOVeH sc-eHgmQL gJqaLD"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Considerations (1)
+        </span>
+      </button>
+    </h2>
   </div>
   <div
     className="sc-gZMcBi liHqSy"
   >
-    <button
-      aria-expanded={false}
-      className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
-      onClick={[Function]}
-      type="button"
+    <h2
+      className="sc-cvbbAY jRiSTg"
     >
-      <svg
-        aria-hidden="true"
-        className="sc-jWBwVP fFdKzu sc-brqgnP bdBJhJ"
-        focusable="false"
-        role="img"
-      />
-      <span
-        className="sc-VigVT bGMrIs"
+      <button
+        aria-expanded={false}
+        className="sc-gqjmRU bTKIiF sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
       >
-        Good (2)
-      </span>
-    </button>
+        <svg
+          aria-hidden="true"
+          className="sc-jWBwVP fFdKzu sc-brqgnP bdBJhJ"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Good (2)
+        </span>
+      </button>
+    </h2>
   </div>
 </div>
 `;

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`the AnalysisResult component matches the snapshot 1`] = `
+exports[`the ContentAnalysis component matches the snapshot 1`] = `
 <div
   className="sc-fjdhpX ekEfiG"
 >
   <div
-    className="sc-jzJRlG kTKuEa"
+    className="sc-jzJRlG ibMVYq"
   >
     Your site language is set to English.
     <a


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added Content Analysis Component.



## Relevant technical choices:

* I've decided to make the analysis result categories (errors, improvements etc.) static, although they are not shown when there is no result in that specific category. For now, I don't see any reason to pass categories as a prop, and implementing it that way would make this component way more complex. 
* The bullet is merely decorative. All information needed is communicated through the headings. 
* Discussed header order with @hedgefield: errors, problems, improvements, considerations, good. The collapsibles of errors and problems should be opened by default, the other categories don't.

## Issues still to be solved

* The language notice should only be shown in the readability analysis (not in the SEO analysis). What would be the best way to handle this?
* ~~In the language notice I use the magic number 48px, but that's the only way I get it to work in responsive view:`width: calc(100% - 48px);`~~
* ~~I can't get it to work to bold the language in the language notice and at the same time using a prop to set that language. Assistance is very welcome!~~

## Test instructions

This PR can be tested by following these steps:

* The content analysis tab is opened by default in the app.
* Margins/paddings are already discussed with @hedgefield. However, suggestions are always welcome, of course. 
* Play around a bit with empty result categories to make sure the respective headings are not shown when there are no results to show.
* Only the 'Errors' and 'Problems' category collapsibles should be opened by default.
* Only one button should be active at any given time (or zero).

Fixes #194
