### PR TITLE
Avoid collapsible header button full re-render.

### DIFF
--- a/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
@@ -90,17 +90,17 @@ export const AnalysisCollapsibleStateless = ( props ) => {
 	let title = props.title;
 	let count = getChildrenCount( props.children );
 
-	const MaybeWrappedButton = props.element;
+	const Button = props.element;
 
 	return (
 		<AnalysisHeaderContainer>
-			<MaybeWrappedButton
+			<Button
 				aria-expanded={ props.isOpen }
 				onClick={ props.onToggle }
 				icon={ props.isOpen ? angleUp : angleDown }
 				iconColor={ colors.$color_grey_dark } >
 				<AnalysisTitle>{ `${ title } (${ count })` }</AnalysisTitle>
-			</MaybeWrappedButton>
+			</Button>
 			{
 				props.isOpen && props.children &&
 					<AnalysisList role="list">{ props.children }</AnalysisList>

--- a/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisCollapsible.js
@@ -90,21 +90,20 @@ export const AnalysisCollapsibleStateless = ( props ) => {
 	let title = props.title;
 	let count = getChildrenCount( props.children );
 
-	const Button = props.hasHeading ? wrapInHeading( AnalysisHeaderButton, props.headingLevel ) : AnalysisHeaderButton;
+	const MaybeWrappedButton = props.element;
 
 	return (
 		<AnalysisHeaderContainer>
-			<Button
+			<MaybeWrappedButton
 				aria-expanded={ props.isOpen }
 				onClick={ props.onToggle }
 				icon={ props.isOpen ? angleUp : angleDown }
 				iconColor={ colors.$color_grey_dark } >
 				<AnalysisTitle>{ `${ title } (${ count })` }</AnalysisTitle>
-			</Button>
+			</MaybeWrappedButton>
 			{
-				props.isOpen && props.children
-					? <AnalysisList role="list">{ props.children }</AnalysisList>
-					: null
+				props.isOpen && props.children &&
+					<AnalysisList role="list">{ props.children }</AnalysisList>
 			}
 		</AnalysisHeaderContainer>
 	);
@@ -120,6 +119,7 @@ AnalysisCollapsibleStateless.propTypes = {
 		PropTypes.arrayOf( PropTypes.node ),
 		PropTypes.node,
 	] ),
+	element: PropTypes.func,
 };
 
 AnalysisCollapsibleStateless.defaultProps = {
@@ -141,6 +141,13 @@ export class AnalysisCollapsible extends React.Component {
 		};
 
 		this.toggleOpen = this.toggleOpen.bind( this );
+
+		/*
+		 * Evaluate if the button should be wrapped in a heading in this constructor
+		 * instead of doing it in the AnalysisCollapsibleStateless component to
+		 * avoid a full re-render of the button, which is bad for accessibility.
+		 */
+		this.element = props.hasHeading ? wrapInHeading( AnalysisHeaderButton, props.headingLevel ) : AnalysisHeaderButton;
 	}
 
 	/**
@@ -167,6 +174,7 @@ export class AnalysisCollapsible extends React.Component {
 				isOpen={ this.state.isOpen }
 				hasHeading={ this.props.hasHeading }
 				headingLevel={ this.props.headingLevel }
+				element={ this.element }
 			>
 				{ this.props.children }
 			</AnalysisCollapsibleStateless>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Avoid to fully re-render the collapsible header to improve accessibility

## Relevant technical choices:

* moved the evaluation of the "wrapping" to avoid to run `wrapInHeading()` in the stateless component, which is rendered every time a button gets clicked

## Test instructions

This PR can be tested by following these steps:

- before switching to this branch, go in the Content Analysis tab
- using Safari and VoiceOver, focus one ot the results heading
- using Control-Option-Spacebar, activate the button in the heading
- do it on different headings, multiple times
- observe how the `aria-expanded` change is not announced correctly and there's a focus loss, sometimes it's very evident focus goes on a different element
- switch to this branch
- repeat the steps above
- observe there's no focus loss and the `aria-expanded` change is announced correctly

You can also observe the Chrome inspector and see how the heading gets fully re-rendered before this changes, while in this PR it just gets updated.

Fixes #385 
