### PR TITLE
Move svgIcon warning test and use mock

### DIFF
--- a/composites/Plugin/Shared/tests/SvgIconTest.js
+++ b/composites/Plugin/Shared/tests/SvgIconTest.js
@@ -14,7 +14,7 @@ test( "the SvgIcon matches the snapshot", () => {
 
 test( "throws a warning when a non-existing icon is passed", () => {
 	console.warn = jest.fn();
-	const component = renderer.create(
+	renderer.create(
 		<SvgIcon icon="fake-icon" color="black" size="32px" className="my-icon" />
 	);
 

--- a/composites/Plugin/Shared/tests/SvgIconTest.js
+++ b/composites/Plugin/Shared/tests/SvgIconTest.js
@@ -11,3 +11,12 @@ test( "the SvgIcon matches the snapshot", () => {
 	let tree = component.toJSON();
 	expect( tree ).toMatchSnapshot();
 } );
+
+test( "throws a warning when a non-existing icon is passed", () => {
+	console.warn = jest.fn();
+	const component = renderer.create(
+		<SvgIcon icon="fake-icon" color="black" size="32px" className="my-icon" />
+	);
+
+	expect( console.warn ).toHaveBeenCalledTimes( 1 );
+} );

--- a/forms/StyledSection/tests/__snapshots__/styledSectionTest.js.snap
+++ b/forms/StyledSection/tests/__snapshots__/styledSectionTest.js.snap
@@ -1136,61 +1136,6 @@ exports[`StyledSection can change the icon to times 1`] = `
 </section>
 `;
 
-exports[`StyledSection can not add an non-existing icon 1`] = `
-.c0 {
-  box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
-  background-color: #fff;
-  padding: 0 20px 16px;
-}
-
-.c0 *,
-.c0 {
-  box-sizing: border-box;
-}
-
-.c0 *:before,
-.c0:before,
-.c0 *:after,
-.c0:after {
-  box-sizing: border-box;
-}
-
-.c0 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  padding: 8px 0 0;
-  font-size: 1rem;
-  line-height: 1.5;
-  margin: 0 0 16px;
-  font-family: "Open Sans",sans-serif;
-  font-weight: 300;
-  color: red;
-}
-
-.c0 .StyledSection__StyledIcon-ebXrFH {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  margin-right: 8px;
-}
-
-<section
-  className="yoast-section c0"
->
-  <h2
-    className="c1 "
-  >
-    Insights. Hello, this is a Styled Section heading.
-  </h2>
-</section>
-`;
-
 exports[`StyledSection have a red icon 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );

--- a/forms/StyledSection/tests/styledSectionTest.js
+++ b/forms/StyledSection/tests/styledSectionTest.js
@@ -49,24 +49,6 @@ describe( "StyledSection", () => {
 		expect( tree.children[ 0 ].type ).toBe( "h4" );
 	} );
 
-	test( "can not add an non-existing icon", () => {
-		const component = renderer.create(
-			<StyledSection
-				headingText="Insights. Hello, this is a Styled Section heading."
-				headingColor="red"
-				headingLevel={2}
-				headingIcon="fake-icon"
-				headingIconColor="blue"
-				headingIconSize="16"
-			/>
-		);
-
-		const tree = component.toJSON();
-		expect( tree ).toMatchSnapshot();
-		const child = tree.children[ 0 ].children[ 0 ];
-		expect( typeof child ).toEqual( "string" );
-	} );
-
 	forEach( icons, function( icon ) {
 		test( `can change the icon to ${icon}`, () => {
 			const component = renderer.create(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* I've mocked the warning to prevent it from turning up in the console when running `yarn test`. 

## Test instructions

This PR can be tested by following these steps:

* Run yarn test. Make sure all tests pass and no console warning is shown.

Fixes #469 
