### PR TITLE
Remove minheight from Content Analysis component.

### DIFF
--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -9,7 +9,6 @@ import AnalysisResult from "../components/AnalysisResult.js";
 import AnalysisCollapsible from "../components/AnalysisCollapsible.js";
 
 export const ContentAnalysisContainer = styled.div`
-	min-height: 700px;
 	width: 100%;
 	background-color: white;
 	max-width: 800px;

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the ContentAnalysis component with language notice matches the snapshot 1`] = `
 <div
-  className="sc-fjdhpX ekEfiG"
+  className="sc-fjdhpX dMpTuU"
 >
   <p
     className="sc-jzJRlG klMrMa"
@@ -223,7 +223,7 @@ exports[`the ContentAnalysis component with language notice matches the snapshot
 
 exports[`the ContentAnalysis component without language notice matches the snapshot 1`] = `
 <div
-  className="sc-fjdhpX ekEfiG"
+  className="sc-fjdhpX dMpTuU"
 >
   <div
     className="sc-gZMcBi liHqSy"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Remove `min-height` from Content Analysis component.


## Test instructions

This PR can be tested by following these steps:

* Look at the ContentAnalysis component in the app.js

Fixes #371
