### PR TITLE
Add prop to disable and hide marking buttons

### DIFF
--- a/app/ContentAnalysisWrapper.js
+++ b/app/ContentAnalysisWrapper.js
@@ -75,6 +75,7 @@ export default function HelpCenterWrapper() {
 			onMarkButtonClick={ ( id, marker ) => {
 				console.log( "Marker button clicked", id, marker );
 			} }
+			marksButtonStatus={ "enabled" }
 		/>
 	);
 }

--- a/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
@@ -26,10 +26,14 @@ const AnalysisResultText = styled.p`
 	flex: 1 1 auto;
 `;
 
+/**
+ * Determines whether the buttons should be hidden.
+ *
+ * @param {Object} props The component's props.
+ * @returns {boolean} True if buttons should be hidden.
+ */
 let areButtonsHidden = function( props ) {
-	if ( props.marksButtonStatus === "hidden" ) {
-		return true;
-	}
+	return props.marksButtonStatus === "hidden";
 };
 
 /**

--- a/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
@@ -46,6 +46,7 @@ export const AnalysisResult = ( props ) => {
 				props.hasMarksButton &&
 					<IconButtonToggle
 						buttonsDisabled={ props.buttonsDisabled }
+						className={ props.markButtonClassName }
 						onClick={ props.onButtonClick }
 						id={ props.buttonId }
 						icon={ eye }
@@ -66,6 +67,7 @@ AnalysisResult.propTypes = {
 	ariaLabel: PropTypes.string.isRequired,
 	onButtonClick: PropTypes.func.isRequired,
 	buttonsDisabled: PropTypes.bool,
+	markButtonClassName: PropTypes.string,
 };
 
 AnalysisResult.defaultProps = {

--- a/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
@@ -26,6 +26,12 @@ const AnalysisResultText = styled.p`
 	flex: 1 1 auto;
 `;
 
+let areButtonsHidden = function( props ) {
+	if ( props.buttonStatus === "hidden" ) {
+		return true;
+	}
+};
+
 /**
  * Returns an AnalysisResult component.
  *
@@ -43,9 +49,9 @@ export const AnalysisResult = ( props ) => {
 			/>
 			<AnalysisResultText dangerouslySetInnerHTML={ { __html: props.text } } />
 			{
-				props.hasMarksButton && ! props.buttonsHidden &&
+				props.hasMarksButton && ! areButtonsHidden( props ) &&
 					<IconButtonToggle
-						buttonsDisabled={ props.buttonsDisabled }
+						buttonStatus={ props.buttonStatus }
 						className={ props.markButtonClassName }
 						onClick={ props.onButtonClick }
 						id={ props.buttonId }
@@ -66,14 +72,12 @@ AnalysisResult.propTypes = {
 	pressed: PropTypes.bool.isRequired,
 	ariaLabel: PropTypes.string.isRequired,
 	onButtonClick: PropTypes.func.isRequired,
-	buttonsHidden: PropTypes.bool,
-	buttonsDisabled: PropTypes.bool,
+	buttonStatus: PropTypes.string,
 	markButtonClassName: PropTypes.string,
 };
 
 AnalysisResult.defaultProps = {
-	buttonsDisabled: false,
-	buttonsHidden: false,
+	buttonStatus: "enabled",
 };
 
 export default AnalysisResult;

--- a/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
@@ -43,7 +43,7 @@ export const AnalysisResult = ( props ) => {
 			/>
 			<AnalysisResultText dangerouslySetInnerHTML={ { __html: props.text } } />
 			{
-				props.hasMarksButton &&
+				props.hasMarksButton && ! props.buttonsHidden &&
 					<IconButtonToggle
 						buttonsDisabled={ props.buttonsDisabled }
 						className={ props.markButtonClassName }
@@ -66,12 +66,14 @@ AnalysisResult.propTypes = {
 	pressed: PropTypes.bool.isRequired,
 	ariaLabel: PropTypes.string.isRequired,
 	onButtonClick: PropTypes.func.isRequired,
+	buttonsHidden: PropTypes.bool,
 	buttonsDisabled: PropTypes.bool,
 	markButtonClassName: PropTypes.string,
 };
 
 AnalysisResult.defaultProps = {
 	buttonsDisabled: false,
+	buttonsHidden: false,
 };
 
 export default AnalysisResult;

--- a/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
@@ -27,7 +27,7 @@ const AnalysisResultText = styled.p`
 `;
 
 let areButtonsHidden = function( props ) {
-	if ( props.buttonStatus === "hidden" ) {
+	if ( props.marksButtonStatus === "hidden" ) {
 		return true;
 	}
 };
@@ -51,8 +51,8 @@ export const AnalysisResult = ( props ) => {
 			{
 				props.hasMarksButton && ! areButtonsHidden( props ) &&
 					<IconButtonToggle
-						buttonStatus={ props.buttonStatus }
-						className={ props.markButtonClassName }
+						marksButtonStatus={ props.marksButtonStatus }
+						className={ props.marksButtonClassName }
 						onClick={ props.onButtonClick }
 						id={ props.buttonId }
 						icon={ eye }
@@ -72,12 +72,12 @@ AnalysisResult.propTypes = {
 	pressed: PropTypes.bool.isRequired,
 	ariaLabel: PropTypes.string.isRequired,
 	onButtonClick: PropTypes.func.isRequired,
-	buttonStatus: PropTypes.string,
-	markButtonClassName: PropTypes.string,
+	marksButtonStatus: PropTypes.string,
+	marksButtonClassName: PropTypes.string,
 };
 
 AnalysisResult.defaultProps = {
-	buttonStatus: "enabled",
+	marksButtonStatus: "enabled",
 };
 
 export default AnalysisResult;

--- a/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisResult.js
@@ -45,6 +45,7 @@ export const AnalysisResult = ( props ) => {
 			{
 				props.hasMarksButton &&
 					<IconButtonToggle
+						buttonsDisabled={ props.buttonsDisabled }
 						onClick={ props.onButtonClick }
 						id={ props.buttonId }
 						icon={ eye }
@@ -64,6 +65,11 @@ AnalysisResult.propTypes = {
 	pressed: PropTypes.bool.isRequired,
 	ariaLabel: PropTypes.string.isRequired,
 	onButtonClick: PropTypes.func.isRequired,
+	buttonsDisabled: PropTypes.bool,
+};
+
+AnalysisResult.defaultProps = {
+	buttonsDisabled: false,
 };
 
 export default AnalysisResult;

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -142,7 +142,7 @@ class ContentAnalysis extends React.Component {
 			let color = this.getColor( result.rating );
 			let isPressed = result.id === this.state.checked;
 			let ariaLabel = "";
-			if ( this.props.buttonStatus === "disabled" ) {
+			if ( this.props.marksButtonStatus === "disabled" ) {
 				ariaLabel = this.props.intl.formatMessage( messages.disabledButton );
 			} else if ( isPressed ) {
 				ariaLabel = this.props.intl.formatMessage( messages.noHighlight );
@@ -158,8 +158,8 @@ class ContentAnalysis extends React.Component {
 				pressed={ isPressed }
 				buttonId={ result.id }
 				onButtonClick={ this.handleClick.bind( this, result.id, result.marker ) }
-				markButtonClassName={ this.props.markButtonClassName }
-				buttonStatus={ this.props.buttonStatus }
+				marksButtonClassName={ this.props.marksButtonClassName }
+				marksButtonStatus={ this.props.marksButtonStatus }
 			/>;
 		} );
 	}
@@ -283,8 +283,8 @@ ContentAnalysis.propTypes = {
 	language: PropTypes.string.isRequired,
 	showLanguageNotice: PropTypes.bool,
 	headingLevel: PropTypes.number,
-	buttonStatus: PropTypes.string,
-	markButtonClassName: PropTypes.string,
+	marksButtonStatus: PropTypes.string,
+	marksButtonClassName: PropTypes.string,
 	intl: intlShape.isRequired,
 };
 
@@ -298,7 +298,7 @@ ContentAnalysis.defaultProps = {
 	showLanguageNotice: false,
 	canChangeLanguage: false,
 	headingLevel: 4,
-	buttonStatus: "enabled",
+	marksButtonStatus: "enabled",
 };
 
 export default injectIntl( ContentAnalysis );

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -138,17 +138,15 @@ class ContentAnalysis extends React.Component {
 	 * @returns {array} A list of AnalysisResult components.
 	 */
 	getResults( results ) {
-		let defaultAriaLabel = "";
-		if ( this.props.marksButtonStatus === "disabled" ) {
-			defaultAriaLabel = this.props.intl.formatMessage( messages.disabledButton );
-		}
 		return results.map( ( result ) => {
 			let color = this.getColor( result.rating );
 			let isPressed = result.id === this.state.checked;
-			let ariaLabel = defaultAriaLabel;
-			if ( isPressed ) {
+			let ariaLabel = "";
+			if ( this.props.marksButtonStatus === "disabled" ) {
+				ariaLabel = this.props.intl.formatMessage( messages.disabledButton );
+			} else if ( isPressed ) {
 				ariaLabel = this.props.intl.formatMessage( messages.noHighlight );
-			}  else {
+			} else {
 				ariaLabel = this.props.intl.formatMessage( messages.highlight );
 			}
 			return <AnalysisResult

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -138,15 +138,17 @@ class ContentAnalysis extends React.Component {
 	 * @returns {array} A list of AnalysisResult components.
 	 */
 	getResults( results ) {
+		let defaultAriaLabel = "";
+		if ( this.props.marksButtonStatus === "disabled" ) {
+			defaultAriaLabel = this.props.intl.formatMessage( messages.disabledButton );
+		}
 		return results.map( ( result ) => {
 			let color = this.getColor( result.rating );
 			let isPressed = result.id === this.state.checked;
-			let ariaLabel = "";
-			if ( this.props.marksButtonStatus === "disabled" ) {
-				ariaLabel = this.props.intl.formatMessage( messages.disabledButton );
-			} else if ( isPressed ) {
+			let ariaLabel = defaultAriaLabel;
+			if ( isPressed ) {
 				ariaLabel = this.props.intl.formatMessage( messages.noHighlight );
-			} else {
+			}  else {
 				ariaLabel = this.props.intl.formatMessage( messages.highlight );
 			}
 			return <AnalysisResult

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -143,7 +143,7 @@ class ContentAnalysis extends React.Component {
 			let isPressed = result.id === this.state.checked;
 			let ariaLabel = "";
 			if ( this.props.buttonsDisabled ) {
-				ariaLabel = this.props.intl.formatMessage( messages.buttonsDisabled );
+				ariaLabel = this.props.intl.formatMessage( messages.disabledButton );
 			} else if ( ! this.props.buttonsDisabled && isPressed ) {
 				ariaLabel = this.props.intl.formatMessage( messages.noHighlight );
 			} else if ( ! this.props.buttonsDisabled && ! isPressed ) {

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -160,6 +160,7 @@ class ContentAnalysis extends React.Component {
 				onButtonClick={ this.handleClick.bind( this, result.id, result.marker ) }
 				markButtonClassName={ this.props.markButtonClassName }
 				buttonsDisabled={ this.props.buttonsDisabled }
+				buttonsHidden={ this.props.buttonsHidden }
 			/>;
 		} );
 	}
@@ -284,6 +285,7 @@ ContentAnalysis.propTypes = {
 	showLanguageNotice: PropTypes.bool,
 	headingLevel: PropTypes.number,
 	buttonsDisabled: PropTypes.bool,
+	buttonsHidden: PropTypes.bool,
 	markButtonClassName: PropTypes.string,
 	intl: intlShape.isRequired,
 };
@@ -299,6 +301,7 @@ ContentAnalysis.defaultProps = {
 	canChangeLanguage: false,
 	headingLevel: 4,
 	buttonsDisabled: false,
+	buttonsHidden: false,
 };
 
 export default injectIntl( ContentAnalysis );

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -55,6 +55,10 @@ const messages = defineMessages( {
 		id: "content-analysis.highlight",
 		defaultMessage: "Highlight this result in the text",
 	},
+	noHighlight: {
+		id: "content-analysis.nohighlight",
+		defaultMessage: "Remove highlight from the text",
+	},
 } );
 
 /**
@@ -132,15 +136,17 @@ class ContentAnalysis extends React.Component {
 	getResults( results ) {
 		return results.map( ( result ) => {
 			let color = this.getColor( result.rating );
+			let isPressed = result.id === this.state.checked;
 			return <AnalysisResult
 				key={ result.id }
 				text={ result.text }
 				bulletColor={ color }
 				hasMarksButton={ result.hasMarks }
-				ariaLabel={ this.props.intl.formatMessage( messages.highlight ) }
-				pressed={ result.id === this.state.checked }
+				ariaLabel={ isPressed ? this.props.intl.formatMessage( messages.noHighlight ) : this.props.intl.formatMessage( messages.highlight ) }
+				pressed={ isPressed }
 				buttonId={ result.id }
 				onButtonClick={ this.handleClick.bind( this, result.id, result.marker ) }
+				markButtonClassName={ this.props.markButtonClassName }
 				buttonsDisabled={ this.props.buttonsDisabled }
 			/>;
 		} );
@@ -266,6 +272,7 @@ ContentAnalysis.propTypes = {
 	showLanguageNotice: PropTypes.bool,
 	headingLevel: PropTypes.number,
 	buttonsDisabled: PropTypes.bool,
+	markButtonClassName: PropTypes.string,
 	intl: intlShape.isRequired,
 };
 

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -59,6 +59,10 @@ const messages = defineMessages( {
 		id: "content-analysis.nohighlight",
 		defaultMessage: "Remove highlight from the text",
 	},
+	disabledButton: {
+		id: "content-analysis.disabledButton",
+		defaultMessage: "Marks are disabled in current view",
+	},
 } );
 
 /**
@@ -137,12 +141,20 @@ class ContentAnalysis extends React.Component {
 		return results.map( ( result ) => {
 			let color = this.getColor( result.rating );
 			let isPressed = result.id === this.state.checked;
+			let ariaLabel = "";
+			if ( this.props.buttonsDisabled ) {
+				ariaLabel = this.props.intl.formatMessage( messages.buttonsDisabled );
+			} else if ( ! this.props.buttonsDisabled && isPressed ) {
+				ariaLabel = this.props.intl.formatMessage( messages.noHighlight );
+			} else if ( ! this.props.buttonsDisabled && ! isPressed ) {
+				ariaLabel = this.props.intl.formatMessage( messages.highlight );
+			}
 			return <AnalysisResult
 				key={ result.id }
 				text={ result.text }
 				bulletColor={ color }
 				hasMarksButton={ result.hasMarks }
-				ariaLabel={ isPressed ? this.props.intl.formatMessage( messages.noHighlight ) : this.props.intl.formatMessage( messages.highlight ) }
+				ariaLabel={ ariaLabel }
 				pressed={ isPressed }
 				buttonId={ result.id }
 				onButtonClick={ this.handleClick.bind( this, result.id, result.marker ) }

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -144,9 +144,9 @@ class ContentAnalysis extends React.Component {
 			let ariaLabel = "";
 			if ( this.props.buttonsDisabled ) {
 				ariaLabel = this.props.intl.formatMessage( messages.disabledButton );
-			} else if ( ! this.props.buttonsDisabled && isPressed ) {
+			} else if ( isPressed ) {
 				ariaLabel = this.props.intl.formatMessage( messages.noHighlight );
-			} else if ( ! this.props.buttonsDisabled && ! isPressed ) {
+			} else {
 				ariaLabel = this.props.intl.formatMessage( messages.highlight );
 			}
 			return <AnalysisResult

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -141,6 +141,7 @@ class ContentAnalysis extends React.Component {
 				pressed={ result.id === this.state.checked }
 				buttonId={ result.id }
 				onButtonClick={ this.handleClick.bind( this, result.id, result.marker ) }
+				buttonsDisabled={ this.props.buttonsDisabled }
 			/>;
 		} );
 	}
@@ -264,6 +265,7 @@ ContentAnalysis.propTypes = {
 	language: PropTypes.string.isRequired,
 	showLanguageNotice: PropTypes.bool,
 	headingLevel: PropTypes.number,
+	buttonsDisabled: PropTypes.bool,
 	intl: intlShape.isRequired,
 };
 
@@ -277,6 +279,7 @@ ContentAnalysis.defaultProps = {
 	showLanguageNotice: false,
 	canChangeLanguage: false,
 	headingLevel: 4,
+	buttonsDisabled: false,
 };
 
 export default injectIntl( ContentAnalysis );

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -142,7 +142,7 @@ class ContentAnalysis extends React.Component {
 			let color = this.getColor( result.rating );
 			let isPressed = result.id === this.state.checked;
 			let ariaLabel = "";
-			if ( this.props.buttonsDisabled ) {
+			if ( this.props.buttonStatus === "disabled" ) {
 				ariaLabel = this.props.intl.formatMessage( messages.disabledButton );
 			} else if ( isPressed ) {
 				ariaLabel = this.props.intl.formatMessage( messages.noHighlight );
@@ -159,8 +159,7 @@ class ContentAnalysis extends React.Component {
 				buttonId={ result.id }
 				onButtonClick={ this.handleClick.bind( this, result.id, result.marker ) }
 				markButtonClassName={ this.props.markButtonClassName }
-				buttonsDisabled={ this.props.buttonsDisabled }
-				buttonsHidden={ this.props.buttonsHidden }
+				buttonStatus={ this.props.buttonStatus }
 			/>;
 		} );
 	}
@@ -284,8 +283,7 @@ ContentAnalysis.propTypes = {
 	language: PropTypes.string.isRequired,
 	showLanguageNotice: PropTypes.bool,
 	headingLevel: PropTypes.number,
-	buttonsDisabled: PropTypes.bool,
-	buttonsHidden: PropTypes.bool,
+	buttonStatus: PropTypes.string,
 	markButtonClassName: PropTypes.string,
 	intl: intlShape.isRequired,
 };
@@ -300,8 +298,7 @@ ContentAnalysis.defaultProps = {
 	showLanguageNotice: false,
 	canChangeLanguage: false,
 	headingLevel: 4,
-	buttonsDisabled: false,
-	buttonsHidden: false,
+	buttonStatus: "enabled",
 };
 
 export default injectIntl( ContentAnalysis );

--- a/composites/Plugin/ContentAnalysis/tests/AnalysisResultTest.js
+++ b/composites/Plugin/ContentAnalysis/tests/AnalysisResultTest.js
@@ -37,3 +37,22 @@ test( "the AnalysisResult component with html in the text matches the snapshot",
 	let tree = component.toJSON();
 	expect( tree ).toMatchSnapshot();
 } );
+
+test( "the AnalysisResult component with disabled buttons matches the snapshot", () => {
+	const component = createComponentWithIntl(
+		<AnalysisResult
+			ariaLabel="SEOResult"
+			bulletColor="blue"
+			buttonId="Result button"
+			pressed={ true }
+			hasMarksButton={ true }
+			onButtonClick={ () => {} }
+			text={ "You're doing great!" }
+			score="good"
+			buttonsDisabled={ true }
+		/>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );

--- a/composites/Plugin/ContentAnalysis/tests/AnalysisResultTest.js
+++ b/composites/Plugin/ContentAnalysis/tests/AnalysisResultTest.js
@@ -49,7 +49,26 @@ test( "the AnalysisResult component with disabled buttons matches the snapshot",
 			onButtonClick={ () => {} }
 			text={ "You're doing great!" }
 			score="good"
-			buttonsDisabled={ true }
+			marksButtonStatus={ "disabled" }
+		/>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );
+
+test( "the AnalysisResult component with hidden buttons matches the snapshot", () => {
+	const component = createComponentWithIntl(
+		<AnalysisResult
+			ariaLabel="SEOResult"
+			bulletColor="blue"
+			buttonId="Result button"
+			pressed={ true }
+			hasMarksButton={ true }
+			onButtonClick={ () => {} }
+			text={ "You're doing great!" }
+			score="good"
+			marksButtonStatus={ "hidden" }
 		/>
 	);
 

--- a/composites/Plugin/ContentAnalysis/tests/ContentAnalysisTest.js
+++ b/composites/Plugin/ContentAnalysis/tests/ContentAnalysisTest.js
@@ -211,3 +211,22 @@ test( "the ContentAnalysis component with language notice for someone who cannot
 	let tree = component.toJSON();
 	expect( tree ).toMatchSnapshot();
 } );
+
+test( "the ContentAnalysis component with disabled buttons matches the snapshot", () => {
+	const component = createComponentWithIntl(
+		<ContentAnalysis
+			problemsResults={ problemsResults }
+			improvementsResults={ improvementsResults }
+			goodResults={ goodResults }
+			considerationsResults={ considerationsResults }
+			errorsResults={ errorsResults }
+			changeLanguageLink={ "#" }
+			language="English"
+			showLanguageNotice={ true }
+			buttonsDisabled={ true }
+		/>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );

--- a/composites/Plugin/ContentAnalysis/tests/ContentAnalysisTest.js
+++ b/composites/Plugin/ContentAnalysis/tests/ContentAnalysisTest.js
@@ -223,7 +223,26 @@ test( "the ContentAnalysis component with disabled buttons matches the snapshot"
 			changeLanguageLink={ "#" }
 			language="English"
 			showLanguageNotice={ true }
-			buttonsDisabled={ true }
+			marksButtonStatus={ "disabled" }
+		/>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );
+
+test( "the ContentAnalysis component with hidden buttons matches the snapshot", () => {
+	const component = createComponentWithIntl(
+		<ContentAnalysis
+			problemsResults={ problemsResults }
+			improvementsResults={ improvementsResults }
+			goodResults={ goodResults }
+			considerationsResults={ considerationsResults }
+			errorsResults={ errorsResults }
+			changeLanguageLink={ "#" }
+			language="English"
+			showLanguageNotice={ true }
+			marksButtonStatus={ "hidden" }
 		/>
 	);
 

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisResultTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisResultTest.js.snap
@@ -21,7 +21,8 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
   <button
     aria-label="SEOResult"
     aria-pressed={true}
-    className="sc-bdVaJa VNVFd"
+    className="sc-bdVaJa bimAMX"
+    disabled={false}
     id="Result button"
     onClick={[Function]}
     type="button"
@@ -29,6 +30,43 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
     <svg
       aria-hidden="true"
       className="sc-EHOje cEzfCV"
+      focusable="false"
+      role="img"
+    />
+  </button>
+</li>
+`;
+
+exports[`the AnalysisResult component with disabled buttons matches the snapshot 1`] = `
+<li
+  className="sc-bwzfXH kaQsFW"
+>
+  <svg
+    aria-hidden="true"
+    className="sc-htpNat kcPZvN sc-htoDjs hFWmva"
+    focusable="false"
+    role="img"
+  />
+  <p
+    className="sc-bxivhb eBerdq"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "You're doing great!",
+      }
+    }
+  />
+  <button
+    aria-label="SEOResult"
+    aria-pressed={true}
+    className="sc-bdVaJa bimAMX"
+    disabled={true}
+    id="Result button"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="sc-dnqmqq haxLBt"
       focusable="false"
       role="img"
     />
@@ -57,7 +95,8 @@ exports[`the AnalysisResult component with html in the text matches the snapshot
   <button
     aria-label="SEOResult"
     aria-pressed={true}
-    className="sc-bdVaJa VNVFd"
+    className="sc-bdVaJa bimAMX"
+    disabled={false}
     id="Result button"
     onClick={[Function]}
     type="button"

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisResultTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisResultTest.js.snap
@@ -21,7 +21,7 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
   <button
     aria-label="SEOResult"
     aria-pressed={true}
-    className="sc-bdVaJa bimAMX"
+    className="sc-bdVaJa jgsRfK"
     disabled={false}
     id="Result button"
     onClick={[Function]}
@@ -58,7 +58,7 @@ exports[`the AnalysisResult component with disabled buttons matches the snapshot
   <button
     aria-label="SEOResult"
     aria-pressed={true}
-    className="sc-bdVaJa bimAMX"
+    className="sc-bdVaJa jgsRfK"
     disabled={true}
     id="Result button"
     onClick={[Function]}
@@ -95,7 +95,7 @@ exports[`the AnalysisResult component with html in the text matches the snapshot
   <button
     aria-label="SEOResult"
     aria-pressed={true}
-    className="sc-bdVaJa bimAMX"
+    className="sc-bdVaJa jgsRfK"
     disabled={false}
     id="Result button"
     onClick={[Function]}

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisResultTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisResultTest.js.snap
@@ -74,6 +74,27 @@ exports[`the AnalysisResult component with disabled buttons matches the snapshot
 </li>
 `;
 
+exports[`the AnalysisResult component with hidden buttons matches the snapshot 1`] = `
+<li
+  className="sc-bwzfXH kaQsFW"
+>
+  <svg
+    aria-hidden="true"
+    className="sc-htpNat kcPZvN sc-iwsKbI kbxVcT"
+    focusable="false"
+    role="img"
+  />
+  <p
+    className="sc-bxivhb eBerdq"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "You're doing great!",
+      }
+    }
+  />
+</li>
+`;
+
 exports[`the AnalysisResult component with html in the text matches the snapshot 1`] = `
 <li
   className="sc-bwzfXH kaQsFW"

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -1,5 +1,215 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`the ContentAnalysis component with disabled buttons matches the snapshot 1`] = `
+<div
+  className="sc-fjdhpX dMpTuU"
+>
+  <p
+    className="sc-jzJRlG hFCzcu"
+  >
+    <span>
+      Your site language is set to 
+      <strong>
+        English
+      </strong>
+      . If this is not correct, contact your site administrator.
+    </span>
+  </p>
+  <div
+    className="sc-gZMcBi klyNBW"
+  >
+    <h4
+      className="sc-krDsej dGWWNq"
+    >
+      <button
+        aria-expanded={true}
+        className="sc-gqjmRU hBRzYx sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-dTdPqK dHKKhJ sc-itybZL fqEEnC"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Errors (1)
+        </span>
+      </button>
+    </h4>
+    <ul
+      className="sc-jTzLTM fYcrfm"
+      role="list"
+    >
+      <li
+        className="sc-htpNat hLKTNr"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-bxivhb gapdhR sc-eMigcr gZATRT"
+          focusable="false"
+          role="img"
+        />
+        <p
+          className="sc-ifAKCX jLpTt"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Error: Analysis not loaded",
+            }
+          }
+        />
+      </li>
+    </ul>
+  </div>
+  <div
+    className="sc-gZMcBi klyNBW"
+  >
+    <h4
+      className="sc-fzsDOv dDTeCw"
+    >
+      <button
+        aria-expanded={true}
+        className="sc-gqjmRU hBRzYx sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-gPWkxV hDctdB sc-jVODtj kMeGt"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Problems (1)
+        </span>
+      </button>
+    </h4>
+    <ul
+      className="sc-jTzLTM fYcrfm"
+      role="list"
+    >
+      <li
+        className="sc-htpNat hLKTNr"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-bxivhb gapdhR sc-kUaPvJ hahcYd"
+          focusable="false"
+          role="img"
+        />
+        <p
+          className="sc-ifAKCX jLpTt"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Your text is bad, and you should feel bad.",
+            }
+          }
+        />
+        <button
+          aria-label="Highlight this result in the text"
+          aria-pressed={false}
+          className="sc-bwzfXH eUCgZO"
+          disabled={true}
+          id="1"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="sc-giadOv hDSKeU"
+            focusable="false"
+            role="img"
+          />
+        </button>
+      </li>
+    </ul>
+  </div>
+  <div
+    className="sc-gZMcBi klyNBW"
+  >
+    <h4
+      className="sc-fONwsr kmdyEe"
+    >
+      <button
+        aria-expanded={false}
+        className="sc-gqjmRU hBRzYx sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-VJcYb eXDciX sc-ipXKqB fTFIpq"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Improvements (1)
+        </span>
+      </button>
+    </h4>
+  </div>
+  <div
+    className="sc-gZMcBi klyNBW"
+  >
+    <h4
+      className="sc-hmXxxW itxirD"
+    >
+      <button
+        aria-expanded={false}
+        className="sc-gqjmRU hBRzYx sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-cqCuEk ioJFCo sc-dliRfk dzMPgi"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Considerations (1)
+        </span>
+      </button>
+    </h4>
+  </div>
+  <div
+    className="sc-gZMcBi klyNBW"
+  >
+    <h4
+      className="sc-kLIISr castoN"
+    >
+      <button
+        aria-expanded={false}
+        className="sc-gqjmRU hBRzYx sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-qrIAp fmiYgw sc-iqzUVk lmyejJ"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Good (2)
+        </span>
+      </button>
+    </h4>
+  </div>
+</div>
+`;
+
 exports[`the ContentAnalysis component with language notice for someone who can change the language matches the snapshot 1`] = `
 <div
   className="sc-fjdhpX dMpTuU"
@@ -126,7 +336,8 @@ exports[`the ContentAnalysis component with language notice for someone who can 
         <button
           aria-label="Highlight this result in the text"
           aria-pressed={false}
-          className="sc-bwzfXH iSOXYD"
+          className="sc-bwzfXH eUCgZO"
+          disabled={false}
           id="1"
           onClick={[Function]}
           type="button"
@@ -348,7 +559,8 @@ exports[`the ContentAnalysis component with language notice for someone who cann
         <button
           aria-label="Highlight this result in the text"
           aria-pressed={false}
-          className="sc-bwzfXH iSOXYD"
+          className="sc-bwzfXH eUCgZO"
+          disabled={false}
           id="1"
           onClick={[Function]}
           type="button"
@@ -557,7 +769,8 @@ exports[`the ContentAnalysis component with language notice matches the snapshot
         <button
           aria-label="Highlight this result in the text"
           aria-pressed={false}
-          className="sc-bwzfXH iSOXYD"
+          className="sc-bwzfXH eUCgZO"
+          disabled={false}
           id="1"
           onClick={[Function]}
           type="button"
@@ -755,7 +968,8 @@ exports[`the ContentAnalysis component with specified header level matches the s
         <button
           aria-label="Highlight this result in the text"
           aria-pressed={false}
-          className="sc-bwzfXH iSOXYD"
+          className="sc-bwzfXH eUCgZO"
+          disabled={false}
           id="1"
           onClick={[Function]}
           type="button"
@@ -953,7 +1167,8 @@ exports[`the ContentAnalysis component without language notice matches the snaps
         <button
           aria-label="Highlight this result in the text"
           aria-pressed={false}
-          className="sc-bwzfXH iSOXYD"
+          className="sc-bwzfXH eUCgZO"
+          disabled={false}
           id="1"
           onClick={[Function]}
           type="button"
@@ -1588,7 +1803,8 @@ exports[`the ContentAnalysis component without problems, improvements and consid
         <button
           aria-label="Highlight this result in the text"
           aria-pressed={false}
-          className="sc-bwzfXH iSOXYD"
+          className="sc-bwzfXH eUCgZO"
+          disabled={false}
           id="3"
           onClick={[Function]}
           type="button"

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -111,9 +111,9 @@ exports[`the ContentAnalysis component with disabled buttons matches the snapsho
           }
         />
         <button
-          aria-label="Highlight this result in the text"
+          aria-label="Marks are disabled in current view"
           aria-pressed={false}
-          className="sc-bwzfXH eUCgZO"
+          className="sc-bwzfXH dQxpDv"
           disabled={true}
           id="1"
           onClick={[Function]}
@@ -336,7 +336,7 @@ exports[`the ContentAnalysis component with language notice for someone who can 
         <button
           aria-label="Highlight this result in the text"
           aria-pressed={false}
-          className="sc-bwzfXH eUCgZO"
+          className="sc-bwzfXH dQxpDv"
           disabled={false}
           id="1"
           onClick={[Function]}
@@ -559,7 +559,7 @@ exports[`the ContentAnalysis component with language notice for someone who cann
         <button
           aria-label="Highlight this result in the text"
           aria-pressed={false}
-          className="sc-bwzfXH eUCgZO"
+          className="sc-bwzfXH dQxpDv"
           disabled={false}
           id="1"
           onClick={[Function]}
@@ -769,7 +769,7 @@ exports[`the ContentAnalysis component with language notice matches the snapshot
         <button
           aria-label="Highlight this result in the text"
           aria-pressed={false}
-          className="sc-bwzfXH eUCgZO"
+          className="sc-bwzfXH dQxpDv"
           disabled={false}
           id="1"
           onClick={[Function]}
@@ -968,7 +968,7 @@ exports[`the ContentAnalysis component with specified header level matches the s
         <button
           aria-label="Highlight this result in the text"
           aria-pressed={false}
-          className="sc-bwzfXH eUCgZO"
+          className="sc-bwzfXH dQxpDv"
           disabled={false}
           id="1"
           onClick={[Function]}
@@ -1167,7 +1167,7 @@ exports[`the ContentAnalysis component without language notice matches the snaps
         <button
           aria-label="Highlight this result in the text"
           aria-pressed={false}
-          className="sc-bwzfXH eUCgZO"
+          className="sc-bwzfXH dQxpDv"
           disabled={false}
           id="1"
           onClick={[Function]}
@@ -1803,7 +1803,7 @@ exports[`the ContentAnalysis component without problems, improvements and consid
         <button
           aria-label="Highlight this result in the text"
           aria-pressed={false}
-          className="sc-bwzfXH eUCgZO"
+          className="sc-bwzfXH dQxpDv"
           disabled={false}
           id="3"
           onClick={[Function]}

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -210,6 +210,200 @@ exports[`the ContentAnalysis component with disabled buttons matches the snapsho
 </div>
 `;
 
+exports[`the ContentAnalysis component with hidden buttons matches the snapshot 1`] = `
+<div
+  className="sc-fjdhpX dMpTuU"
+>
+  <p
+    className="sc-jzJRlG hFCzcu"
+  >
+    <span>
+      Your site language is set to 
+      <strong>
+        English
+      </strong>
+      . If this is not correct, contact your site administrator.
+    </span>
+  </p>
+  <div
+    className="sc-gZMcBi klyNBW"
+  >
+    <h4
+      className="sc-ipZHIp irmlHr"
+    >
+      <button
+        aria-expanded={true}
+        className="sc-gqjmRU hBRzYx sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-iGrrsa cCfCix sc-bmyXtO fxeFoV"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Errors (1)
+        </span>
+      </button>
+    </h4>
+    <ul
+      className="sc-jTzLTM fYcrfm"
+      role="list"
+    >
+      <li
+        className="sc-htpNat hLKTNr"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-bxivhb gapdhR sc-dEoRIm gSJVGg"
+          focusable="false"
+          role="img"
+        />
+        <p
+          className="sc-ifAKCX jLpTt"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Error: Analysis not loaded",
+            }
+          }
+        />
+      </li>
+    </ul>
+  </div>
+  <div
+    className="sc-gZMcBi klyNBW"
+  >
+    <h4
+      className="sc-jtggT eGicUc"
+    >
+      <button
+        aria-expanded={true}
+        className="sc-gqjmRU hBRzYx sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-ebFjAB bbrMgq sc-jKVCRD jKMreH"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Problems (1)
+        </span>
+      </button>
+    </h4>
+    <ul
+      className="sc-jTzLTM fYcrfm"
+      role="list"
+    >
+      <li
+        className="sc-htpNat hLKTNr"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-bxivhb gapdhR sc-kaNhvL hJbrLb"
+          focusable="false"
+          role="img"
+        />
+        <p
+          className="sc-ifAKCX jLpTt"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Your text is bad, and you should feel bad.",
+            }
+          }
+        />
+      </li>
+    </ul>
+  </div>
+  <div
+    className="sc-gZMcBi klyNBW"
+  >
+    <h4
+      className="sc-LKuAh fbQloi"
+    >
+      <button
+        aria-expanded={false}
+        className="sc-gqjmRU hBRzYx sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-iBEsjs cqtxfr sc-hzNEM jPbHSA"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Improvements (1)
+        </span>
+      </button>
+    </h4>
+  </div>
+  <div
+    className="sc-gZMcBi klyNBW"
+  >
+    <h4
+      className="sc-chbbiW iwpnvD"
+    >
+      <button
+        aria-expanded={false}
+        className="sc-gqjmRU hBRzYx sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-kxynE gImWlb sc-cooIXK kHJwOi"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Considerations (1)
+        </span>
+      </button>
+    </h4>
+  </div>
+  <div
+    className="sc-gZMcBi klyNBW"
+  >
+    <h4
+      className="sc-fcdeBU gsgNmM"
+    >
+      <button
+        aria-expanded={false}
+        className="sc-gqjmRU hBRzYx sc-iwsKbI ljgvpn sc-dnqmqq fzLqCC sc-htoDjs dFKnSN sc-gzVnrw jzmimO sc-bZQynM iYyoWB sc-EHOje cUKXHE"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="sc-gmeYpB kprgmZ sc-kZmsYB eQBtJm"
+          focusable="false"
+          role="img"
+        />
+        <span
+          className="sc-VigVT bGMrIs"
+        >
+          Good (2)
+        </span>
+      </button>
+    </h4>
+  </div>
+</div>
+`;
+
 exports[`the ContentAnalysis component with language notice for someone who can change the language matches the snapshot 1`] = `
 <div
   className="sc-fjdhpX dMpTuU"

--- a/composites/Plugin/Shared/components/IconButtonToggle.js
+++ b/composites/Plugin/Shared/components/IconButtonToggle.js
@@ -31,18 +31,26 @@ const IconButtonBase = styled.button`
 	}
 `;
 
+/**
+ * Determines whether the buttons should be disabled.
+ *
+ * @param {Object} props The component's props.
+ * @returns {boolean} True if the buttons should be disabled.
+ */
 let areButtonsDisabled = function( props ) {
 	if ( props.marksButtonStatus === "disabled" ) {
 		return true;
-	} else if ( props.marksButtonStatus === "enabled" ) {
+	}
+	if ( props.marksButtonStatus === "enabled" ) {
 		return false;
 	}
+	return true;
 };
 
 /**
  * Returns the ChangingIconButton component.
  *
- * @param {object} props Component props.
+ * @param {Object} props Component props.
  *
  * @returns {ReactElement} ChangingIconButton component.
  */

--- a/composites/Plugin/Shared/components/IconButtonToggle.js
+++ b/composites/Plugin/Shared/components/IconButtonToggle.js
@@ -32,9 +32,9 @@ const IconButtonBase = styled.button`
 `;
 
 let areButtonsDisabled = function( props ) {
-	if ( props.buttonStatus === "disabled" ) {
+	if ( props.marksButtonStatus === "disabled" ) {
 		return true;
-	} else if ( props.buttonStatus === "enabled" ) {
+	} else if ( props.marksButtonStatus === "enabled" ) {
 		return false;
 	}
 };
@@ -101,7 +101,7 @@ ChangingIconButton.propTypes = {
 	icon: PropTypes.func.isRequired,
 	pressed: PropTypes.bool.isRequired,
 	hoverBorderColor: PropTypes.string,
-	buttonStatus: PropTypes.string,
+	marksButtonStatus: PropTypes.string,
 	disabledIconColor: PropTypes.string,
 	className: PropTypes.string,
 };
@@ -114,7 +114,7 @@ ChangingIconButton.defaultProps = {
 	pressedIconColor: colors.$color_white,
 	unpressedIconColor: colors.$color_button_text,
 	hoverBorderColor: colors.$color_white,
-	buttonStatus: "enabled",
+	marksButtonStatus: "enabled",
 	disabledIconColor: colors.$color_grey,
 };
 

--- a/composites/Plugin/Shared/components/IconButtonToggle.js
+++ b/composites/Plugin/Shared/components/IconButtonToggle.js
@@ -31,6 +31,14 @@ const IconButtonBase = styled.button`
 	}
 `;
 
+let areButtonsDisabled = function( props ) {
+	if ( props.buttonStatus === "disabled" ) {
+		return true;
+	} else if ( props.buttonStatus === "enabled" ) {
+		return false;
+	}
+};
+
 /**
  * Returns the ChangingIconButton component.
  *
@@ -41,7 +49,7 @@ const IconButtonBase = styled.button`
 const ChangingIconButton = ( props ) => {
 	return (
 		<IconButtonBase
-			disabled={ props.buttonsDisabled }
+			disabled={ areButtonsDisabled( props ) }
 			type="button"
 			onClick={ props.onClick }
 			pressed={ props.pressed }
@@ -52,24 +60,24 @@ const ChangingIconButton = ( props ) => {
 			id={ props.id }
 			aria-label={ props.ariaLabel }
 			aria-pressed={ props.pressed }
-			unpressedIconColor={ props.buttonsDisabled ? props.disabledIconColor : props.unpressedIconColor }
+			unpressedIconColor={ areButtonsDisabled( props ) ? props.disabledIconColor : props.unpressedIconColor }
 			pressedIconColor={ props.pressedIconColor }
 			hoverBorderColor={ props.hoverBorderColor }
 			className={ props.className }
 		>
-			{ props.buttonsDisabled &&
+			{ areButtonsDisabled( props ) &&
 				<Icon
 					icon={ props.icon }
 					color={ props.disabledIconColor }
 					size="18px"/>
 			}
-			{ ! props.pressed && ! props.buttonsDisabled &&
+			{ ! props.pressed && ! areButtonsDisabled( props ) &&
 				<Icon
 					icon={ props.icon }
 					color={ props.unpressedIconColor }
 					size="18px"/>
 			}
-			{ props.pressed && ! props.buttonsDisabled &&
+			{ props.pressed && ! areButtonsDisabled( props ) &&
 				<Icon
 					icon={ props.icon }
 					color={ props.pressedIconColor }
@@ -93,7 +101,7 @@ ChangingIconButton.propTypes = {
 	icon: PropTypes.func.isRequired,
 	pressed: PropTypes.bool.isRequired,
 	hoverBorderColor: PropTypes.string,
-	buttonsDisabled: PropTypes.bool,
+	buttonStatus: PropTypes.string,
 	disabledIconColor: PropTypes.string,
 	className: PropTypes.string,
 };
@@ -106,7 +114,7 @@ ChangingIconButton.defaultProps = {
 	pressedIconColor: colors.$color_white,
 	unpressedIconColor: colors.$color_button_text,
 	hoverBorderColor: colors.$color_white,
-	buttonsDisabled: false,
+	buttonStatus: "enabled",
 	disabledIconColor: colors.$color_grey,
 };
 

--- a/composites/Plugin/Shared/components/IconButtonToggle.js
+++ b/composites/Plugin/Shared/components/IconButtonToggle.js
@@ -38,13 +38,7 @@ const IconButtonBase = styled.button`
  * @returns {boolean} True if the buttons should be disabled.
  */
 let areButtonsDisabled = function( props ) {
-	if ( props.marksButtonStatus === "disabled" ) {
-		return true;
-	}
-	if ( props.marksButtonStatus === "enabled" ) {
-		return false;
-	}
-	return true;
+	return props.marksButtonStatus === "disabled";
 };
 
 /**

--- a/composites/Plugin/Shared/components/IconButtonToggle.js
+++ b/composites/Plugin/Shared/components/IconButtonToggle.js
@@ -21,10 +21,11 @@ const IconButtonBase = styled.button`
 	height: ${ props => props.pressed ? "23px" : "24px" };
 
 	&:hover {
-		border-color: ${ props => props.hoverBorderColor }
+		border-color: ${ props => props.hoverBorderColor };
 	}
 	&:disabled {
-		box-shadow: 0;
+		background-color: ${ props => props.unpressedBackground };
+		box-shadow: none;
 		border: none;
 		cursor: auto;
 	}
@@ -55,7 +56,7 @@ const ChangingIconButton = ( props ) => {
 			pressedIconColor={ props.pressedIconColor }
 			hoverBorderColor={ props.hoverBorderColor }
 		>
-			{ ! props.pressed && props.buttonsDisabled &&
+			{ props.buttonsDisabled &&
 				<Icon
 					icon={ props.icon }
 					color={ props.disabledIconColor }
@@ -67,7 +68,7 @@ const ChangingIconButton = ( props ) => {
 					color={ props.unpressedIconColor }
 					size="18px"/>
 			}
-			{ props.pressed &&
+			{ props.pressed && ! props.buttonsDisabled &&
 				<Icon
 					icon={ props.icon }
 					color={ props.pressedIconColor }

--- a/composites/Plugin/Shared/components/IconButtonToggle.js
+++ b/composites/Plugin/Shared/components/IconButtonToggle.js
@@ -27,7 +27,7 @@ const IconButtonBase = styled.button`
 		background-color: ${ props => props.unpressedBackground };
 		box-shadow: none;
 		border: none;
-		cursor: auto;
+		cursor: default;
 	}
 `;
 
@@ -55,6 +55,7 @@ const ChangingIconButton = ( props ) => {
 			unpressedIconColor={ props.buttonsDisabled ? props.disabledIconColor : props.unpressedIconColor }
 			pressedIconColor={ props.pressedIconColor }
 			hoverBorderColor={ props.hoverBorderColor }
+			className={ props.className }
 		>
 			{ props.buttonsDisabled &&
 				<Icon
@@ -94,6 +95,7 @@ ChangingIconButton.propTypes = {
 	hoverBorderColor: PropTypes.string,
 	buttonsDisabled: PropTypes.bool,
 	disabledIconColor: PropTypes.string,
+	className: PropTypes.string,
 };
 
 ChangingIconButton.defaultProps = {

--- a/composites/Plugin/Shared/components/IconButtonToggle.js
+++ b/composites/Plugin/Shared/components/IconButtonToggle.js
@@ -6,7 +6,7 @@ import colors from "../../../../style-guide/colors.json";
 import { Icon } from "./Icon";
 import { rgba } from "../../../../style-guide/helpers";
 
-const ChangingIconButtonBase = styled.button`
+const IconButtonBase = styled.button`
 	box-sizing: border-box;
 	min-width: 32px;
 	display: inline-block;
@@ -23,6 +23,11 @@ const ChangingIconButtonBase = styled.button`
 	&:hover {
 		border-color: ${ props => props.hoverBorderColor }
 	}
+	&:disabled {
+		box-shadow: 0;
+		border: none;
+		cursor: auto;
+	}
 `;
 
 /**
@@ -34,7 +39,8 @@ const ChangingIconButtonBase = styled.button`
  */
 const ChangingIconButton = ( props ) => {
 	return (
-		<ChangingIconButtonBase
+		<IconButtonBase
+			disabled={ props.buttonsDisabled }
 			type="button"
 			onClick={ props.onClick }
 			pressed={ props.pressed }
@@ -45,21 +51,29 @@ const ChangingIconButton = ( props ) => {
 			id={ props.id }
 			aria-label={ props.ariaLabel }
 			aria-pressed={ props.pressed }
-			unpressedIconColor={ props.unpressedIconColor }
+			unpressedIconColor={ props.buttonsDisabled ? props.disabledIconColor : props.unpressedIconColor }
 			pressedIconColor={ props.pressedIconColor }
 			hoverBorderColor={ props.hoverBorderColor }
 		>
-			{ props.pressed
-				? <Icon
+			{ ! props.pressed && props.buttonsDisabled &&
+				<Icon
 					icon={ props.icon }
-					color={ props.pressedIconColor }
+					color={ props.disabledIconColor }
 					size="18px"/>
-				: <Icon
+			}
+			{ ! props.pressed && ! props.buttonsDisabled &&
+				<Icon
 					icon={ props.icon }
 					color={ props.unpressedIconColor }
 					size="18px"/>
 			}
-		</ChangingIconButtonBase>
+			{ props.pressed &&
+				<Icon
+					icon={ props.icon }
+					color={ props.pressedIconColor }
+					size="18px"/>
+			}
+		</IconButtonBase>
 	);
 };
 
@@ -77,6 +91,8 @@ ChangingIconButton.propTypes = {
 	icon: PropTypes.func.isRequired,
 	pressed: PropTypes.bool.isRequired,
 	hoverBorderColor: PropTypes.string,
+	buttonsDisabled: PropTypes.bool,
+	disabledIconColor: PropTypes.string,
 };
 
 ChangingIconButton.defaultProps = {
@@ -87,6 +103,8 @@ ChangingIconButton.defaultProps = {
 	pressedIconColor: colors.$color_white,
 	unpressedIconColor: colors.$color_button_text,
 	hoverBorderColor: colors.$color_white,
+	buttonsDisabled: false,
+	disabledIconColor: colors.$color_grey,
 };
 
 export default ChangingIconButton;

--- a/composites/Plugin/Shared/tests/IconButtonToggleTest.js
+++ b/composites/Plugin/Shared/tests/IconButtonToggleTest.js
@@ -6,7 +6,13 @@ import eye from "../../../../style-guide/svg/eye.svg";
 
 test( "the unpressed IconButtonToggle matches the snapshot", () => {
 	const component = renderer.create(
-		<IconButtonToggle name="group1" id="RadioButton" ariaLabel="important toggle" icon={ eye } pressed={ false } onClick={ () => {} }/>
+		<IconButtonToggle
+			name="group1"
+			id="RadioButton"
+			ariaLabel="important toggle"
+			icon={ eye }
+			pressed={ false }
+			onClick={ () => {} }/>
 	);
 
 	let tree = component.toJSON();
@@ -15,7 +21,29 @@ test( "the unpressed IconButtonToggle matches the snapshot", () => {
 
 test( "the pressed IconButtonToggle matches the snapshot", () => {
 	const component = renderer.create(
-		<IconButtonToggle name="group1" id="RadioButton2" ariaLabel="important toggle" icon={ eye } pressed={ true } onClick={ () => {} }/>
+		<IconButtonToggle
+			name="group1"
+			id="RadioButton2"
+			ariaLabel="important toggle"
+			icon={ eye }
+			pressed={ true }
+			onClick={ () => {} }/>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );
+
+test( "the disabled IconButtonToggle matches the snapshot", () => {
+	const component = renderer.create(
+		<IconButtonToggle
+			name="group1"
+			id="RadioButton2"
+			ariaLabel="important toggle"
+			icon={ eye }
+			pressed={ false }
+			onClick={ () => {} }
+			buttonsDisabled={ true }/>
 	);
 
 	let tree = component.toJSON();

--- a/composites/Plugin/Shared/tests/IconButtonToggleTest.js
+++ b/composites/Plugin/Shared/tests/IconButtonToggleTest.js
@@ -43,7 +43,7 @@ test( "the disabled IconButtonToggle matches the snapshot", () => {
 			icon={ eye }
 			pressed={ false }
 			onClick={ () => {} }
-			buttonsDisabled={ true }/>
+			marksButtonStatus={ "disabled" }/>
 	);
 
 	let tree = component.toJSON();

--- a/composites/Plugin/Shared/tests/__snapshots__/IconButtonToggleTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/IconButtonToggleTest.js.snap
@@ -1,10 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`the disabled IconButtonToggle matches the snapshot 1`] = `
+<button
+  aria-label="important toggle"
+  aria-pressed={false}
+  className="sc-bdVaJa gwTboi"
+  disabled={true}
+  id="RadioButton2"
+  onClick={[Function]}
+  type="button"
+>
+  <svg
+    aria-hidden="true"
+    className="sc-bxivhb kWWPTV"
+    focusable="false"
+    role="img"
+  />
+</button>
+`;
+
 exports[`the pressed IconButtonToggle matches the snapshot 1`] = `
 <button
   aria-label="important toggle"
   aria-pressed={true}
-  className="sc-bdVaJa VNVFd"
+  className="sc-bdVaJa bimAMX"
+  disabled={false}
   id="RadioButton2"
   onClick={[Function]}
   type="button"
@@ -22,7 +42,8 @@ exports[`the unpressed IconButtonToggle matches the snapshot 1`] = `
 <button
   aria-label="important toggle"
   aria-pressed={false}
-  className="sc-bdVaJa inADYO"
+  className="sc-bdVaJa gwTboi"
+  disabled={false}
   id="RadioButton"
   onClick={[Function]}
   type="button"

--- a/composites/Plugin/Shared/tests/__snapshots__/IconButtonToggleTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/IconButtonToggleTest.js.snap
@@ -4,7 +4,7 @@ exports[`the disabled IconButtonToggle matches the snapshot 1`] = `
 <button
   aria-label="important toggle"
   aria-pressed={false}
-  className="sc-bdVaJa gwTboi"
+  className="sc-bdVaJa chrcxo"
   disabled={true}
   id="RadioButton2"
   onClick={[Function]}
@@ -23,7 +23,7 @@ exports[`the pressed IconButtonToggle matches the snapshot 1`] = `
 <button
   aria-label="important toggle"
   aria-pressed={true}
-  className="sc-bdVaJa bimAMX"
+  className="sc-bdVaJa jgsRfK"
   disabled={false}
   id="RadioButton2"
   onClick={[Function]}
@@ -42,7 +42,7 @@ exports[`the unpressed IconButtonToggle matches the snapshot 1`] = `
 <button
   aria-label="important toggle"
   aria-pressed={false}
-  className="sc-bdVaJa gwTboi"
+  className="sc-bdVaJa chrcxo"
   disabled={false}
   id="RadioButton"
   onClick={[Function]}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "pinVersions": false,
+  "dependencies": {
+    "pinVersions": false
+  },
+  "timezone": "Europe/Amsterdam",
+  "schedule": ["after 10pm and before 5am on every weekday", "every weekend"],
+  "updateNotScheduled": false
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added a prop to the `ContentAnalysis` to disable or hide the eye buttons.

## Relevant technical choices:

* I've reset the cursor to `default` rather than `pointer` on hovering a disabled button. This is consistent with what WP is doing. 
* I've changed the icon color of the disabled button to #ddd ($color_grey) instead of #e6e6e6 (which is not in the colors.json). #ddd is a little darker, but the background is darker as well,
 because now there is a button background instead of the white meta box background. The color contrast is 1.27 instead of 1.25 🎉 .
* The design of the disabled button has been approved by @hedgefield.


## Test instructions

This PR can be tested by following these steps:

* Check out this branch.
* `yarn install`,`yarn start`
* Go to `localhost:3333`
* Change the marksButtonStatus in `app/ContentAnalysisWrapper.js` to 'hidden' and 'disabled' and check whether the buttons are hidden or disabled.

Part of the fix for https://github.com/Yoast/wordpress-seo/issues/8442
Fixes #408 
