### PR TITLE
Replaced all string refs to ref callbacks

### DIFF
--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -118,12 +118,11 @@ class OnboardingWizard extends React.Component {
 		sendStep(
 			this.props.endpoint.url,
 			{
-				data: this.refs.step.state.fieldValues[ this.state.currentStepId ],
+				data: this.step.state.fieldValues[ this.state.currentStepId ],
 				headers: this.props.endpoint.headers,
-			}
-		)
-		.then( this.handleSuccessful.bind( this, step ) )
-		.catch( this.handleFailure.bind( this ) );
+			} )
+			.then( this.handleSuccessful.bind( this, step ) )
+			.catch( this.handleFailure.bind( this ) );
 	}
 
 	/**
@@ -153,7 +152,7 @@ class OnboardingWizard extends React.Component {
 		/* eslint-disable react/no-find-dom-node */
 		// Set focus on the main content but not when clicking the step buttons.
 		if ( -1 === this.clickedButton.className.indexOf( "step" ) ) {
-			ReactDOM.findDOMNode( this.refs.step.refs.stepContainer ).focus();
+			ReactDOM.findDOMNode( this.step.stepContainer ).focus();
 		}
 		/* eslint-enable react/no-find-dom-node */
 	}
@@ -311,7 +310,9 @@ class OnboardingWizard extends React.Component {
 						<div className="yoast-wizard">
 							{ this.renderErrorMessage() }
 							<Step
-								ref="step"
+								ref={ step => {
+									this.step = step;
+								} }
 								currentStep={ this.state.currentStepId }
 								title={ step.title }
 								fields={ step.fields }

--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import ReactDOM from "react-dom";
 import Step from "./Step";
 import StepIndicator from "./StepIndicator";
 import LoadingIndicator from "./LoadingIndicator";
@@ -149,12 +148,10 @@ class OnboardingWizard extends React.Component {
 			currentStepId: step,
 		} );
 
-		/* eslint-disable react/no-find-dom-node */
 		// Set focus on the main content but not when clicking the step buttons.
 		if ( -1 === this.clickedButton.className.indexOf( "step" ) ) {
-			ReactDOM.findDOMNode( this.step.stepContainer ).focus();
+			this.step.stepContainer.focus();
 		}
