### PR TITLE
Add date to snippet editor props

### DIFF
--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -296,6 +296,7 @@ class SnippetEditor extends React.Component {
 			onChange,
 			data,
 			mode,
+			date,
 		} = this.props;
 
 		const {
@@ -315,6 +316,7 @@ class SnippetEditor extends React.Component {
 			<div>
 				<SnippetPreview
 					mode={ mode }
+					date={ date }
 					activeField={ this.mapFieldToPreview( activeField ) }
 					hoveredField={ this.mapFieldToPreview( hoveredField ) }
 					onMouseOver={ this.onMouseOver }
@@ -353,6 +355,7 @@ SnippetEditor.propTypes = {
 	} ).isRequired,
 	baseUrl: PropTypes.string.isRequired,
 	mode: PropTypes.oneOf( MODES ),
+	date: PropTypes.string,
 	onChange: PropTypes.func.isRequired,
 	titleLengthAssessment: lengthAssessmentShape,
 	descriptionLengthAssessment: lengthAssessmentShape,
@@ -361,6 +364,7 @@ SnippetEditor.propTypes = {
 
 SnippetEditor.defaultProps = {
 	mode: DEFAULT_MODE,
+	date: "",
 	replacementVariables: [],
 	titleLengthAssessment: {
 		max: 600,

--- a/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
@@ -62,6 +62,10 @@ describe( "SnippetEditor", () => {
 		renderSnapshotWithArgs( { mode: MODE_DESKTOP } );
 	} );
 
+	it( "passes the date prop", () => {
+		renderSnapshotWithArgs( { date: "date string" } );
+	} );
+
 	it( "accepts a custom data mapping function", () => {
 		const mapper = jest.fn( () => {
 			return {

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -827,6 +827,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
       "title": "Test title",
     }
   }
+  date=""
   descriptionLengthAssessment={
     Object {
       "actual": 0,
@@ -2079,6 +2080,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
       "title": "Test title",
     }
   }
+  date=""
   descriptionLengthAssessment={
     Object {
       "actual": 0,
@@ -3331,6 +3333,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
       "title": "Test title",
     }
   }
+  date=""
   descriptionLengthAssessment={
     Object {
       "actual": 0,
@@ -4583,6 +4586,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
       "title": "Test title",
     }
   }
+  date=""
   descriptionLengthAssessment={
     Object {
       "actual": 0,
@@ -5760,6 +5764,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
       "title": "Test title",
     }
   }
+  date=""
   descriptionLengthAssessment={
     Object {
       "actual": 0,
@@ -6748,6 +6753,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
       "title": "Test title",
     }
   }
+  date=""
   descriptionLengthAssessment={
     Object {
       "actual": 0,
@@ -8032,6 +8038,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
       "title": "Test title",
     }
   }
+  date=""
   descriptionLengthAssessment={
     Object {
       "actual": 330,
@@ -10259,6 +10266,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
       "title": "Test title",
     }
   }
+  date=""
   descriptionLengthAssessment={
     Object {
       "actual": 0,
@@ -11554,6 +11562,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
       "title": "Test title",
     }
   }
+  date=""
   descriptionLengthAssessment={
     Object {
       "actual": 0,
@@ -12815,6 +12824,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
       "title": "Test title",
     }
   }
+  date=""
   descriptionLengthAssessment={
     Object {
       "actual": 0,
@@ -14067,6 +14077,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
       "title": "Test title",
     }
   }
+  date=""
   descriptionLengthAssessment={
     Object {
       "actual": 0,
@@ -15055,6 +15066,445 @@ exports[`SnippetEditor passes replacement variables to the title and description
     </Button>
   </div>
 </SnippetEditor>
+`;
+
+exports[`SnippetEditor passes the date prop 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+}
+
+.c9 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+}
+
+.c8 {
+  line-height: 1em;
+  max-height: 4em;
+  overflow: hidden;
+}
+
+.c1 {
+  padding: 16px;
+}
+
+.c10 {
+  color: #808080;
+}
+
+.c7 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c17 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c12 {
+  font-size: 0.8rem;
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c12:hover,
+.c12:focus {
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c13:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c14:hover {
+  color: #000;
+}
+
+.c15::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c15:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c16 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c16 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c19 {
+  font-size: 0.8rem;
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c19:hover,
+.c19:focus {
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c21 {
+  font-size: 0.8rem;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  margin: 10px 0 0 9px;
+}
+
+.c21 svg {
+  margin-right: 7px;
+}
+
+.c11 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c18 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c20 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c22 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c16::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<div>
+  <section>
+    <div
+      className="c0"
+      onMouseLeave={undefined}
+      width={640}
+    >
+      <div
+        className="c1"
+      >
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          SEO title preview:
+        </span>
+        <div
+          className="c2"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          <div
+            className="c3 c4"
+          >
+            <span
+              className="c5"
+            >
+              Test title
+            </span>
+          </div>
+        </div>
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          Url preview:
+        </span>
+        <div
+          className="c6"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          example.org › test-slug
+        </div>
+      </div>
+      <hr
+        className="c7"
+      />
+      <div
+        className="c1"
+      >
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          Meta description preview:
+        </span>
+        <div
+          className="c8 c9"
+          color="#545454"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          <span
+            className="c10"
+          >
+            date string
+             - 
+          </span>
+          Test description, %%replacement_variable%%
+        </div>
+      </div>
+    </div>
+  </section>
+  <div
+    className="c11"
+  >
+    <button
+      aria-pressed={true}
+      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-mobile c18"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="22px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Mobile preview
+      </span>
+    </button>
+    <button
+      aria-pressed={false}
+      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-desktop c20"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="18px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Desktop preview
+      </span>
+    </button>
+  </div>
+  <button
+    aria-expanded={false}
+    className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      aria-hidden={true}
+      className="yoast-svg-icon yoast-svg-icon-edit c22"
+      fill={undefined}
+      focusable="false"
+      role="img"
+      size="16px"
+      viewBox="0 0 1792 1792"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+      />
+    </svg>
+    <span>
+      Edit snippet
+    </span>
+  </button>
+</div>
 `;
 
 exports[`SnippetEditor removes the highlight from the hovered field on calling onMouseLeave() 1`] = `

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -233,6 +233,7 @@ export default class SnippetPreview extends PureComponent {
 	 * @param {string} props.keyword                The keyword for the page.
 	 * @param {string} props.isDescriptionGenerated Whether the description was generated.
 	 * @param {string} props.locale                 The locale of the page.
+	 * @param {string} props.date                   Optional, the date to display before the meta description.
 	 *
 	 * @returns {ReactElement} The SnippetPreview component.
 	 */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added an optional date prop to the SnippetEditor.

## Relevant technical choices:

* Added as separate prop and not inside data because it does not represent an editable field.

## Test instructions

This PR can be tested by following these steps:

* Run `yarn test`

Fixes https://github.com/Yoast/wordpress-seo/issues/9535
