### PR TITLE
Add optional help text to contentanalysis

### DIFF
--- a/app/ContentAnalysisWrapper.js
+++ b/app/ContentAnalysisWrapper.js
@@ -76,6 +76,10 @@ export default function HelpCenterWrapper() {
 				console.log( "Marker button clicked", id, marker );
 			} }
 			marksButtonStatus={ "enabled" }
+			helpText={ [
+				"Enter the search term you'd like this post to be found with and see how it would rank. ",
+				<a key="1" href="https://yoa.st/" target="_blank" rel="noopener">Learn more about the Content Analysis Tool.</a>,
+			] }
 		/>
 	);
 }

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -226,7 +226,7 @@ class ContentAnalysis extends React.Component {
 		// Analysis collapsibles are only rendered when there is at least one analysis result for that category present.
 		return (
 			<ContentAnalysisContainer>
-				{ helpText && <HelpText text={helpText} /> }
+				{ helpText && <HelpText text={ helpText } /> }
 				{ this.renderLanguageNotice() }
 				{ errorsFound > 0 &&
 				<AnalysisCollapsible

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -1,12 +1,15 @@
+/* External dependencies */
 import React from "react";
 import styled from "styled-components";
-import colors from "../../../../style-guide/colors.json";
 import PropTypes from "prop-types";
-
 import { injectIntl, intlShape, defineMessages, FormattedMessage } from "react-intl";
+
+/* Internal dependencies */
+import colors from "../../../../style-guide/colors.json";
 import { makeOutboundLink } from "../../../../utils/makeOutboundLink";
 import AnalysisResult from "../components/AnalysisResult.js";
 import AnalysisCollapsible from "../components/AnalysisCollapsible.js";
+import HelpText, { HelpTextPropType } from "../../../../composites/Plugin/Shared/components/HelpText";
 
 export const ContentAnalysisContainer = styled.div`
 	width: 100%;
@@ -205,21 +208,25 @@ class ContentAnalysis extends React.Component {
 	 * @returns {ReactElement} The rendered ContentAnalysis component.
 	 */
 	render() {
-		let problemsResults = this.props.problemsResults;
-		let improvementsResults = this.props.improvementsResults;
-		let goodResults = this.props.goodResults;
-		let considerationsResults = this.props.considerationsResults;
-		let errorsResults = this.props.errorsResults;
-		let headingLevel = this.props.headingLevel;
-		let errorsFound = errorsResults.length;
-		let problemsFound = problemsResults.length;
-		let improvementsFound = improvementsResults.length;
-		let considerationsFound = considerationsResults.length;
-		let goodResultsFound = goodResults.length;
+		const {
+			problemsResults,
+			improvementsResults,
+			goodResults,
+			considerationsResults,
+			errorsResults,
+			headingLevel,
+			helpText,
+		} = this.props;
+		const errorsFound = errorsResults.length;
+		const problemsFound = problemsResults.length;
+		const improvementsFound = improvementsResults.length;
+		const considerationsFound = considerationsResults.length;
+		const goodResultsFound = goodResults.length;
 
 		// Analysis collapsibles are only rendered when there is at least one analysis result for that category present.
 		return (
 			<ContentAnalysisContainer>
+				{ helpText && <HelpText text={helpText} /> }
 				{ this.renderLanguageNotice() }
 				{ errorsFound > 0 &&
 				<AnalysisCollapsible
@@ -276,6 +283,7 @@ ContentAnalysis.propTypes = {
 	marksButtonStatus: PropTypes.string,
 	marksButtonClassName: PropTypes.string,
 	intl: intlShape.isRequired,
+	helpText: HelpTextPropType,
 };
 
 ContentAnalysis.defaultProps = {

--- a/composites/Plugin/ContentAnalysis/tests/ContentAnalysisTest.js
+++ b/composites/Plugin/ContentAnalysis/tests/ContentAnalysisTest.js
@@ -53,199 +53,223 @@ const considerationsResults = [
 	},
 ];
 
-test( "the ContentAnalysis component without language notice matches the snapshot", () => {
-	const component = createComponentWithIntl(
-		<ContentAnalysis
-			problemsResults={ problemsResults }
-			improvementsResults={ improvementsResults }
-			goodResults={ goodResults }
-			considerationsResults={ considerationsResults }
-			errorsResults={ errorsResults }
-			changeLanguageLink={ "#" }
-			language="English"
-		/>
-	);
+describe( "ContentAnalysis", () => {
+	it( "the ContentAnalysis component without language notice matches the snapshot", () => {
+		const component = createComponentWithIntl(
+			<ContentAnalysis
+				problemsResults={ problemsResults }
+				improvementsResults={ improvementsResults }
+				goodResults={ goodResults }
+				considerationsResults={ considerationsResults }
+				errorsResults={ errorsResults }
+				changeLanguageLink={ "#" }
+				language="English"
+			/>
+		);
 
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
-} );
+		let tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
 
-test( "the ContentAnalysis component without problems matches the snapshot", () => {
-	const component = createComponentWithIntl(
-		<ContentAnalysis
-			problemsResults={ [] }
-			improvementsResults={ improvementsResults }
-			goodResults={ goodResults }
-			considerationsResults={ considerationsResults }
-			errorsResults={ errorsResults }
-			changeLanguageLink={ "#" }
-			language="English"
-		/>
-	);
+	it( "the ContentAnalysis component without problems matches the snapshot", () => {
+		const component = createComponentWithIntl(
+			<ContentAnalysis
+				problemsResults={ [] }
+				improvementsResults={ improvementsResults }
+				goodResults={ goodResults }
+				considerationsResults={ considerationsResults }
+				errorsResults={ errorsResults }
+				changeLanguageLink={ "#" }
+				language="English"
+			/>
+		);
 
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
-} );
+		let tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
 
-test( "the ContentAnalysis component without problems and improvements matches the snapshot", () => {
-	const component = createComponentWithIntl(
-		<ContentAnalysis
-			problemsResults={ [] }
-			improvementsResults={ [] }
-			goodResults={ goodResults }
-			considerationsResults={ considerationsResults }
-			errorsResults={ errorsResults }
-			changeLanguageLink={ "#" }
-			language="English"
-		/>
-	);
+	it( "the ContentAnalysis component without problems and improvements matches the snapshot", () => {
+		const component = createComponentWithIntl(
+			<ContentAnalysis
+				problemsResults={ [] }
+				improvementsResults={ [] }
+				goodResults={ goodResults }
+				considerationsResults={ considerationsResults }
+				errorsResults={ errorsResults }
+				changeLanguageLink={ "#" }
+				language="English"
+			/>
+		);
 
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
-} );
+		let tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
 
-test( "the ContentAnalysis component without problems, improvements and considerations matches the snapshot", () => {
-	const component = createComponentWithIntl(
-		<ContentAnalysis
-			problemsResults={ [] }
-			improvementsResults={ [] }
-			goodResults={ goodResults }
-			considerationsResults={ [] }
-			errorsResults={ errorsResults }
-			changeLanguageLink={ "#" }
-			language="English"
-		/>
-	);
+	it( "the ContentAnalysis component without problems, improvements and considerations matches the snapshot", () => {
+		const component = createComponentWithIntl(
+			<ContentAnalysis
+				problemsResults={ [] }
+				improvementsResults={ [] }
+				goodResults={ goodResults }
+				considerationsResults={ [] }
+				errorsResults={ errorsResults }
+				changeLanguageLink={ "#" }
+				language="English"
+			/>
+		);
 
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
-} );
+		let tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
 
-test( "the ContentAnalysis component without problems and considerations, but with improvements and good matches the snapshot", () => {
-	const component = createComponentWithIntl(
-		<ContentAnalysis
-			problemsResults={ [] }
-			improvementsResults={ improvementsResults }
-			goodResults={ goodResults }
-			considerationsResults={ [] }
-			errorsResults={ errorsResults }
-			changeLanguageLink={ "#" }
-			language="English"
-		/>
-	);
+	it( "the ContentAnalysis component without problems and considerations, but with improvements and good matches the snapshot", () => {
+		const component = createComponentWithIntl(
+			<ContentAnalysis
+				problemsResults={ [] }
+				improvementsResults={ improvementsResults }
+				goodResults={ goodResults }
+				considerationsResults={ [] }
+				errorsResults={ errorsResults }
+				changeLanguageLink={ "#" }
+				language="English"
+			/>
+		);
 
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
-} );
+		let tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
 
-test( "the ContentAnalysis component with specified header level matches the snapshot", () => {
-	const component = createComponentWithIntl(
-		<ContentAnalysis
-			headingLevel={ 3 }
-			problemsResults={ problemsResults }
-			improvementsResults={ improvementsResults }
-			goodResults={ goodResults }
-			considerationsResults={ considerationsResults }
-			errorsResults={ errorsResults }
-			changeLanguageLink={ "#" }
-			language="English"
-		/>
-	);
+	it( "the ContentAnalysis component with specified header level matches the snapshot", () => {
+		const component = createComponentWithIntl(
+			<ContentAnalysis
+				headingLevel={ 3 }
+				problemsResults={ problemsResults }
+				improvementsResults={ improvementsResults }
+				goodResults={ goodResults }
+				considerationsResults={ considerationsResults }
+				errorsResults={ errorsResults }
+				changeLanguageLink={ "#" }
+				language="English"
+			/>
+		);
 
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
-} );
+		let tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
 
-test( "the ContentAnalysis component with language notice matches the snapshot", () => {
-	const component = createComponentWithIntl(
-		<ContentAnalysis
-			problemsResults={ problemsResults }
-			improvementsResults={ improvementsResults }
-			goodResults={ goodResults }
-			considerationsResults={ considerationsResults }
-			errorsResults={ errorsResults }
-			changeLanguageLink={ "#" }
-			language="English"
-			showLanguageNotice={ true }
-		/>
-	);
+	it( "the ContentAnalysis component with language notice matches the snapshot", () => {
+		const component = createComponentWithIntl(
+			<ContentAnalysis
+				problemsResults={ problemsResults }
+				improvementsResults={ improvementsResults }
+				goodResults={ goodResults }
+				considerationsResults={ considerationsResults }
+				errorsResults={ errorsResults }
+				changeLanguageLink={ "#" }
+				language="English"
+				showLanguageNotice={ true }
+			/>
+		);
 
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
-} );
+		let tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
 
-test( "the ContentAnalysis component with language notice for someone who can change the language matches the snapshot", () => {
-	const component = createComponentWithIntl(
-		<ContentAnalysis
-			problemsResults={ problemsResults }
-			improvementsResults={ improvementsResults }
-			goodResults={ goodResults }
-			considerationsResults={ considerationsResults }
-			errorsResults={ errorsResults }
-			changeLanguageLink={ "#" }
-			language="English"
-			showLanguageNotice={ true }
-			canChangeLanguage={ true }
-		/>
-	);
+	it( "the ContentAnalysis component with language notice for someone who can change the language matches the snapshot", () => {
+		const component = createComponentWithIntl(
+			<ContentAnalysis
+				problemsResults={ problemsResults }
+				improvementsResults={ improvementsResults }
+				goodResults={ goodResults }
+				considerationsResults={ considerationsResults }
+				errorsResults={ errorsResults }
+				changeLanguageLink={ "#" }
+				language="English"
+				showLanguageNotice={ true }
+				canChangeLanguage={ true }
+			/>
+		);
 
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
-} );
+		let tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
 
-test( "the ContentAnalysis component with language notice for someone who cannot change the language matches the snapshot", () => {
-	const component = createComponentWithIntl(
-		<ContentAnalysis
-			problemsResults={ problemsResults }
-			improvementsResults={ improvementsResults }
-			goodResults={ goodResults }
-			considerationsResults={ considerationsResults }
-			errorsResults={ errorsResults }
-			changeLanguageLink={ "#" }
-			language="English"
-			showLanguageNotice={ true }
-			canChangeLanguage={ true }
-		/>
-	);
+	it( "the ContentAnalysis component with language notice for someone who cannot change the language matches the snapshot", () => {
+		const component = createComponentWithIntl(
+			<ContentAnalysis
+				problemsResults={ problemsResults }
+				improvementsResults={ improvementsResults }
+				goodResults={ goodResults }
+				considerationsResults={ considerationsResults }
+				errorsResults={ errorsResults }
+				changeLanguageLink={ "#" }
+				language="English"
+				showLanguageNotice={ true }
+				canChangeLanguage={ true }
+			/>
+		);
 
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
-} );
+		let tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
 
-test( "the ContentAnalysis component with disabled buttons matches the snapshot", () => {
-	const component = createComponentWithIntl(
-		<ContentAnalysis
-			problemsResults={ problemsResults }
-			improvementsResults={ improvementsResults }
-			goodResults={ goodResults }
-			considerationsResults={ considerationsResults }
-			errorsResults={ errorsResults }
-			changeLanguageLink={ "#" }
-			language="English"
-			showLanguageNotice={ true }
-			marksButtonStatus={ "disabled" }
-		/>
-	);
+	it( "the ContentAnalysis component with disabled buttons matches the snapshot", () => {
+		const component = createComponentWithIntl(
+			<ContentAnalysis
+				problemsResults={ problemsResults }
+				improvementsResults={ improvementsResults }
+				goodResults={ goodResults }
+				considerationsResults={ considerationsResults }
+				errorsResults={ errorsResults }
+				changeLanguageLink={ "#" }
+				language="English"
+				showLanguageNotice={ true }
+				marksButtonStatus={ "disabled" }
+			/>
+		);
 
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
-} );
+		let tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
 
-test( "the ContentAnalysis component with hidden buttons matches the snapshot", () => {
-	const component = createComponentWithIntl(
-		<ContentAnalysis
-			problemsResults={ problemsResults }
-			improvementsResults={ improvementsResults }
-			goodResults={ goodResults }
-			considerationsResults={ considerationsResults }
-			errorsResults={ errorsResults }
-			changeLanguageLink={ "#" }
-			language="English"
-			showLanguageNotice={ true }
-			marksButtonStatus={ "hidden" }
-		/>
-	);
+	it( "the ContentAnalysis component with hidden buttons matches the snapshot", () => {
+		const component = createComponentWithIntl(
+			<ContentAnalysis
+				problemsResults={ problemsResults }
+				improvementsResults={ improvementsResults }
+				goodResults={ goodResults }
+				considerationsResults={ considerationsResults }
+				errorsResults={ errorsResults }
+				changeLanguageLink={ "#" }
+				language="English"
+				showLanguageNotice={ true }
+				marksButtonStatus={ "hidden" }
+			/>
+		);
 
-	let tree = component.toJSON();
-	expect( tree ).toMatchSnapshot();
+		let tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+
+	it( "the ContentAnalysis component with HelpText matches the snapshot", () => {
+		const component = createComponentWithIntl(
+			<ContentAnalysis
+				problemsResults={ problemsResults }
+				improvementsResults={ improvementsResults }
+				goodResults={ goodResults }
+				considerationsResults={ considerationsResults }
+				errorsResults={ errorsResults }
+				changeLanguageLink={ "#" }
+				language="English"
+				helpText={ [
+					"This is a text to help you ",
+					<a key="1" href="http://www.example.com">with a link</a>,
+					" and some more text.",
+				] }
+			/>
+		);
+
+		let tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
 } );

--- a/composites/Plugin/ContentAnalysis/tests/ContentAnalysisTest.js
+++ b/composites/Plugin/ContentAnalysis/tests/ContentAnalysisTest.js
@@ -205,7 +205,7 @@ describe( "ContentAnalysis", () => {
 				changeLanguageLink={ "#" }
 				language="English"
 				showLanguageNotice={ true }
-				canChangeLanguage={ true }
+				canChangeLanguage={ false }
 			/>
 		);
 

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -1,6 +1,650 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`the ContentAnalysis component with disabled buttons matches the snapshot 1`] = `
+exports[`ContentAnalysis the ContentAnalysis component with HelpText matches the snapshot 1`] = `
+.c18 {
+  box-sizing: border-box;
+  min-width: 32px;
+  display: inline-block;
+  border: 1px solid #ccc;
+  background-color: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,0.7 );
+  border-radius: 3px;
+  cursor: pointer;
+  padding: 0;
+  height: 24px;
+}
+
+.c18:hover {
+  border-color: #fff;
+}
+
+.c18:disabled {
+  background-color: #f7f7f7;
+  box-shadow: none;
+  border: none;
+  cursor: default;
+}
+
+.c14 {
+  min-height: 24px;
+  padding: 0 4px 0 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c15 {
+  margin-top: 3px;
+  position: relative;
+  left: -1px;
+}
+
+.c17 {
+  margin: 0 8px 0 11px;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c10 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c5 {
+  font-size: 0.8rem;
+}
+
+.c6:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c7:hover {
+  color: #000;
+}
+
+.c8::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c8:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c9 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c2 {
+  background-color: #fff;
+}
+
+.c12 {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow-x: hidden;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  font-size: 1.03em;
+  font-weight: 600;
+}
+
+.c3 {
+  margin: 0;
+  font-weight: normal;
+}
+
+.c4 {
+  width: 100%;
+  background-color: #fff;
+  padding: 0;
+  border-color: transparent;
+  border-radius: 0;
+  outline: none;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  box-shadow: none;
+  color: #0066cd;
+}
+
+.c4:hover {
+  border-color: transparent;
+  color: #0066cd;
+}
+
+.c4:active {
+  box-shadow: none;
+  background-color: #fff;
+  color: #0066cd;
+}
+
+.c4 svg {
+  margin: 0 8px 0 -5px;
+  padding-bottom: 2px;
+  width: 20px;
+  height: 20px;
+}
+
+.c4 span {
+  margin: 8px 0;
+  word-wrap: break-word;
+  font-size: 1.25em;
+  line-height: 1.25;
+  font-weight: inherit;
+}
+
+.c13 {
+  margin: 0;
+  list-style: none;
+  padding: 0 16px 0 0;
+}
+
+.c1 {
+  color: #646464;
+  font-size: 0.9em;
+}
+
+.c0 {
+  width: 100%;
+  background-color: white;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.c11 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c16 {
+  width: 13px;
+  height: 13px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c19 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c9::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<div
+  className="c0"
+>
+  <p
+    className="c1"
+  >
+    This is a text to help you 
+    <a
+      href="http://www.example.com"
+    >
+      with a link
+    </a>
+     and some more text.
+  </p>
+  <div
+    className="c2"
+  >
+    <h4
+      className="c3"
+    >
+      <button
+        aria-expanded={true}
+        className="c4 c5 Button-kDSBcD c6 Button-kDSBcD c7 Button-kDSBcD c8 Button-kDSBcD c9 c10"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          className="yoast-svg-icon yoast-svg-icon-angle-up c11"
+          fill="#555"
+          focusable="false"
+          role="img"
+          size="16px"
+          viewBox="0 0 1792 1792"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1395 1184q0 13-10 23l-50 50q-10 10-23 10t-23-10l-393-393-393 393q-10 10-23 10t-23-10l-50-50q-10-10-10-23t10-23l466-466q10-10 23-10t23 10l466 466q10 10 10 23z"
+          />
+        </svg>
+        <span
+          className="c12"
+        >
+          Errors (1)
+        </span>
+      </button>
+    </h4>
+    <ul
+      className="c13"
+      role="list"
+    >
+      <li
+        className="c14"
+      >
+        <svg
+          aria-hidden={true}
+          className="yoast-svg-icon yoast-svg-icon-circle c15 c16"
+          fill="#888"
+          focusable="false"
+          role="img"
+          size="13px"
+          viewBox="0 0 1792 1792"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1664 896q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+          />
+        </svg>
+        <p
+          className="c17"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Error: Analysis not loaded",
+            }
+          }
+        />
+      </li>
+    </ul>
+  </div>
+  <div
+    className="c2"
+  >
+    <h4
+      className="c3"
+    >
+      <button
+        aria-expanded={true}
+        className="c4 c5 Button-kDSBcD c6 Button-kDSBcD c7 Button-kDSBcD c8 Button-kDSBcD c9 c10"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          className="yoast-svg-icon yoast-svg-icon-angle-up c11"
+          fill="#555"
+          focusable="false"
+          role="img"
+          size="16px"
+          viewBox="0 0 1792 1792"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1395 1184q0 13-10 23l-50 50q-10 10-23 10t-23-10l-393-393-393 393q-10 10-23 10t-23-10l-50-50q-10-10-10-23t10-23l466-466q10-10 23-10t23 10l466 466q10 10 10 23z"
+          />
+        </svg>
+        <span
+          className="c12"
+        >
+          Problems (1)
+        </span>
+      </button>
+    </h4>
+    <ul
+      className="c13"
+      role="list"
+    >
+      <li
+        className="c14"
+      >
+        <svg
+          aria-hidden={true}
+          className="yoast-svg-icon yoast-svg-icon-circle c15 c16"
+          fill="#dc3232"
+          focusable="false"
+          role="img"
+          size="13px"
+          viewBox="0 0 1792 1792"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1664 896q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+          />
+        </svg>
+        <p
+          className="c17"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Your text is bad, and you should feel bad.",
+            }
+          }
+        />
+        <button
+          aria-label="Highlight this result in the text"
+          aria-pressed={false}
+          className="c18"
+          disabled={false}
+          id="1"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden={true}
+            className="yoast-svg-icon yoast-svg-icon-eye c19"
+            fill="#555"
+            focusable="false"
+            role="img"
+            size="18px"
+            viewBox="0 0 1792 1792"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
+            />
+          </svg>
+        </button>
+      </li>
+    </ul>
+  </div>
+  <div
+    className="c2"
+  >
+    <h4
+      className="c3"
+    >
+      <button
+        aria-expanded={true}
+        className="c4 c5 Button-kDSBcD c6 Button-kDSBcD c7 Button-kDSBcD c8 Button-kDSBcD c9 c10"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          className="yoast-svg-icon yoast-svg-icon-angle-up c11"
+          fill="#555"
+          focusable="false"
+          role="img"
+          size="16px"
+          viewBox="0 0 1792 1792"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1395 1184q0 13-10 23l-50 50q-10 10-23 10t-23-10l-393-393-393 393q-10 10-23 10t-23-10l-50-50q-10-10-10-23t10-23l466-466q10-10 23-10t23 10l466 466q10 10 10 23z"
+          />
+        </svg>
+        <span
+          className="c12"
+        >
+          Improvements (1)
+        </span>
+      </button>
+    </h4>
+    <ul
+      className="c13"
+      role="list"
+    >
+      <li
+        className="c14"
+      >
+        <svg
+          aria-hidden={true}
+          className="yoast-svg-icon yoast-svg-icon-circle c15 c16"
+          fill="#ee7c1b"
+          focusable="false"
+          role="img"
+          size="13px"
+          viewBox="0 0 1792 1792"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1664 896q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+          />
+        </svg>
+        <p
+          className="c17"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "I know you can do better! You can do it!",
+            }
+          }
+        />
+      </li>
+    </ul>
+  </div>
+  <div
+    className="c2"
+  >
+    <h4
+      className="c3"
+    >
+      <button
+        aria-expanded={true}
+        className="c4 c5 Button-kDSBcD c6 Button-kDSBcD c7 Button-kDSBcD c8 Button-kDSBcD c9 c10"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          className="yoast-svg-icon yoast-svg-icon-angle-up c11"
+          fill="#555"
+          focusable="false"
+          role="img"
+          size="16px"
+          viewBox="0 0 1792 1792"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1395 1184q0 13-10 23l-50 50q-10 10-23 10t-23-10l-393-393-393 393q-10 10-23 10t-23-10l-50-50q-10-10-10-23t10-23l466-466q10-10 23-10t23 10l466 466q10 10 10 23z"
+          />
+        </svg>
+        <span
+          className="c12"
+        >
+          Considerations (1)
+        </span>
+      </button>
+    </h4>
+    <ul
+      className="c13"
+      role="list"
+    >
+      <li
+        className="c14"
+      >
+        <svg
+          aria-hidden={true}
+          className="yoast-svg-icon yoast-svg-icon-circle c15 c16"
+          fill="#888"
+          focusable="false"
+          role="img"
+          size="13px"
+          viewBox="0 0 1792 1792"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1664 896q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+          />
+        </svg>
+        <p
+          className="c17"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Maybe you should change this...",
+            }
+          }
+        />
+      </li>
+    </ul>
+  </div>
+  <div
+    className="c2"
+  >
+    <h4
+      className="c3"
+    >
+      <button
+        aria-expanded={true}
+        className="c4 c5 Button-kDSBcD c6 Button-kDSBcD c7 Button-kDSBcD c8 Button-kDSBcD c9 c10"
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          className="yoast-svg-icon yoast-svg-icon-angle-up c11"
+          fill="#555"
+          focusable="false"
+          role="img"
+          size="16px"
+          viewBox="0 0 1792 1792"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1395 1184q0 13-10 23l-50 50q-10 10-23 10t-23-10l-393-393-393 393q-10 10-23 10t-23-10l-50-50q-10-10-10-23t10-23l466-466q10-10 23-10t23 10l466 466q10 10 10 23z"
+          />
+        </svg>
+        <span
+          className="c12"
+        >
+          Good results (2)
+        </span>
+      </button>
+    </h4>
+    <ul
+      className="c13"
+      role="list"
+    >
+      <li
+        className="c14"
+      >
+        <svg
+          aria-hidden={true}
+          className="yoast-svg-icon yoast-svg-icon-circle c15 c16"
+          fill="#7ad03a"
+          focusable="false"
+          role="img"
+          size="13px"
+          viewBox="0 0 1792 1792"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1664 896q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+          />
+        </svg>
+        <p
+          className="c17"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "You're doing great!",
+            }
+          }
+        />
+      </li>
+      <li
+        className="c14"
+      >
+        <svg
+          aria-hidden={true}
+          className="yoast-svg-icon yoast-svg-icon-circle c15 c16"
+          fill="#7ad03a"
+          focusable="false"
+          role="img"
+          size="13px"
+          viewBox="0 0 1792 1792"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1664 896q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+          />
+        </svg>
+        <p
+          className="c17"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Woohoo!",
+            }
+          }
+        />
+        <button
+          aria-label="Highlight this result in the text"
+          aria-pressed={false}
+          className="c18"
+          disabled={false}
+          id="3"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden={true}
+            className="yoast-svg-icon yoast-svg-icon-eye c19"
+            fill="#555"
+            focusable="false"
+            role="img"
+            size="18px"
+            viewBox="0 0 1792 1792"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
+            />
+          </svg>
+        </button>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`ContentAnalysis the ContentAnalysis component with disabled buttons matches the snapshot 1`] = `
 .c18 {
   box-sizing: border-box;
   min-width: 32px;
@@ -645,7 +1289,7 @@ exports[`the ContentAnalysis component with disabled buttons matches the snapsho
 </div>
 `;
 
-exports[`the ContentAnalysis component with hidden buttons matches the snapshot 1`] = `
+exports[`ContentAnalysis the ContentAnalysis component with hidden buttons matches the snapshot 1`] = `
 .c14 {
   min-height: 24px;
   padding: 0 4px 0 0;
@@ -1210,7 +1854,7 @@ exports[`the ContentAnalysis component with hidden buttons matches the snapshot 
 </div>
 `;
 
-exports[`the ContentAnalysis component with language notice for someone who can change the language matches the snapshot 1`] = `
+exports[`ContentAnalysis the ContentAnalysis component with language notice for someone who can change the language matches the snapshot 1`] = `
 .c3 {
   border: 0;
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -1891,7 +2535,7 @@ exports[`the ContentAnalysis component with language notice for someone who can 
 </div>
 `;
 
-exports[`the ContentAnalysis component with language notice for someone who cannot change the language matches the snapshot 1`] = `
+exports[`ContentAnalysis the ContentAnalysis component with language notice for someone who cannot change the language matches the snapshot 1`] = `
 .c3 {
   border: 0;
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -2572,7 +3216,7 @@ exports[`the ContentAnalysis component with language notice for someone who cann
 </div>
 `;
 
-exports[`the ContentAnalysis component with language notice matches the snapshot 1`] = `
+exports[`ContentAnalysis the ContentAnalysis component with language notice matches the snapshot 1`] = `
 .c18 {
   box-sizing: border-box;
   min-width: 32px;
@@ -3217,7 +3861,7 @@ exports[`the ContentAnalysis component with language notice matches the snapshot
 </div>
 `;
 
-exports[`the ContentAnalysis component with specified header level matches the snapshot 1`] = `
+exports[`ContentAnalysis the ContentAnalysis component with specified header level matches the snapshot 1`] = `
 .c17 {
   box-sizing: border-box;
   min-width: 32px;
@@ -3845,7 +4489,7 @@ exports[`the ContentAnalysis component with specified header level matches the s
 </div>
 `;
 
-exports[`the ContentAnalysis component without language notice matches the snapshot 1`] = `
+exports[`ContentAnalysis the ContentAnalysis component without language notice matches the snapshot 1`] = `
 .c17 {
   box-sizing: border-box;
   min-width: 32px;
@@ -4473,7 +5117,7 @@ exports[`the ContentAnalysis component without language notice matches the snaps
 </div>
 `;
 
-exports[`the ContentAnalysis component without problems and considerations, but with improvements and good matches the snapshot 1`] = `
+exports[`ContentAnalysis the ContentAnalysis component without problems and considerations, but with improvements and good matches the snapshot 1`] = `
 .c17 {
   box-sizing: border-box;
   min-width: 32px;
@@ -4947,7 +5591,7 @@ exports[`the ContentAnalysis component without problems and considerations, but 
 </div>
 `;
 
-exports[`the ContentAnalysis component without problems and improvements matches the snapshot 1`] = `
+exports[`ContentAnalysis the ContentAnalysis component without problems and improvements matches the snapshot 1`] = `
 .c17 {
   box-sizing: border-box;
   min-width: 32px;
@@ -5421,7 +6065,7 @@ exports[`the ContentAnalysis component without problems and improvements matches
 </div>
 `;
 
-exports[`the ContentAnalysis component without problems matches the snapshot 1`] = `
+exports[`ContentAnalysis the ContentAnalysis component without problems matches the snapshot 1`] = `
 .c17 {
   box-sizing: border-box;
   min-width: 32px;
@@ -5960,7 +6604,7 @@ exports[`the ContentAnalysis component without problems matches the snapshot 1`]
 </div>
 `;
 
-exports[`the ContentAnalysis component without problems, improvements and considerations matches the snapshot 1`] = `
+exports[`ContentAnalysis the ContentAnalysis component without problems, improvements and considerations matches the snapshot 1`] = `
 .c17 {
   box-sizing: border-box;
   min-width: 32px;

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -2536,25 +2536,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
 `;
 
 exports[`ContentAnalysis the ContentAnalysis component with language notice for someone who cannot change the language matches the snapshot 1`] = `
-.c3 {
-  border: 0;
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute !important;
-  width: 1px;
-  word-wrap: normal !important;
-  -webkit-transform: translateY(1em);
-  -ms-transform: translateY(1em);
-  transform: translateY(1em);
-}
-
-.c20 {
+.c18 {
   box-sizing: border-box;
   min-width: 32px;
   display: inline-block;
@@ -2567,18 +2549,18 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
   height: 24px;
 }
 
-.c20:hover {
+.c18:hover {
   border-color: #fff;
 }
 
-.c20:disabled {
+.c18:disabled {
   background-color: #f7f7f7;
   box-shadow: none;
   border: none;
   cursor: default;
 }
 
-.c16 {
+.c14 {
   min-height: 24px;
   padding: 0 4px 0 0;
   display: -webkit-box;
@@ -2591,49 +2573,49 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
   align-items: flex-start;
 }
 
-.c17 {
+.c15 {
   margin-top: 3px;
   position: relative;
   left: -1px;
 }
 
-.c19 {
+.c17 {
   margin: 0 8px 0 11px;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
 }
 
-.c12 {
+.c10 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c7 {
+.c5 {
   font-size: 0.8rem;
 }
 
-.c8:active {
+.c6:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c9:hover {
+.c7:hover {
   color: #000;
 }
 
-.c10::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border-width: 0;
 }
 
-.c10:focus {
+.c8:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c11 {
+.c9 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2662,17 +2644,17 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
   min-height: 32px;
 }
 
-.c11 svg {
+.c9 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4 {
+.c2 {
   background-color: #fff;
 }
 
-.c14 {
+.c12 {
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
@@ -2685,12 +2667,12 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
   font-weight: 600;
 }
 
-.c5 {
+.c3 {
   margin: 0;
   font-weight: normal;
 }
 
-.c6 {
+.c4 {
   width: 100%;
   background-color: #fff;
   padding: 0;
@@ -2705,25 +2687,25 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
   color: #0066cd;
 }
 
-.c6:hover {
+.c4:hover {
   border-color: transparent;
   color: #0066cd;
 }
 
-.c6:active {
+.c4:active {
   box-shadow: none;
   background-color: #fff;
   color: #0066cd;
 }
 
-.c6 svg {
+.c4 svg {
   margin: 0 8px 0 -5px;
   padding-bottom: 2px;
   width: 20px;
   height: 20px;
 }
 
-.c6 span {
+.c4 span {
   margin: 8px 0;
   word-wrap: break-word;
   font-size: 1.25em;
@@ -2731,7 +2713,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
   font-weight: inherit;
 }
 
-.c15 {
+.c13 {
   margin: 0;
   list-style: none;
   padding: 0 16px 0 0;
@@ -2750,12 +2732,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
   margin-left: 24px;
 }
 
-.c2 {
-  color: #0066cd;
-  margin-left: 4px;
-}
-
-.c13 {
+.c11 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -2763,7 +2740,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
   flex: none;
 }
 
-.c18 {
+.c16 {
   width: 13px;
   height: 13px;
   -webkit-flex: none;
@@ -2771,7 +2748,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
   flex: none;
 }
 
-.c21 {
+.c19 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -2780,7 +2757,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c11::after {
+  .c9::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -2798,37 +2775,24 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
       <strong>
         English
       </strong>
-      .
+      . If this is not correct, contact your site administrator.
     </span>
-    <a
-      className="c2"
-      href="#"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Change language
-      <span
-        className="c3"
-      >
-        (Opens in a new browser tab)
-      </span>
-    </a>
   </p>
   <div
-    className="c4"
+    className="c2"
   >
     <h4
-      className="c5"
+      className="c3"
     >
       <button
         aria-expanded={true}
-        className="c6 c7 Button-kDSBcD c8 Button-kDSBcD c9 Button-kDSBcD c10 Button-kDSBcD c11 c12"
+        className="c4 c5 Button-kDSBcD c6 Button-kDSBcD c7 Button-kDSBcD c8 Button-kDSBcD c9 c10"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-angle-up c13"
+          className="yoast-svg-icon yoast-svg-icon-angle-up c11"
           fill="#555"
           focusable="false"
           role="img"
@@ -2841,22 +2805,22 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
           />
         </svg>
         <span
-          className="c14"
+          className="c12"
         >
           Errors (1)
         </span>
       </button>
     </h4>
     <ul
-      className="c15"
+      className="c13"
       role="list"
     >
       <li
-        className="c16"
+        className="c14"
       >
         <svg
           aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-circle c17 c18"
+          className="yoast-svg-icon yoast-svg-icon-circle c15 c16"
           fill="#888"
           focusable="false"
           role="img"
@@ -2869,7 +2833,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
           />
         </svg>
         <p
-          className="c19"
+          className="c17"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Error: Analysis not loaded",
@@ -2880,20 +2844,20 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
     </ul>
   </div>
   <div
-    className="c4"
+    className="c2"
   >
     <h4
-      className="c5"
+      className="c3"
     >
       <button
         aria-expanded={true}
-        className="c6 c7 Button-kDSBcD c8 Button-kDSBcD c9 Button-kDSBcD c10 Button-kDSBcD c11 c12"
+        className="c4 c5 Button-kDSBcD c6 Button-kDSBcD c7 Button-kDSBcD c8 Button-kDSBcD c9 c10"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-angle-up c13"
+          className="yoast-svg-icon yoast-svg-icon-angle-up c11"
           fill="#555"
           focusable="false"
           role="img"
@@ -2906,22 +2870,22 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
           />
         </svg>
         <span
-          className="c14"
+          className="c12"
         >
           Problems (1)
         </span>
       </button>
     </h4>
     <ul
-      className="c15"
+      className="c13"
       role="list"
     >
       <li
-        className="c16"
+        className="c14"
       >
         <svg
           aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-circle c17 c18"
+          className="yoast-svg-icon yoast-svg-icon-circle c15 c16"
           fill="#dc3232"
           focusable="false"
           role="img"
@@ -2934,7 +2898,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
           />
         </svg>
         <p
-          className="c19"
+          className="c17"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Your text is bad, and you should feel bad.",
@@ -2944,7 +2908,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
         <button
           aria-label="Highlight this result in the text"
           aria-pressed={false}
-          className="c20"
+          className="c18"
           disabled={false}
           id="1"
           onClick={[Function]}
@@ -2952,7 +2916,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
         >
           <svg
             aria-hidden={true}
-            className="yoast-svg-icon yoast-svg-icon-eye c21"
+            className="yoast-svg-icon yoast-svg-icon-eye c19"
             fill="#555"
             focusable="false"
             role="img"
@@ -2969,20 +2933,20 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
     </ul>
   </div>
   <div
-    className="c4"
+    className="c2"
   >
     <h4
-      className="c5"
+      className="c3"
     >
       <button
         aria-expanded={true}
-        className="c6 c7 Button-kDSBcD c8 Button-kDSBcD c9 Button-kDSBcD c10 Button-kDSBcD c11 c12"
+        className="c4 c5 Button-kDSBcD c6 Button-kDSBcD c7 Button-kDSBcD c8 Button-kDSBcD c9 c10"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-angle-up c13"
+          className="yoast-svg-icon yoast-svg-icon-angle-up c11"
           fill="#555"
           focusable="false"
           role="img"
@@ -2995,22 +2959,22 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
           />
         </svg>
         <span
-          className="c14"
+          className="c12"
         >
           Improvements (1)
         </span>
       </button>
     </h4>
     <ul
-      className="c15"
+      className="c13"
       role="list"
     >
       <li
-        className="c16"
+        className="c14"
       >
         <svg
           aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-circle c17 c18"
+          className="yoast-svg-icon yoast-svg-icon-circle c15 c16"
           fill="#ee7c1b"
           focusable="false"
           role="img"
@@ -3023,7 +2987,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
           />
         </svg>
         <p
-          className="c19"
+          className="c17"
           dangerouslySetInnerHTML={
             Object {
               "__html": "I know you can do better! You can do it!",
@@ -3034,20 +2998,20 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
     </ul>
   </div>
   <div
-    className="c4"
+    className="c2"
   >
     <h4
-      className="c5"
+      className="c3"
     >
       <button
         aria-expanded={true}
-        className="c6 c7 Button-kDSBcD c8 Button-kDSBcD c9 Button-kDSBcD c10 Button-kDSBcD c11 c12"
+        className="c4 c5 Button-kDSBcD c6 Button-kDSBcD c7 Button-kDSBcD c8 Button-kDSBcD c9 c10"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-angle-up c13"
+          className="yoast-svg-icon yoast-svg-icon-angle-up c11"
           fill="#555"
           focusable="false"
           role="img"
@@ -3060,22 +3024,22 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
           />
         </svg>
         <span
-          className="c14"
+          className="c12"
         >
           Considerations (1)
         </span>
       </button>
     </h4>
     <ul
-      className="c15"
+      className="c13"
       role="list"
     >
       <li
-        className="c16"
+        className="c14"
       >
         <svg
           aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-circle c17 c18"
+          className="yoast-svg-icon yoast-svg-icon-circle c15 c16"
           fill="#888"
           focusable="false"
           role="img"
@@ -3088,7 +3052,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
           />
         </svg>
         <p
-          className="c19"
+          className="c17"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Maybe you should change this...",
@@ -3099,20 +3063,20 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
     </ul>
   </div>
   <div
-    className="c4"
+    className="c2"
   >
     <h4
-      className="c5"
+      className="c3"
     >
       <button
         aria-expanded={true}
-        className="c6 c7 Button-kDSBcD c8 Button-kDSBcD c9 Button-kDSBcD c10 Button-kDSBcD c11 c12"
+        className="c4 c5 Button-kDSBcD c6 Button-kDSBcD c7 Button-kDSBcD c8 Button-kDSBcD c9 c10"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-angle-up c13"
+          className="yoast-svg-icon yoast-svg-icon-angle-up c11"
           fill="#555"
           focusable="false"
           role="img"
@@ -3125,22 +3089,22 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
           />
         </svg>
         <span
-          className="c14"
+          className="c12"
         >
           Good results (2)
         </span>
       </button>
     </h4>
     <ul
-      className="c15"
+      className="c13"
       role="list"
     >
       <li
-        className="c16"
+        className="c14"
       >
         <svg
           aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-circle c17 c18"
+          className="yoast-svg-icon yoast-svg-icon-circle c15 c16"
           fill="#7ad03a"
           focusable="false"
           role="img"
@@ -3153,7 +3117,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
           />
         </svg>
         <p
-          className="c19"
+          className="c17"
           dangerouslySetInnerHTML={
             Object {
               "__html": "You're doing great!",
@@ -3162,11 +3126,11 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
         />
       </li>
       <li
-        className="c16"
+        className="c14"
       >
         <svg
           aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-circle c17 c18"
+          className="yoast-svg-icon yoast-svg-icon-circle c15 c16"
           fill="#7ad03a"
           focusable="false"
           role="img"
@@ -3179,7 +3143,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
           />
         </svg>
         <p
-          className="c19"
+          className="c17"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Woohoo!",
@@ -3189,7 +3153,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
         <button
           aria-label="Highlight this result in the text"
           aria-pressed={false}
-          className="c20"
+          className="c18"
           disabled={false}
           id="3"
           onClick={[Function]}
@@ -3197,7 +3161,7 @@ exports[`ContentAnalysis the ContentAnalysis component with language notice for 
         >
           <svg
             aria-hidden={true}
-            className="yoast-svg-icon yoast-svg-icon-eye c21"
+            className="yoast-svg-icon yoast-svg-icon-eye c19"
             fill="#555"
             focusable="false"
             role="img"

--- a/composites/Plugin/Shared/components/HelpText.js
+++ b/composites/Plugin/Shared/components/HelpText.js
@@ -7,7 +7,7 @@ import styled from "styled-components";
 import colors from "../../../../style-guide/colors";
 
 const YoastHelpText = styled.p`
-	color: ${colors.$color_grey_text};
+	color: ${ colors.$color_grey_text };
 	font-size: 0.9em;
 `;
 
@@ -29,7 +29,7 @@ export default class HelpText extends React.Component {
 
 		return (
 			<YoastHelpText>
-				{text}
+				{ text }
 			</YoastHelpText>
 		);
 	}

--- a/composites/Plugin/Shared/components/HelpText.js
+++ b/composites/Plugin/Shared/components/HelpText.js
@@ -1,0 +1,50 @@
+/* External dependencies */
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+/* Internal dependencies */
+import colors from "../../../../style-guide/colors";
+
+const YoastHelpText = styled.p`
+	color: ${colors.$color_grey_text};
+	font-size: 0.9em;
+`;
+
+/**
+ * Returns the HelpText component.
+ *
+ * @param {Object} props Component props.
+ *
+ * @returns {ReactElement} HelpText component.
+ */
+export default class HelpText extends React.Component {
+	/**
+	 * Renders a help text component.
+	 *
+	 * @returns {ReactElement} The rendered help text component.
+	 */
+	render() {
+		const { text } = this.props;
+
+		return (
+			<YoastHelpText>
+				{text}
+			</YoastHelpText>
+		);
+	}
+}
+
+/**
+ * React prop type for the help text.
+ *
+ * Use this in your components to pass along the text.
+ */
+export const HelpTextPropType = PropTypes.oneOfType( [
+	PropTypes.string,
+	PropTypes.array,
+] );
+
+HelpText.propTypes = {
+	text: HelpTextPropType.isRequired,
+};

--- a/composites/Plugin/Shared/tests/HelpTextTest.js
+++ b/composites/Plugin/Shared/tests/HelpTextTest.js
@@ -1,5 +1,3 @@
-/* describe it */
-
 /* External dependencies */
 import React from "react";
 import renderer from "react-test-renderer";

--- a/composites/Plugin/Shared/tests/HelpTextTest.js
+++ b/composites/Plugin/Shared/tests/HelpTextTest.js
@@ -1,0 +1,28 @@
+/* describe it */
+
+/* External dependencies */
+import React from "react";
+import renderer from "react-test-renderer";
+
+/* Internal dependencies */
+import HelpText from "../components/HelpText";
+
+describe( "HelpText", () => {
+	it( "matches the snapshot by default", () => {
+		const component = renderer.create(
+			<HelpText text="Some help text." />
+		);
+
+		let tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+
+	it( "matches the snapshot when an array is provided as text", () => {
+		const component = renderer.create(
+			<HelpText text={ [ "Text ", "<a href=\"https://www.example.com\">with a link</a>", " in the middle." ] } />
+		);
+
+		let tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+} );

--- a/composites/Plugin/Shared/tests/__snapshots__/HelpTextTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/HelpTextTest.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HelpText matches the snapshot by default 1`] = `
+.c0 {
+  color: #646464;
+  font-size: 0.9em;
+}
+
+<p
+  className="c0"
+>
+  Some help text.
+</p>
+`;
+
+exports[`HelpText matches the snapshot when an array is provided as text 1`] = `
+.c0 {
+  color: #646464;
+  font-size: 0.9em;
+}
+
+<p
+  className="c0"
+>
+  Text 
+  &lt;a href="https://www.example.com"&gt;with a link&lt;/a&gt;
+   in the middle.
+</p>
+`;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added a help text component.

## Relevant technical choices:

* Uses PropType one of to make it possible to pass the text in an array as well as just a string. In the array you can pass a link for example. This prop type is exported to be used in a component that uses HelpText.
* Uses a paragraph element with a default style as main parent.

## Test instructions

This PR can be tested by following these steps:

* View the HelpText in action: `yarn start` -> `localhost:3333` -> tab `Content analysis`.
* Check `yarn test` && `grunt check`.

Fixes #476 
