### PR TITLE
Remove console logs from Checkbox test

### DIFF
--- a/composites/Plugin/Shared/tests/CheckboxTest.js
+++ b/composites/Plugin/Shared/tests/CheckboxTest.js
@@ -6,23 +6,23 @@ import Checkbox from "../components/Checkbox";
 describe( Checkbox, () => {
 	it( "matches the snapshot", () => {
 		const component = renderer.create(
-			<Checkbox id="test-id" onChange={() => {
-			}} label="test label"/>
+			<Checkbox id="test-id" onChange={ () => {
+			} } label="test label"/>
 		);
 
 		let tree = component.toJSON();
-		expect(tree).toMatchSnapshot();
-	});
+		expect( tree ).toMatchSnapshot();
+	} );
 
 	it( "matches the snapshot when an array is provided as a label", () => {
 		const component = renderer.create(
 			<Checkbox id="test-id" onChange={() => {
-			}} label={["test label ", "using arrays"]}/>
+			}} label={ [ "test label ", "using arrays" ] }/>
 		);
 
 		let tree = component.toJSON();
-		expect(tree).toMatchSnapshot();
-	});
+		expect( tree ).toMatchSnapshot();
+	} );
 
 	it( "executes callback once", () => {
 		let event = {
@@ -40,8 +40,8 @@ describe( Checkbox, () => {
 		);
 
 		let tree = component.toJSON();
-		tree[0].props.onChange(event);
+		tree[ 0 ].props.onChange( event );
 
-		expect(onChange).toHaveBeenCalledTimes(1);
-	});
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+	} );
 } );

--- a/composites/Plugin/Shared/tests/CheckboxTest.js
+++ b/composites/Plugin/Shared/tests/CheckboxTest.js
@@ -3,70 +3,45 @@ import renderer from "react-test-renderer";
 
 import Checkbox from "../components/Checkbox";
 
-test( "the Checkbox matches the snapshot", () => {
-	const component = renderer.create(
-		<Checkbox id="test-id" onChange={ value => console.log( value ) } label="test label" />
-	);
+describe( Checkbox, () => {
+	it( "matches the snapshot", () => {
+		const component = renderer.create(
+			<Checkbox id="test-id" onChange={() => {
+			}} label="test label"/>
+		);
 
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
-} );
+		let tree = component.toJSON();
+		expect(tree).toMatchSnapshot();
+	});
 
-test( "the Checkbox matches the snapshot when an array is provided as a label", () => {
-	const component = renderer.create(
-		<Checkbox id="test-id" onChange={ value => console.log( value ) } label={ [ "test label ", "using arrays" ] } />
-	);
+	it( "matches the snapshot when an array is provided as a label", () => {
+		const component = renderer.create(
+			<Checkbox id="test-id" onChange={() => {
+			}} label={["test label ", "using arrays"]}/>
+		);
 
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
-} );
+		let tree = component.toJSON();
+		expect(tree).toMatchSnapshot();
+	});
 
-test( "the Checkbox executes callback", () => {
-	let event = {
-		target: {
-			checked: false,
-		},
-	};
-	const component = renderer.create(
-		<Checkbox
-			id="testCallback"
-			onChange={ () => {
-				console.log( "changed" );
-			} }
-			label="testCallbackLabel"
-		/>
-	);
+	it( "executes callback once", () => {
+		let event = {
+			target: {
+				checked: false,
+			},
+		};
+		let onChange = jest.fn();
+		const component = renderer.create(
+			<Checkbox
+				id="testCallback"
+				onChange={onChange}
+				label="testCallbackLabel"
+			/>
+		);
 
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
+		let tree = component.toJSON();
+		tree[0].props.onChange(event);
 
-	tree[ 0 ].props.onChange( event );
-
-	tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
-} );
-
-test( "the Checkbox executes callback when the state changes", () => {
-	let event = {
-		target: {
-			checked: true,
-		},
-	};
-	const component = renderer.create(
-		<Checkbox
-			id="testCallback"
-			onChange={ () => {
-				console.log( "changed" );
-			} }
-			label="testCallbackLabel"
-		/>
-	);
-
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
-
-	tree[ 0 ].props.onChange( event );
-
-	tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
+		expect(onChange).toHaveBeenCalledTimes(1);
+	});
 } );

--- a/composites/Plugin/Shared/tests/__snapshots__/CheckboxTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/CheckboxTest.js.snap
@@ -1,86 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`the Checkbox executes callback 1`] = `
-Array [
-  .c0 {
-  margin-right: 0.5em;
-}
-
-<input
-    className="c0"
-    id="testCallback"
-    onChange={[Function]}
-    type="checkbox"
-  />,
-  <label
-    htmlFor="testCallback"
-  >
-    testCallbackLabel
-  </label>,
-]
-`;
-
-exports[`the Checkbox executes callback 2`] = `
-Array [
-  .c0 {
-  margin-right: 0.5em;
-}
-
-<input
-    className="c0"
-    id="testCallback"
-    onChange={[Function]}
-    type="checkbox"
-  />,
-  <label
-    htmlFor="testCallback"
-  >
-    testCallbackLabel
-  </label>,
-]
-`;
-
-exports[`the Checkbox executes callback when the state changes 1`] = `
-Array [
-  .c0 {
-  margin-right: 0.5em;
-}
-
-<input
-    className="c0"
-    id="testCallback"
-    onChange={[Function]}
-    type="checkbox"
-  />,
-  <label
-    htmlFor="testCallback"
-  >
-    testCallbackLabel
-  </label>,
-]
-`;
-
-exports[`the Checkbox executes callback when the state changes 2`] = `
-Array [
-  .c0 {
-  margin-right: 0.5em;
-}
-
-<input
-    className="c0"
-    id="testCallback"
-    onChange={[Function]}
-    type="checkbox"
-  />,
-  <label
-    htmlFor="testCallback"
-  >
-    testCallbackLabel
-  </label>,
-]
-`;
-
-exports[`the Checkbox matches the snapshot 1`] = `
+exports[`Checkbox matches the snapshot 1`] = `
 Array [
   .c0 {
   margin-right: 0.5em;
@@ -100,7 +20,7 @@ Array [
 ]
 `;
 
-exports[`the Checkbox matches the snapshot when an array is provided as a label 1`] = `
+exports[`Checkbox matches the snapshot when an array is provided as a label 1`] = `
 Array [
   .c0 {
   margin-right: 0.5em;

--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -1,6 +1,6 @@
 module.exports = {
 	target: [ "<%= files.components %>" ],
 	options: {
-		maxWarnings: 5,
+		maxWarnings: 0,
 	},
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* I removed the console logs from the checkbox test, and mocked the onClick function instead. 
* I removed duplicate tests and snapshots that didn't add value. 
* I set the max-warnings in the eslint config to 0 🎉. When there are 1 or more warnings, eslint will throw: `Warning: ESLint found too many warnings (maximum: 0) Use --force to continue.`. I did not remove the option altogether, because in that case eslint won't throw a warning when there are 1 or more warnings.

## Test instructions

This PR can be tested by following these steps:

* Run `yarn test` and see that the console logs are gone.

Fixes #471