### PR TITLE
Remove obsolete references in all.scss

### DIFF
--- a/css/all.scss
+++ b/css/all.scss
@@ -1,5 +1,3 @@
 @import "accessibility";
-@import "../composites/SearchResultPreview/search-result-preview";
-@import "../composites/SearchResultForm/search-result-form";
 @import "../composites/OnboardingWizard/onboarding-wizard";
 @import "../composites/basic/loader";


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes old references in `all.scss` that caused build errors (a new release is needed as soon as possible).

## Test instructions

This PR can be tested by following these steps:

* Run yarn install and grunt build
* The build should complete without errors
