### PR TITLE
Update good results heading default message.

### DIFF
--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -49,7 +49,7 @@ const messages = defineMessages( {
 	},
 	goodHeader: {
 		id: "content-analysis.good",
-		defaultMessage: "Good",
+		defaultMessage: "Good results",
 	},
 	highlight: {
 		id: "content-analysis.highlight",

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -202,7 +202,7 @@ exports[`the ContentAnalysis component with disabled buttons matches the snapsho
         <span
           className="sc-VigVT bGMrIs"
         >
-          Good (2)
+          Good results (2)
         </span>
       </button>
     </h4>
@@ -396,7 +396,7 @@ exports[`the ContentAnalysis component with hidden buttons matches the snapshot 
         <span
           className="sc-VigVT bGMrIs"
         >
-          Good (2)
+          Good results (2)
         </span>
       </button>
     </h4>
@@ -619,7 +619,7 @@ exports[`the ContentAnalysis component with language notice for someone who can 
         <span
           className="sc-VigVT bGMrIs"
         >
-          Good (2)
+          Good results (2)
         </span>
       </button>
     </h4>
@@ -842,7 +842,7 @@ exports[`the ContentAnalysis component with language notice for someone who cann
         <span
           className="sc-VigVT bGMrIs"
         >
-          Good (2)
+          Good results (2)
         </span>
       </button>
     </h4>
@@ -1052,7 +1052,7 @@ exports[`the ContentAnalysis component with language notice matches the snapshot
         <span
           className="sc-VigVT bGMrIs"
         >
-          Good (2)
+          Good results (2)
         </span>
       </button>
     </h4>
@@ -1251,7 +1251,7 @@ exports[`the ContentAnalysis component with specified header level matches the s
         <span
           className="sc-VigVT bGMrIs"
         >
-          Good (2)
+          Good results (2)
         </span>
       </button>
     </h3>
@@ -1450,7 +1450,7 @@ exports[`the ContentAnalysis component without language notice matches the snaps
         <span
           className="sc-VigVT bGMrIs"
         >
-          Good (2)
+          Good results (2)
         </span>
       </button>
     </h4>
@@ -1581,7 +1581,7 @@ exports[`the ContentAnalysis component without problems and considerations, but 
         <span
           className="sc-VigVT bGMrIs"
         >
-          Good (2)
+          Good results (2)
         </span>
       </button>
     </h4>
@@ -1712,7 +1712,7 @@ exports[`the ContentAnalysis component without problems and improvements matches
         <span
           className="sc-VigVT bGMrIs"
         >
-          Good (2)
+          Good results (2)
         </span>
       </button>
     </h4>
@@ -1869,7 +1869,7 @@ exports[`the ContentAnalysis component without problems matches the snapshot 1`]
         <span
           className="sc-VigVT bGMrIs"
         >
-          Good (2)
+          Good results (2)
         </span>
       </button>
     </h4>
@@ -1951,7 +1951,7 @@ exports[`the ContentAnalysis component without problems, improvements and consid
         <span
           className="sc-VigVT bGMrIs"
         >
-          Good (2)
+          Good results (2)
         </span>
       </button>
     </h4>


### PR DESCRIPTION
## Summary

Updates the default message for the "Good" assessments heading.

**Make sure this PR is released and updated in wordpress-seo before the 6.3 RC.**

Fixes https://github.com/Yoast/wordpress-seo/issues/8532
