### PR TITLE
Make the Wizard previous and next buttons focusable again

### DIFF
--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -278,7 +278,6 @@ class OnboardingWizard extends React.Component {
 				onClick: this.setPreviousStep,
 				disableFocusRipple: true,
 				disableTouchRipple: true,
-				disableKeyboardFocus: true,
 				icon: <ArrowBackwardIcon viewBox="0 0 28 28" />,
 			}, step, "yoast-wizard--button yoast-wizard--button__previous" );
 
@@ -289,7 +288,6 @@ class OnboardingWizard extends React.Component {
 				onClick: this.setNextStep,
 				disableFocusRipple: true,
 				disableTouchRipple: true,
-				disableKeyboardFocus: true,
 				labelPosition: "before",
 				icon: <ArrowForwardIcon viewBox="0 0 28 28" />,
 			}, step, "yoast-wizard--button yoast-wizard--button__next" );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Made the Onboarding Wizard previous and next buttons focusable again

## Relevant technical choices:

* Removes the `disableKeyboardFocus` from the buttons. Seems this prop was initially used in material-ui just for styling purposes, instead now it's also responsible for setting the tabindex attribute.

## Test instructions

- on the develop branch, use the keyboard to Tab to the buttons and see they're not focusable
- see they have a `tabindex="-1"` attribute
- switch to this branch
- check the buttons are now focusable
- check they have a `tabindex="0"` attribute

Aside note: as mentioned in the issue, `material-ui` does lots of things to control elements focusability programmatically. Not sure I really like this approach. Keeping controls behaviors as native as possible is always a better choice.

Fixes #368