-		/* eslint-enable react/no-find-dom-node */
 	}
 
 	/**

--- a/composites/OnboardingWizard/Step.js
+++ b/composites/OnboardingWizard/Step.js
@@ -257,8 +257,13 @@ class Step extends React.Component {
 		let fullWidthClass = this.props.fullWidth ? ` ${ this.props.classPrefix }-content-container__is-full-width` : "";
 
 		return (
-			<div className={`${ this.props.classPrefix }--step--container`} ref="stepContainer"
-				tabIndex="-1" aria-labelledby="step-title">
+			<div
+				className={`${ this.props.classPrefix }--step--container`}
+				ref={ stepContainer => {
+					this.stepContainer = stepContainer;
+				} }
+				tabIndex="-1"
+				aria-labelledby="step-title">
 				<h1 id="step-title">{this.props.title}</h1>
 				<div className={ `${ this.props.classPrefix }-content-container${ fullWidthClass }` }>
 					{ this.getFieldComponents( this.props.fields ) }

--- a/composites/OnboardingWizard/Step.js
+++ b/composites/OnboardingWizard/Step.js
@@ -258,7 +258,7 @@ class Step extends React.Component {
 
 		return (
 			<div
-				className={`${ this.props.classPrefix }--step--container`}
+				className={ `${ this.props.classPrefix }--step--container` }
 				ref={ stepContainer => {
 					this.stepContainer = stepContainer;
 				} }

--- a/composites/Plugin/SnippetPreview/components/InputField.js
+++ b/composites/Plugin/SnippetPreview/components/InputField.js
@@ -32,7 +32,7 @@ export default class InputField extends React.Component {
 			<InputFieldContainer onClick={ this.focus.bind( this ) }>
 				<Editor
 					editorState={ this.state.editorState }
-					handlePastedText= { this.handlePastedText.bind( this ) }
+					handlePastedText={ this.handlePastedText.bind( this ) }
 					onChange={ this.onChange.bind( this ) }
 					placeholder={ this.props.placeholder }
 					ref={ editor => {

--- a/composites/Plugin/SnippetPreview/components/InputField.js
+++ b/composites/Plugin/SnippetPreview/components/InputField.js
@@ -35,7 +35,9 @@ export default class InputField extends React.Component {
 					handlePastedText= { this.handlePastedText.bind( this ) }
 					onChange={ this.onChange.bind( this ) }
 					placeholder={ this.props.placeholder }
-					ref="editor"
+					ref={ editor => {
+						this.editor = editor;
+					} }
 					handleReturn={ () => "handled" }
 				/>
 			</InputFieldContainer>
@@ -47,7 +49,7 @@ export default class InputField extends React.Component {
 	}
 
 	focus() {
-		this.refs.editor.focus();
+		this.editor.focus();
 	}
 
 	handlePastedText( text ) {

--- a/composites/SearchResultForm/SearchResultForm.js
+++ b/composites/SearchResultForm/SearchResultForm.js
@@ -114,7 +114,6 @@ class SearchResultForm extends React.Component {
 
 				<Textfield
 					name="title"
-					ref="formTitle"
 					label="SEO Title"
 					value={this.props.title}
 					onChange={ this.props.onTitleChange }
@@ -137,7 +136,6 @@ class SearchResultForm extends React.Component {
 
 				<Textfield
 					name="slug"
-					ref="formSlug"
 					label="Slug"
 					value={slug}
 					onChange={ this.props.onSlugChange }
@@ -151,7 +149,6 @@ class SearchResultForm extends React.Component {
 
 				<Textfield
 					name="description"
-					ref="formDescription"
 					label="Description"
 					value={this.props.description}
 					onChange={ this.props.onDescriptionChange }

--- a/composites/SearchResultPreview/SearchResultPreview.js
+++ b/composites/SearchResultPreview/SearchResultPreview.js
@@ -9,7 +9,6 @@ import Button from "../../forms/Button";
  * The SearchResultPreview component.
  */
 class SearchResultPreview extends React.Component {
-
 	/**
 	 * Constructs the SearchResultPreview.
 	 *
@@ -82,7 +81,7 @@ class SearchResultPreview extends React.Component {
 	 * @returns {void}
 	 */
 	componentDidMount() {
-		this.props.measureTitle( this.getFieldWidthByReference( "previewTitle" ) );
+		this.props.measureTitle( this.getPreviewTitleWidth() );
 		this.props.measureDescription( this.props.description.length );
 	}
 
@@ -96,7 +95,7 @@ class SearchResultPreview extends React.Component {
 	componentDidUpdate( prevProps ) {
 		if ( this.props.title !== prevProps.title ) {
 			// Recalculate width
-			this.props.measureTitle( this.getFieldWidthByReference( "previewTitle" ) );
+			this.props.measureTitle( this.getPreviewTitleWidth() );
 		}
 
 		if ( this.props.description !== prevProps.description ) {
@@ -106,13 +105,12 @@ class SearchResultPreview extends React.Component {
 	}
 
 	/**
-	 * Gets the width of a specific, referred element.
+	 * Gets the width of the preview title element.
 	 *
-	 * @param {string} reference The reference to look up an element by.
 	 * @returns {number} The width of the referenced element or 0 if nothing was found.
 	 */
-	getFieldWidthByReference( reference ) {
-		return this.refs[ reference ].getBoundingClientRect().width || 0;
+	getPreviewTitleWidth() {
+		return this.previewTitle.getBoundingClientRect().width || 0;
 	}
 
 	/**
@@ -159,33 +157,40 @@ class SearchResultPreview extends React.Component {
 		let translations = this.getTranslations();
 
 		return (
-			<Section level={3}
-			         headingText={translations.previewTitle}
-			         headingClassName={this.classNames.sectionHeading}
-			         className={this.classNames.section}>
+			<Section
+				level={3}
+				headingText={translations.previewTitle}
+				headingClassName={this.classNames.sectionHeading}
+				className={this.classNames.section}>
 				<p className={this.classNames.screenReaderText}>{translations.previewDescription}</p>
 
-				<div ref="previewTitleContainer"
-				     className={this.setClassNameForField( "previewTitleContainer" )}
-				     {...this.mouseEventHandlers( "previewTitleContainer", "formTitle" )}>
+				<div
+					className={this.setClassNameForField( "previewTitleContainer" )}
+					{...this.mouseEventHandlers( "previewTitleContainer", "formTitle" )}>
 					<span className={this.classNames.screenReaderText}>{translations.titleLabel}</span>
-                    <span ref="previewTitle" className={this.classNames.title}>{translations.title}</span>
+					<span
+						ref={ previewTitle => {
+							this.previewTitle = previewTitle;
+						} }
+						className={this.classNames.title}>
+						{translations.title}
+					</span>
 				</div>
 
-				<div ref="previewUrlContainer"
-	                 className={this.setClassNameForField( "previewUrlContainer" )}
-	                 {...this.mouseEventHandlers( "previewUrlContainer", "formSlug" )}>
+				<div
+					className={this.setClassNameForField( "previewUrlContainer" )}
+					{...this.mouseEventHandlers( "previewUrlContainer", "formSlug" )}>
 					<span className={this.classNames.screenReaderText}>{translations.urlLabel}</span>
-					<span ref="previewUrl" className={this.classNames.url}>{this.props.url}</span>
+					<span className={this.classNames.url}>{this.props.url}</span>
 				</div>
 
-				<div ref="previewDescriptionContainer"
-	                 className={this.setClassNameForField( "previewDescriptionContainer" )}
-	                 {...this.mouseEventHandlers( "previewDescriptionContainer", "formDescription" )}>
+				<div
+					className={this.setClassNameForField( "previewDescriptionContainer" )}
+					{...this.mouseEventHandlers( "previewDescriptionContainer", "formDescription" )}>
 					<span className={this.classNames.screenReaderText}>{translations.descriptionLabel}</span>
 					{ this.renderDate() }
-					<span ref="previewDescription"
-					      className={this.classNames.description}>{translations.description.substr( 0, 156 )}</span>
+					<span
+						className={this.classNames.description}>{translations.description.substr( 0, 156 )}</span>
 				</div>
 
 				{ this.renderEditButton() }

--- a/composites/SearchResultPreview/SearchResultPreview.js
+++ b/composites/SearchResultPreview/SearchResultPreview.js
@@ -107,7 +107,7 @@ class SearchResultPreview extends React.Component {
 	/**
 	 * Gets the width of the preview title element.
 	 *
-	 * @returns {number} The width of the referenced element or 0 if nothing was found.
+	 * @returns {number} The width of the preview title element or 0 if nothing was found.
 	 */
 	getPreviewTitleWidth() {
 		return this.previewTitle.getBoundingClientRect().width || 0;
@@ -158,39 +158,39 @@ class SearchResultPreview extends React.Component {
 
 		return (
 			<Section
-				level={3}
-				headingText={translations.previewTitle}
-				headingClassName={this.classNames.sectionHeading}
-				className={this.classNames.section}>
-				<p className={this.classNames.screenReaderText}>{translations.previewDescription}</p>
+				level={ 3 }
+				headingText={ translations.previewTitle }
+				headingClassName={ this.classNames.sectionHeading }
+				className={ this.classNames.section }>
+				<p className={ this.classNames.screenReaderText }>{ translations.previewDescription }</p>
 
 				<div
-					className={this.setClassNameForField( "previewTitleContainer" )}
-					{...this.mouseEventHandlers( "previewTitleContainer", "formTitle" )}>
-					<span className={this.classNames.screenReaderText}>{translations.titleLabel}</span>
+					className={ this.setClassNameForField( "previewTitleContainer" ) }
+					{ ...this.mouseEventHandlers( "previewTitleContainer", "formTitle" ) }>
+					<span className={ this.classNames.screenReaderText }>{ translations.titleLabel }</span>
 					<span
 						ref={ previewTitle => {
 							this.previewTitle = previewTitle;
 						} }
-						className={this.classNames.title}>
-						{translations.title}
+						className={ this.classNames.title }>
+						{ translations.title }
 					</span>
 				</div>
 
 				<div
-					className={this.setClassNameForField( "previewUrlContainer" )}
-					{...this.mouseEventHandlers( "previewUrlContainer", "formSlug" )}>
-					<span className={this.classNames.screenReaderText}>{translations.urlLabel}</span>
-					<span className={this.classNames.url}>{this.props.url}</span>
+					className={ this.setClassNameForField( "previewUrlContainer" ) }
+					{ ...this.mouseEventHandlers( "previewUrlContainer", "formSlug" ) }>
+					<span className={ this.classNames.screenReaderText }>{ translations.urlLabel }</span>
+					<span className={ this.classNames.url }>{ this.props.url }</span>
 				</div>
 
 				<div
-					className={this.setClassNameForField( "previewDescriptionContainer" )}
-					{...this.mouseEventHandlers( "previewDescriptionContainer", "formDescription" )}>
-					<span className={this.classNames.screenReaderText}>{translations.descriptionLabel}</span>
+					className={ this.setClassNameForField( "previewDescriptionContainer" ) }
+					{ ...this.mouseEventHandlers( "previewDescriptionContainer", "formDescription" ) }>
+					<span className={ this.classNames.screenReaderText }>{ translations.descriptionLabel }</span>
 					{ this.renderDate() }
 					<span
-						className={this.classNames.description}>{translations.description.substr( 0, 156 )}</span>
+						className={ this.classNames.description }>{ translations.description.substr( 0, 156 ) }</span>
 				</div>
 
 				{ this.renderEditButton() }
@@ -231,4 +231,3 @@ SearchResultPreview.defaultProps = {
 };
 
 export default localize( SearchResultPreview );
-


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes the deprecated `refs` and replaces them with ref callbacks.

## Test instructions

This PR can be tested by following these steps:

* Test the onboarding wizard and algolia searcher and make sure no errors occur.

Fixes #351 
