### PR TITLE
Speed up Travis by running Jest sequentially

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 
 script:
 - grunt check
-- yarn test -- --coverage
+- yarn test -- --coverage --runInBand
 
 after_success:
 - npm install -g codeclimate-test-reporter


### PR DESCRIPTION
## Summary

Speeds up Travis by running Jest sequentially

Before: 
43.00s
<img width="848" alt="schermafbeelding 2017-11-08 om 15 24 46" src="https://user-images.githubusercontent.com/17744553/32554326-b7dbf98a-c499-11e7-9173-94a4b7501e60.png">
48.21s
<img width="853" alt="schermafbeelding 2017-11-08 om 15 25 07" src="https://user-images.githubusercontent.com/17744553/32554329-b9835a12-c499-11e7-84fd-8570321c19a6.png">

After:
17.27s
<img width="1305" alt="schermafbeelding 2017-11-08 om 15 27 33" src="https://user-images.githubusercontent.com/17744553/32554409-f041154e-c499-11e7-91a2-5b510e3e482f.png">
20.74s
<img width="1313" alt="schermafbeelding 2017-11-08 om 15 43 09" src="https://user-images.githubusercontent.com/17744553/32554895-8ebdcebe-c49b-11e7-8e65-4370d1cf469b.png">

