### PR TITLE
Configure label-has-for eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,8 +5,8 @@ parser: babel-eslint
 rules:
   complexity: [1, 6]
   // A wrapping label is not necessary when there already is an htmlFor attribute.
-  'jsx-a11y/label-has-for': [ 'error', {
-    required: 'id',
+  'jsx-a11y/label-has-for': [ "error", {
+    required: "id",
   } ]
 
 env:

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,9 +5,7 @@ parser: babel-eslint
 rules:
   complexity: [1, 6]
   // A wrapping label is not necessary when there already is an htmlFor attribute.
-  'jsx-a11y/label-has-for': [ "error", {
-    required: "id",
-  } ]
+  'jsx-a11y/label-has-for': [ "error", { required: "id" } ]
 
 env:
   jest: true

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,10 @@ parser: babel-eslint
 
 rules:
   complexity: [1, 6]
+  // A wrapping label is not necessary when there already is an htmlFor attribute.
+  'jsx-a11y/label-has-for': [ 'error', {
+    required: 'id',
+  } ]
 
 env:
   jest: true

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@ parser: babel-eslint
 rules:
   complexity: [1, 6]
   // A wrapping label is not necessary when there already is an htmlFor attribute.
-  'jsx-a11y/label-has-for': [ "error", { required: "id" } ]
+  jsx-a11y/label-has-for: [ "error", { required: "id" } ]
 
 env:
   jest: true

--- a/composites/Plugin/Shared/components/A11yNotice.js
+++ b/composites/Plugin/Shared/components/A11yNotice.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-/**
+/*
  * A span tag invisible to the user, but not to screen readers.
  *
  * If you need a different element then a span, you can use styled-component's .withComponent function.

--- a/composites/Plugin/Shared/components/Checkbox.js
+++ b/composites/Plugin/Shared/components/Checkbox.js
@@ -41,11 +41,6 @@ class Checkbox extends React.Component {
 	 * @returns {ReactElement} The Checkbox react component including its label.
 	 */
 	render() {
-		/*
- 		 * The jsx-a11y plugin doesn't see we actually use htmlFor because we render
-		 * the label without the associated input element.
- 		 */
-		/* eslint-disable jsx-a11y/label-has-for */
 		return(
 			<React.Fragment>
 				<YoastCheckbox type="checkbox" id={ this.props.id } onChange={ this.handleChange.bind( this ) } />
@@ -54,7 +49,6 @@ class Checkbox extends React.Component {
 				</label>
 			</React.Fragment>
 		);
-		/* eslint-enable jsx-a11y/label-has-for */
 	}
 }
 

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -470,9 +470,9 @@ export default class SnippetPreview extends Component {
 		const Url = this.addCaretStyles( "url", BaseUrl );
 
 		/*
-		* The jsx-a11y eslint plugin is asking for an onFocus accompanying the onMouseOver.
-		* However this is not relevant in this case, because the url is not focusable.
-		*/
+		 * The jsx-a11y eslint plugin is asking for an onFocus accompanying the onMouseOver.
+		 * However this is not relevant in this case, because the url is not focusable.
+		 */
 		/* eslint-disable jsx-a11y/mouse-events-have-key-events */
 		return <Url onClick={ onClick.bind( null, "url" ) }
 		            onMouseOver={ partial( onMouseOver, "url" ) }
@@ -548,10 +548,10 @@ export default class SnippetPreview extends Component {
 		const renderedDate = this.renderDate();
 
 		/*
-		* The jsx-a11y eslint plugin is asking for an onFocus accompanying the onMouseOver.
-		* However this is not relevant in this case, because the title and description are
-		* not focusable.
-		*/
+		 * The jsx-a11y eslint plugin is asking for an onFocus accompanying the onMouseOver.
+		 * However this is not relevant in this case, because the title and description are
+		 * not focusable.
+		 */
 		/* eslint-disable jsx-a11y/mouse-events-have-key-events */
 		return (
 			<section>

--- a/forms/Label.js
+++ b/forms/Label.js
@@ -9,15 +9,9 @@ import PropTypes from "prop-types";
  * @constructor
  */
 const Label = ( props ) => {
-	/*
-	 * The jsx-a11y plugin doesn't see we actually use htmlFor because we render
-	 * the label without the associated input element.
-	 */
-	/* eslint-disable jsx-a11y/label-has-for */
 	return (
 		<label htmlFor={props.for} {...props.optionalAttributes}>{props.children}</label>
 	);
-	/* eslint-enable jsx-a11y/label-has-for */
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds the jsx-a11y eslint plugin. 


(The actual adding of the eslint plugin was done in a PR that was accidentally pushed to develop)

## Relevant technical choices:

*   A wrapping label is not necessary when there already is an htmlFor attribute. Therefore, only the id/htmlFor is required. This has been discussed with @afercia.

## Test instructions

This PR can be tested by following these steps:

* Run `grunt eslint` and see there are no eslint errors from jsx-a11y.