### PR TITLE
Tweak kb search input field.

### DIFF
--- a/composites/AlgoliaSearch/SearchBar.js
+++ b/composites/AlgoliaSearch/SearchBar.js
@@ -5,19 +5,17 @@ import { intlShape, injectIntl, defineMessages } from "react-intl";
 import debounce from "lodash/debounce";
 
 import colors from "../../style-guide/colors.json";
-import SearchIcon from "../../style-guide/svg/search.svg";
-import { Icon } from "../Plugin/Shared/components/Icon";
 import { YoastButton } from "../Plugin/Shared/components/YoastButton";
 import breakpoints from "../../style-guide/responsive-breakpoints.json";
 
 const messages = defineMessages( {
 	headingText: {
 		id: "searchBar.headingText",
-		defaultMessage: "Search the Yoast knowledge base",
+		defaultMessage: "Search the Yoast Knowledge Base for answers to your questions:",
 	},
 	placeholderText: {
 		id: "searchBar.placeholderText",
-		defaultMessage: "Search the knowledge base",
+		defaultMessage: "Type here to search...",
 	},
 	buttonText: {
 		id: "searchBar.buttonText",
@@ -26,13 +24,9 @@ const messages = defineMessages( {
 } );
 
 const SearchBarWrapper = styled.div`
-
 	form {
 		display: flex;
-
-		@media screen and ( max-width: ${ breakpoints.mobile } ) {
-			flex-wrap: wrap;
-		}
+		flex-wrap: wrap;
 	}
 
 	@media screen and ( max-width: ${ breakpoints.mobile } ) {
@@ -43,25 +37,11 @@ const SearchBarWrapper = styled.div`
 	}
 `;
 
-const SearchHeading = styled.h2`
-	// !important to override WP rules.
-	font-size: 1em !important;
-	margin: 0.5em 0 0.5em 58px !important;
-	padding: 0 !important;
-	font-weight: 600 !important;
-
-	@media screen and ( max-width: ${ breakpoints.mobile } ) {
-		margin-left: 0;
-	}
-`;
-
 const SearchLabel = styled.label`
-	flex: 0 0 42px;
-	height: 48px;
-	// This label is already a flex item to be aligned with its siblings.
-	// By making it also a flex container, we can align the SVG icon.
-	display: inline-flex;
-	align-items: center;
+	flex: 0 1 100%;
+	font-size: 1em;
+	margin: 0.5em 16px;
+	font-weight: 600;
 `;
 
 const SearchBarInput = styled.input`
@@ -75,7 +55,7 @@ const SearchBarInput = styled.input`
 		border: 1px solid transparent;
 		font-size: 1em;
 		margin-right: 24px;
-		padding: 0 8px 0 16px;
+		padding: 0 8px 0 15px; // 15 + border 1 = 16 for the 8px grid
 
 		:focus {
 			box-shadow:
@@ -175,15 +155,9 @@ class SearchBar extends React.Component {
 
 		return (
 			<SearchBarWrapper role="search">
-				<SearchHeading>
-					{ headingText }
-				</SearchHeading>
 				<form onSubmit={ this.onSubmit.bind( this ) }>
 					<SearchLabel htmlFor="kb-search-input">
-						<Icon icon={ SearchIcon } color="inherit" size="30px" />
-						<span className="screen-reader-text">
-							{ headingText }
-						</span>
+						{ headingText }
 					</SearchLabel>
 					<SearchBarInput
 						onChange={ this.onSearchChange.bind( this ) }
@@ -193,7 +167,7 @@ class SearchBar extends React.Component {
 						defaultValue={ this.props.searchString }
 						autoComplete="off"
 						autoCorrect="off"
-						autoCapitalize="off"
+						autoCapitalize="none"
 						spellCheck="false"
 						placeholder={ placeholderText }
 					/>

--- a/composites/AlgoliaSearch/tests/__snapshots__/AlgoliaSearcherTest.js.snap
+++ b/composites/AlgoliaSearch/tests/__snapshots__/AlgoliaSearcherTest.js.snap
@@ -2,46 +2,31 @@
 
 exports[`the AlgoliaSearcher component with headingText matches the snapshot 1`] = `
 <div
-  className="sc-kgoBCf YQFzU"
+  className="sc-chPdSV fIOnWM"
 >
   <div
-    className="sc-htpNat jAVOHt"
+    className="sc-htpNat bSxwhS"
     role="search"
   >
-    <h2
-      className="sc-bxivhb fMWLJS"
-    >
-      Search the Yoast knowledge base
-    </h2>
     <form
       onSubmit={[Function]}
     >
       <label
-        className="sc-ifAKCX jpZkXH"
+        className="sc-bxivhb zWKWj"
         htmlFor="kb-search-input"
       >
-        <svg
-          aria-hidden="true"
-          className="sc-kGXeez fIgStx"
-          focusable="false"
-          role="img"
-        />
-        <span
-          className="screen-reader-text"
-        >
-          Search the Yoast knowledge base
-        </span>
+        Search the Yoast Knowledge Base for answers to your questions:
       </label>
       <input
-        autoCapitalize="off"
+        autoCapitalize="none"
         autoComplete="off"
         autoCorrect="off"
-        className="sc-EHOje hhGWKG"
+        className="sc-ifAKCX bLGUaF"
         defaultValue=""
         id="kb-search-input"
         name="search-input"
         onChange={[Function]}
-        placeholder="Search the knowledge base"
+        placeholder="Type here to search..."
         spellCheck="false"
         type="text"
       />

--- a/composites/AlgoliaSearch/tests/__snapshots__/SearchBarTest.js.snap
+++ b/composites/AlgoliaSearch/tests/__snapshots__/SearchBarTest.js.snap
@@ -2,43 +2,28 @@
 
 exports[`the SearchBar component with headingText matches the snapshot 1`] = `
 <div
-  className="sc-htpNat jAVOHt"
+  className="sc-htpNat bSxwhS"
   role="search"
 >
-  <h2
-    className="sc-bxivhb fMWLJS"
-  >
-    Search the Yoast knowledge base
-  </h2>
   <form
     onSubmit={[Function]}
   >
     <label
-      className="sc-ifAKCX jpZkXH"
+      className="sc-bxivhb zWKWj"
       htmlFor="kb-search-input"
     >
-      <svg
-        aria-hidden="true"
-        className="sc-bZQynM iEGQbI"
-        focusable="false"
-        role="img"
-      />
-      <span
-        className="screen-reader-text"
-      >
-        Search the Yoast knowledge base
-      </span>
+      Search the Yoast Knowledge Base for answers to your questions:
     </label>
     <input
-      autoCapitalize="off"
+      autoCapitalize="none"
       autoComplete="off"
       autoCorrect="off"
-      className="sc-EHOje hhGWKG"
+      className="sc-ifAKCX bLGUaF"
       defaultValue=""
       id="kb-search-input"
       name="search-input"
       onChange={[Function]}
-      placeholder="Search the knowledge base"
+      placeholder="Type here to search..."
       spellCheck="false"
       type="text"
     />
@@ -58,43 +43,28 @@ exports[`the SearchBar component with headingText matches the snapshot 1`] = `
 
 exports[`the SearchBar component without headingText matches the snapshot 1`] = `
 <div
-  className="sc-htpNat jAVOHt"
+  className="sc-htpNat bSxwhS"
   role="search"
 >
-  <h2
-    className="sc-bxivhb fMWLJS"
-  >
-    Search the Yoast knowledge base
-  </h2>
   <form
     onSubmit={[Function]}
   >
     <label
-      className="sc-ifAKCX jpZkXH"
+      className="sc-bxivhb zWKWj"
       htmlFor="kb-search-input"
     >
-      <svg
-        aria-hidden="true"
-        className="sc-gzVnrw hnODFy"
-        focusable="false"
-        role="img"
-      />
-      <span
-        className="screen-reader-text"
-      >
-        Search the Yoast knowledge base
-      </span>
+      Search the Yoast Knowledge Base for answers to your questions:
     </label>
     <input
-      autoCapitalize="off"
+      autoCapitalize="none"
       autoComplete="off"
       autoCorrect="off"
-      className="sc-EHOje hhGWKG"
+      className="sc-ifAKCX bLGUaF"
       defaultValue=""
       id="kb-search-input"
       name="search-input"
       onChange={[Function]}
-      placeholder="Search the knowledge base"
+      placeholder="Type here to search..."
       spellCheck="false"
       type="text"
     />


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Updated Knowledge Base search input field and labels.

## Relevant technical choices:

Worth noting I'm updating the value of the `autocapitalize` attribute, since `off` is deprecated and `none` is the one to use today: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input

## Test instructions

* for the standalone version, just `yarn start` and go on http://localhost:3333/
* for the plugin, yarn link or use this branch in your package.json, switch the plugin to the `stories/410-kb-search-bar-tweaks` branch see https://github.com/Yoast/wordpress-seo/pull/8484 and build the JS

Screenshots:

![screen shot 2017-12-13 at 11 19 48](https://user-images.githubusercontent.com/1682452/33934620-bc39ba50-dff9-11e7-9f02-6acedfb75e6d.png)

![screen shot 2017-12-13 at 11 23 14](https://user-images.githubusercontent.com/1682452/33934621-bc595a90-dff9-11e7-960f-7958e115ef31.png)


Fixes #410 
