### PR TITLE
Change dashboard widget progress bar height

### DIFF
--- a/composites/Plugin/Shared/components/StackedProgressBar.js
+++ b/composites/Plugin/Shared/components/StackedProgressBar.js
@@ -60,7 +60,7 @@ StackedProgressBar.propTypes = {
 
 StackedProgressBar.defaultProps = {
 	className: "stacked-progress-bar",
-	barHeight: "40px",
+	barHeight: "24px",
 };
 
 export default StackedProgressBar;

--- a/composites/Plugin/Shared/tests/__snapshots__/StackedProgressBarTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/StackedProgressBarTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the StackedProgressBar matches the snapshot 1`] = `
 <div
-  className="stacked-progress-bar sc-bdVaJa bJbZBf"
+  className="stacked-progress-bar sc-bdVaJa cuCSbx"
 >
   <span
     className="stacked-progress-bar__part sc-bwzfXH gpLKCA"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes the dashboard widget progress bar height from 40px to 24 px.

Fixes https://github.com/Yoast/wordpress-seo/issues/8123
