### PR TITLE
Make IconButtonToggle type button

### DIFF
--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisResultTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisResultTest.js.snap
@@ -24,6 +24,7 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
     className="sc-bdVaJa VNVFd"
     id="Result button"
     onClick={[Function]}
+    type="button"
   >
     <svg
       aria-hidden="true"
@@ -59,6 +60,7 @@ exports[`the AnalysisResult component with html in the text matches the snapshot
     className="sc-bdVaJa VNVFd"
     id="Result button"
     onClick={[Function]}
+    type="button"
   >
     <svg
       aria-hidden="true"

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -129,6 +129,7 @@ exports[`the ContentAnalysis component with language notice matches the snapshot
           className="sc-bwzfXH iSOXYD"
           id="1"
           onClick={[Function]}
+          type="button"
         >
           <svg
             aria-hidden="true"
@@ -326,6 +327,7 @@ exports[`the ContentAnalysis component without language notice matches the snaps
           className="sc-bwzfXH iSOXYD"
           id="1"
           onClick={[Function]}
+          type="button"
         >
           <svg
             aria-hidden="true"

--- a/composites/Plugin/Shared/components/IconButtonToggle.js
+++ b/composites/Plugin/Shared/components/IconButtonToggle.js
@@ -35,6 +35,7 @@ const ChangingIconButtonBase = styled.button`
 const ChangingIconButton = ( props ) => {
 	return (
 		<ChangingIconButtonBase
+			type="button"
 			onClick={ props.onClick }
 			pressed={ props.pressed }
 			unpressedBoxShadowColor={ props.unpressedBoxShadowColor }

--- a/composites/Plugin/Shared/tests/__snapshots__/IconButtonToggleTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/IconButtonToggleTest.js.snap
@@ -7,6 +7,7 @@ exports[`the pressed IconButtonToggle matches the snapshot 1`] = `
   className="sc-bdVaJa VNVFd"
   id="RadioButton2"
   onClick={[Function]}
+  type="button"
 >
   <svg
     aria-hidden="true"
@@ -24,6 +25,7 @@ exports[`the unpressed IconButtonToggle matches the snapshot 1`] = `
   className="sc-bdVaJa inADYO"
   id="RadioButton"
   onClick={[Function]}
+  type="button"
 >
   <svg
     aria-hidden="true"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes error in wordpress-seo causing random refresh on content analysis marker button

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Checkout `feature/reactify-content-analysis` in `wordpress-seo`
* Change `yoast-components` version to this branch `https://github.com/Yoast/yoast-components.git#stories/icon-button-toggle-type-button`
* Run `grunt build:js`
* Open the classic editor and paste the following text into the visual editor: `Here is some text. Here is some more. Here is a unicorn.`. Switch to the readability analysis and inspect the button next to the `The text contains 3 consecutive sentences starting with the same word. Try to mix things up!` result. Make sure it has the `type="button"` attribute.
* Click the button a few times to make sure it doesn't reload the page.

