### PR TITLE
Make react-intl peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ import 'Input' from 'yoast-components/forms/Input'
 
 Components that are translated using `react-intl` require that you wrap your application in `react-intl`'s `IntlProvider`.
 
+See [the documentation](https://github.com/yahoo/react-intl) for more information.
+
 ### Webpack
 
 If you use `yoast-components` within your own project we recommend using `webpack` with the following loaders and configuration:

--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ import 'Input' from 'yoast-components/forms/Input'
 
 ## Requirements
 
-If you use `yoast-components` within your own project we recommend using `webpack` with the following loaders and configuration:
+### React intl
 
-### Webpack loaders
+Components that are translated using `react-intl` require that you wrap your application in `react-intl`'s `IntlProvider`.
+
+### Webpack
+
+If you use `yoast-components` within your own project we recommend using `webpack` with the following loaders and configuration:
 
 * Babel-loader
   * Presets: es2015 and react

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "jed": "^1.1.1",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
-    "react-intl": "^2.4.0",
     "react-redux": "^5.0.6",
     "react-tabs": "^2.2.1",
     "redux": "^3.7.2",
@@ -80,6 +79,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-hot-loader": "^4.0.0-beta.17",
+    "react-intl": "^2.4.0",
     "react-tap-event-plugin": "^3.0.2",
     "react-test-renderer": "^16.2.0",
     "redux-devtools": "^3.4.1",
@@ -97,7 +97,8 @@
   "peerDependencies": {
     "material-ui": "^0.18.6",
     "react": "^16.2.0",
-    "react-dom": "16.2.0"
+    "react-dom": "16.2.0",
+    "react-intl": "^2.4.0"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Made `react-intl` a peer dependency, and updated the documentation to inform users they should implement `react-intl`'s `IntlProvider` to use `yoast-components`.

## Test instructions

This PR can be tested by following these steps:

*

Fixes #
