### PR TITLE
Content analysis css tweaks

### DIFF
--- a/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
@@ -65,7 +65,6 @@ const AnalysisList = styled.ul`
 function wrapInHeading( Component, headingLevel ) {
 	const Heading = `h${ headingLevel }`;
 	const StyledHeading = styled( Heading )`
-		padding: 0;
 		margin: 0;
 		font-weight: normal;
 	`;

--- a/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
@@ -65,6 +65,7 @@ const AnalysisList = styled.ul`
 function wrapInHeading( Component, headingLevel ) {
 	const Heading = `h${ headingLevel }`;
 	const StyledHeading = styled( Heading )`
+		padding: 0;
 		margin: 0;
 		font-weight: normal;
 	`;

--- a/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
@@ -8,7 +8,6 @@ import colors from "../../../../style-guide/colors.json";
 import { IconButton } from "../../Shared/components/Button";
 
 const AnalysisHeaderContainer = styled.div`
-	margin: 4px 0 8px 0;
 	background-color: ${ colors.$color_white };
 `;
 

--- a/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
@@ -10,7 +10,7 @@ import IconButtonToggle from "../../Shared/components/IconButtonToggle.js";
 const AnalysisResultBase = styled.li`
 	// This is the height of the IconButtonToggle.
 	min-height: 24px;
-	padding: 8px 4px 8px 0;
+	padding: 0 4px 0 0;
 	display: flex;
 	align-items: flex-start;
 `;

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the AnalysisCollapsible in opened state matches the snapshot 1`] = `
 <div
-  className="sc-bZQynM iXyxsW"
+  className="sc-bZQynM iUmxxL"
 >
   <button
     aria-expanded={true}
@@ -44,7 +44,7 @@ exports[`the AnalysisCollapsible in opened state matches the snapshot 1`] = `
 
 exports[`the AnalysisCollapsible with a heading matches the snapshot 1`] = `
 <div
-  className="sc-bZQynM iXyxsW"
+  className="sc-bZQynM iUmxxL"
 >
   <h2
     className="sc-gqjmRU kWAqZI"
@@ -73,7 +73,7 @@ exports[`the AnalysisCollapsible with a heading matches the snapshot 1`] = `
 
 exports[`the default AnalysisCollapsible matches the snapshot 1`] = `
 <div
-  className="sc-bZQynM iXyxsW"
+  className="sc-bZQynM iUmxxL"
 >
   <button
     aria-expanded={false}

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisResultTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisResultTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the AnalysisResult component matches the snapshot 1`] = `
 <li
-  className="sc-bwzfXH kGIHaC"
+  className="sc-bwzfXH kaQsFW"
 >
   <svg
     aria-hidden="true"
@@ -38,7 +38,7 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
 
 exports[`the AnalysisResult component with html in the text matches the snapshot 1`] = `
 <li
-  className="sc-bwzfXH kGIHaC"
+  className="sc-bwzfXH kaQsFW"
 >
   <svg
     aria-hidden="true"

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -29,7 +29,7 @@ exports[`the ContentAnalysis component with language notice matches the snapshot
     </a>
   </p>
   <div
-    className="sc-gZMcBi liHqSy"
+    className="sc-gZMcBi klyNBW"
   >
     <h2
       className="sc-cMljjf jlRxCV"
@@ -58,7 +58,7 @@ exports[`the ContentAnalysis component with language notice matches the snapshot
       role="list"
     >
       <li
-        className="sc-htpNat gcbOOr"
+        className="sc-htpNat hLKTNr"
       >
         <svg
           aria-hidden="true"
@@ -78,7 +78,7 @@ exports[`the ContentAnalysis component with language notice matches the snapshot
     </ul>
   </div>
   <div
-    className="sc-gZMcBi liHqSy"
+    className="sc-gZMcBi klyNBW"
   >
     <h2
       className="sc-iRbamj hvszbL"
@@ -107,7 +107,7 @@ exports[`the ContentAnalysis component with language notice matches the snapshot
       role="list"
     >
       <li
-        className="sc-htpNat gcbOOr"
+        className="sc-htpNat hLKTNr"
       >
         <svg
           aria-hidden="true"
@@ -142,7 +142,7 @@ exports[`the ContentAnalysis component with language notice matches the snapshot
     </ul>
   </div>
   <div
-    className="sc-gZMcBi liHqSy"
+    className="sc-gZMcBi klyNBW"
   >
     <h2
       className="sc-bRBYWo fDCyos"
@@ -168,7 +168,7 @@ exports[`the ContentAnalysis component with language notice matches the snapshot
     </h2>
   </div>
   <div
-    className="sc-gZMcBi liHqSy"
+    className="sc-gZMcBi klyNBW"
   >
     <h2
       className="sc-fBuWsC lopjZx"
@@ -194,7 +194,7 @@ exports[`the ContentAnalysis component with language notice matches the snapshot
     </h2>
   </div>
   <div
-    className="sc-gZMcBi liHqSy"
+    className="sc-gZMcBi klyNBW"
   >
     <h2
       className="sc-eqIVtm fCubKM"
@@ -227,7 +227,7 @@ exports[`the ContentAnalysis component without language notice matches the snaps
   className="sc-fjdhpX dMpTuU"
 >
   <div
-    className="sc-gZMcBi liHqSy"
+    className="sc-gZMcBi klyNBW"
   >
     <h2
       className="sc-kAzzGY cJSrb"
@@ -256,7 +256,7 @@ exports[`the ContentAnalysis component without language notice matches the snaps
       role="list"
     >
       <li
-        className="sc-htpNat gcbOOr"
+        className="sc-htpNat hLKTNr"
       >
         <svg
           aria-hidden="true"
@@ -276,7 +276,7 @@ exports[`the ContentAnalysis component without language notice matches the snaps
     </ul>
   </div>
   <div
-    className="sc-gZMcBi liHqSy"
+    className="sc-gZMcBi klyNBW"
   >
     <h2
       className="sc-kpOJdX iIoguF"
@@ -305,7 +305,7 @@ exports[`the ContentAnalysis component without language notice matches the snaps
       role="list"
     >
       <li
-        className="sc-htpNat gcbOOr"
+        className="sc-htpNat hLKTNr"
       >
         <svg
           aria-hidden="true"
@@ -340,7 +340,7 @@ exports[`the ContentAnalysis component without language notice matches the snaps
     </ul>
   </div>
   <div
-    className="sc-gZMcBi liHqSy"
+    className="sc-gZMcBi klyNBW"
   >
     <h2
       className="sc-hMqMXs ecLisl"
@@ -366,7 +366,7 @@ exports[`the ContentAnalysis component without language notice matches the snaps
     </h2>
   </div>
   <div
-    className="sc-gZMcBi liHqSy"
+    className="sc-gZMcBi klyNBW"
   >
     <h2
       className="sc-iAyFgw hdFflt"
@@ -392,7 +392,7 @@ exports[`the ContentAnalysis component without language notice matches the snaps
     </h2>
   </div>
   <div
-    className="sc-gZMcBi liHqSy"
+    className="sc-gZMcBi klyNBW"
   >
     <h2
       className="sc-cvbbAY gpNEXt"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Remove unnecessary whitespace between `AnalysisResult`s and between `AnalysisCollapsible`s

Old situation:
<img width="191" alt="schermafbeelding 2017-11-20 om 11 47 19" src="https://user-images.githubusercontent.com/17744553/33014977-6267b0d0-cde9-11e7-849e-21753b3afc89.png">

New situation:
<img width="195" alt="schermafbeelding 2017-11-20 om 11 47 02" src="https://user-images.githubusercontent.com/17744553/33014967-5c86ca52-cde9-11e7-9be4-e1ca02dddd34.png">

Old situation:
<img width="239" alt="schermafbeelding 2017-11-20 om 11 02 21" src="https://user-images.githubusercontent.com/17744553/33012885-7c3924f0-cde2-11e7-9d58-f83f302e9742.png">


New situation:
<img width="216" alt="schermafbeelding 2017-11-20 om 11 49 10" src="https://user-images.githubusercontent.com/17744553/33014961-59778dce-cde9-11e7-85fc-c6764a488d1d.png">



## Test instructions

This PR can be tested by following these steps:

* Compare whitespace between `develop` and this branch using localhost:3333. Please note that WP adds extra whitespace. 

Fixes #381
