### PR TITLE
Use func proptype for icons

### DIFF
--- a/composites/OnboardingWizard/Header.js
+++ b/composites/OnboardingWizard/Header.js
@@ -22,7 +22,7 @@ const Header = ( props ) => {
 };
 
 Header.propTypes = {
-	icon: PropTypes.string,
+	icon: PropTypes.oneOfType([ PropTypes.func, PropTypes.string ]),
 	headerTitle: PropTypes.string,
 };
 

--- a/composites/OnboardingWizard/Header.js
+++ b/composites/OnboardingWizard/Header.js
@@ -22,7 +22,7 @@ const Header = ( props ) => {
 };
 
 Header.propTypes = {
-	icon: PropTypes.oneOfType([ PropTypes.func, PropTypes.string ]),
+	icon: PropTypes.oneOfType( [ PropTypes.func, PropTypes.string ] ),
 	headerTitle: PropTypes.string,
 };
 

--- a/composites/OnboardingWizard/Header.js
+++ b/composites/OnboardingWizard/Header.js
@@ -22,7 +22,7 @@ const Header = ( props ) => {
 };
 
 Header.propTypes = {
-	icon: PropTypes.oneOfType( [ PropTypes.func, PropTypes.string ] ),
+	icon: PropTypes.func,
 	headerTitle: PropTypes.string,
 };
 

--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -346,7 +346,7 @@ OnboardingWizard.propTypes = {
 	customComponents: PropTypes.object,
 	finishUrl: PropTypes.string,
 	translate: PropTypes.any,
-	headerIcon: PropTypes.string,
+	headerIcon: PropTypes.oneOfType([ PropTypes.func, PropTypes.string ]),
 };
 
 OnboardingWizard.defaultProps = {

--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -346,7 +346,7 @@ OnboardingWizard.propTypes = {
 	customComponents: PropTypes.object,
 	finishUrl: PropTypes.string,
 	translate: PropTypes.any,
-	headerIcon: PropTypes.oneOfType([ PropTypes.func, PropTypes.string ]),
+	headerIcon: PropTypes.oneOfType( [ PropTypes.func, PropTypes.string ] ),
 };
 
 OnboardingWizard.defaultProps = {

--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -346,7 +346,7 @@ OnboardingWizard.propTypes = {
 	customComponents: PropTypes.object,
 	finishUrl: PropTypes.string,
 	translate: PropTypes.any,
-	headerIcon: PropTypes.oneOfType( [ PropTypes.func, PropTypes.string ] ),
+	headerIcon: PropTypes.func,
 };
 
 OnboardingWizard.defaultProps = {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a console warning is given if an function is given as icon.


## Test instructions

This PR can be tested by following these steps:

* You can best test this against: https://github.com/Yoast/wordpress-seo/pull/9171

Fixes #438
