### PR TITLE
Fix styling react snippet editor

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
+++ b/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
@@ -18,7 +18,7 @@ import PropTypes from "prop-types";
  *
  * @returns {ReactComponent} The rendered component.
  */
-const SwitcherButton = Button.extend`
+const SwitcherButton = styled( Button )`
 	border: none;
 	border-bottom: 4px solid transparent;
 	
@@ -26,6 +26,7 @@ const SwitcherButton = Button.extend`
 	height: 31px;
 	
 	border-color: ${ ( props ) => props.isActive ? colors.$color_snippet_active : "transparent" };
+	background-color: ${ ( props ) => props.isActive ? colors.$color_white : "inherit" };
 	color: ${ colors.$color_snippet_active };
 	
 	transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;

--- a/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
+++ b/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
@@ -21,6 +21,7 @@ import PropTypes from "prop-types";
 const SwitcherButton = Button.extend`
 	border: none;
 	border-bottom: 4px solid transparent;
+	
 	width: 31px;
 	height: 31px;
 	

--- a/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
+++ b/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
@@ -37,6 +37,7 @@ const SwitcherButton = styled( Button )`
 		border-bottom: 4px solid transparent;
 		border-color: ${ colors.$color_snippet_focus };
 		color: ${ colors.$color_snippet_focus };
+		box-shadow: none;
 	}
 `;
 

--- a/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
+++ b/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
@@ -21,7 +21,6 @@ import PropTypes from "prop-types";
 const SwitcherButton = Button.extend`
 	border: none;
 	border-bottom: 4px solid transparent;
-	
 	width: 31px;
 	height: 31px;
 	

--- a/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
+++ b/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
@@ -32,6 +32,7 @@ const SwitcherButton = Button.extend`
 	transition-property: border-color;
 	
 	&:hover, &:focus {
+		background-color: ${ colors.$color_white };
 		border: none;
 		border-bottom: 4px solid transparent;
 		border-color: ${ colors.$color_snippet_focus };

--- a/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
+++ b/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
@@ -26,7 +26,6 @@ const SwitcherButton = styled( Button )`
 	height: 31px;
 	
 	border-color: ${ ( props ) => props.isActive ? colors.$color_snippet_active : "transparent" };
-	background-color: ${ ( props ) => props.isActive ? colors.$color_white : "inherit" };
 	color: ${ colors.$color_snippet_active };
 	
 	transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -20,11 +20,13 @@ const SnippetEditorButton = Button.extend`
 	height: 33px;
 	border: 1px solid #dbdbdb;
 	box-shadow: none;
+	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
 `;
 
 const EditSnippetButton = SnippetEditorButton.extend`
-	margin: 10px 0 0 9px;
+	margin: 10px 0 0 4px;
 	fill: ${ colors.$color_grey_dark };
+	padding-left: 8px;
 	
 	& svg {
 		margin-right: 7px;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -14,14 +14,17 @@ import { Button } from "../../Shared/components/Button";
 import SvgIcon from "../../Shared/components/SvgIcon";
 import { lengthAssessmentShape, replacementVariablesShape } from "../constants";
 import ModeSwitcher from "./ModeSwitcher";
+import colors from "../../../../style-guide/colors";
 
 const SnippetEditorButton = Button.extend`
+	height: 33px;
 	border: 1px solid #dbdbdb;
 	box-shadow: none;
 `;
 
 const EditSnippetButton = SnippetEditorButton.extend`
 	margin: 10px 0 0 9px;
+	fill: ${ colors.$color_grey_dark };
 	
 	& svg {
 		margin-right: 7px;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -62,7 +62,7 @@ function getCaretColor( props ) {
  */
 const InputContainer = styled.div.attrs( {
 } )`
-	padding: 5px;
+	padding: 3px;
 	border: 1px solid ${ ( props ) => props.isActive ? "#5b9dd9" : "#ddd" };
 	box-shadow: ${ ( props ) => props.isActive ? "0 0 2px rgba(30,140,190,.8);" : "inset 0 1px 2px rgba(0,0,0,.07)" };
 	background-color: #fff;
@@ -70,6 +70,8 @@ const InputContainer = styled.div.attrs( {
 	outline: 0;
 	transition: 50ms border-color ease-in-out;
 	position: relative;
+	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
+	font-size: 14px;
 	
 	&::before {
 		display: block;
@@ -94,6 +96,8 @@ const StyledEditor = styled.section`
 
 const SimulatedLabel = styled.div`
 	cursor: pointer;
+	font-size: 16px;
+	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
 `;
 
 class SnippetEditorFields extends React.Component {

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -72,6 +72,7 @@ const InputContainer = styled.div.attrs( {
 	position: relative;
 	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
 	font-size: 14px;
+	margin-top: 5px;
 	
 	&::before {
 		display: block;
@@ -91,7 +92,7 @@ const FormSection = styled.div`
 `;
 
 const StyledEditor = styled.section`
-	padding: 0 20px;
+	padding-top: 20px;
 `;
 
 const SimulatedLabel = styled.div`

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -77,7 +77,7 @@ const InputContainer = styled.div.attrs( {
 	&::before {
 		display: block;
 		position: absolute;
-		top: 4px;
+		top: -1px;
 		left: -25px;
 		width: 24px;
 		height: 24px;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -73,7 +73,6 @@ const InputContainer = styled.div.attrs( {
 	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
 	font-size: 14px;
 	margin-top: 5px;
-	height: ${ ( props ) => props.height ? props.height + "px;" : "auto;" }
 	
 	&::before {
 		display: block;
@@ -221,7 +220,7 @@ class SnippetEditorFields extends React.Component {
 						id={ this.uniqueId + "-title" }
 						onClick={ () => onFocus( "title" ) }
 					>{ intl.formatMessage( messages.seoTitle ) }</SimulatedLabel>
-					<InputContainer isActive={ activeField === "title" } isHovered={ hoveredField === "title" } height={ 25 }>
+					<InputContainer isActive={ activeField === "title" } isHovered={ hoveredField === "title" }>
 						<ReplacementVariableEditor
 							content={ title }
 							onChange={ content => onChange( "title", content ) }
@@ -243,7 +242,7 @@ class SnippetEditorFields extends React.Component {
 						id={ this.uniqueId + "-slug" }
 						onClick={ () => onFocus( "slug" ) }
 					>{ intl.formatMessage( messages.slug ) }</SimulatedLabel>
-					<InputContainer isActive={ activeField === "slug" } isHovered={ hoveredField === "slug" } height={ 25 }>
+					<InputContainer isActive={ activeField === "slug" } isHovered={ hoveredField === "slug" }>
 						<ReplacementVariableEditor
 							content={ slug }
 							onChange={ content => onChange( "slug", content ) }
@@ -259,7 +258,7 @@ class SnippetEditorFields extends React.Component {
 						id={ this.uniqueId + "-description" }
 						onClick={ () => onFocus( "description" ) }
 					>{ intl.formatMessage( messages.metaDescription ) }</SimulatedLabel>
-					<InputContainer isActive={ activeField === "description" } isHovered={ hoveredField === "description" } height={ 84 }>
+					<InputContainer isActive={ activeField === "description" } isHovered={ hoveredField === "description" }>
 						<ReplacementVariableEditor
 							content={ description }
 							onChange={ content => onChange( "description", content ) }

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -73,6 +73,7 @@ const InputContainer = styled.div.attrs( {
 	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
 	font-size: 14px;
 	margin-top: 5px;
+	height: ${ ( props ) => props.height ? props.height + "px;" : "auto;" }
 	
 	&::before {
 		display: block;
@@ -92,7 +93,7 @@ const FormSection = styled.div`
 `;
 
 const StyledEditor = styled.section`
-	padding-top: 20px;
+	padding: 20px 20px 0;
 `;
 
 const SimulatedLabel = styled.div`
@@ -220,7 +221,7 @@ class SnippetEditorFields extends React.Component {
 						id={ this.uniqueId + "-title" }
 						onClick={ () => onFocus( "title" ) }
 					>{ intl.formatMessage( messages.seoTitle ) }</SimulatedLabel>
-					<InputContainer isActive={ activeField === "title" } isHovered={ hoveredField === "title" }>
+					<InputContainer isActive={ activeField === "title" } isHovered={ hoveredField === "title" } height={ 25 }>
 						<ReplacementVariableEditor
 							content={ title }
 							onChange={ content => onChange( "title", content ) }
@@ -242,7 +243,7 @@ class SnippetEditorFields extends React.Component {
 						id={ this.uniqueId + "-slug" }
 						onClick={ () => onFocus( "slug" ) }
 					>{ intl.formatMessage( messages.slug ) }</SimulatedLabel>
-					<InputContainer isActive={ activeField === "slug" } isHovered={ hoveredField === "slug" }>
+					<InputContainer isActive={ activeField === "slug" } isHovered={ hoveredField === "slug" } height={ 25 }>
 						<ReplacementVariableEditor
 							content={ slug }
 							onChange={ content => onChange( "slug", content ) }
@@ -258,7 +259,7 @@ class SnippetEditorFields extends React.Component {
 						id={ this.uniqueId + "-description" }
 						onClick={ () => onFocus( "description" ) }
 					>{ intl.formatMessage( messages.metaDescription ) }</SimulatedLabel>
-					<InputContainer isActive={ activeField === "description" } isHovered={ hoveredField === "description" }>
+					<InputContainer isActive={ activeField === "description" } isHovered={ hoveredField === "description" } height={ 84 }>
 						<ReplacementVariableEditor
 							content={ description }
 							onChange={ content => onChange( "description", content ) }

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -62,7 +62,7 @@ function getCaretColor( props ) {
  */
 const InputContainer = styled.div.attrs( {
 } )`
-	padding: 3px;
+	padding: 3px 5px;
 	border: 1px solid ${ ( props ) => props.isActive ? "#5b9dd9" : "#ddd" };
 	box-shadow: ${ ( props ) => props.isActive ? "0 0 2px rgba(30,140,190,.8);" : "inset 0 1px 2px rgba(0,0,0,.07)" };
 	background-color: #fff;
@@ -87,12 +87,18 @@ const InputContainer = styled.div.attrs( {
 	}
 `;
 
+const InputContainerDescription = InputContainer.extend`
+	min-height: 60px;
+	padding: 2px 6px;
+	line-height: 19.6px;
+`;
+
 const FormSection = styled.div`
-	margin: 1em 0;
+	margin: 32px 0;
 `;
 
 const StyledEditor = styled.section`
-	padding: 20px 20px 0;
+	padding: 10px 20px 20px 20px;
 `;
 
 const SimulatedLabel = styled.div`
@@ -258,7 +264,7 @@ class SnippetEditorFields extends React.Component {
 						id={ this.uniqueId + "-description" }
 						onClick={ () => onFocus( "description" ) }
 					>{ intl.formatMessage( messages.metaDescription ) }</SimulatedLabel>
-					<InputContainer isActive={ activeField === "description" } isHovered={ hoveredField === "description" }>
+					<InputContainerDescription isActive={ activeField === "description" } isHovered={ hoveredField === "description" }>
 						<ReplacementVariableEditor
 							content={ description }
 							onChange={ content => onChange( "description", content ) }
@@ -267,7 +273,7 @@ class SnippetEditorFields extends React.Component {
 							ref={ ref => this.setRef( "description", ref ) }
 							ariaLabelledBy={ this.uniqueId + "-description" }
 						/>
-					</InputContainer>
+					</InputContainerDescription>
 
 					<ProgressBar
 						max={ descriptionLengthAssessment.max }

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -182,6 +182,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c19 {
@@ -205,6 +206,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c10 {
@@ -820,6 +822,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c19 {
@@ -843,6 +846,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c10 {
@@ -2139,6 +2143,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c19 {
@@ -2162,6 +2167,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c10 {
@@ -3458,6 +3464,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c19 {
@@ -3481,6 +3488,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c10 {
@@ -4777,6 +4785,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c19 {
@@ -4800,6 +4809,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c10 {
@@ -5984,6 +5994,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c19 {
@@ -6007,6 +6018,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c10 {
@@ -7039,6 +7051,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c19 {
@@ -7062,6 +7075,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c10 {
@@ -8390,6 +8404,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c19 {
@@ -8413,6 +8428,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c10 {
@@ -9678,6 +9694,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c19 {
@@ -9701,6 +9718,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c10 {
@@ -10123,6 +10141,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c19 {
@@ -10146,6 +10165,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c10 {
@@ -10707,6 +10727,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c20 {
@@ -10730,6 +10751,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c11 {
@@ -12045,6 +12067,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c20 {
@@ -12068,6 +12091,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c11 {
@@ -13385,6 +13409,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c19 {
@@ -13408,6 +13433,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c10 {
@@ -14704,6 +14730,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c19 {
@@ -14727,6 +14754,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c10 {
@@ -16042,6 +16070,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c19 {
@@ -16065,6 +16094,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c10 {
@@ -16491,6 +16521,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c19 {
@@ -16514,6 +16545,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
+  box-shadow: none;
 }
 
 .c10 {

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -6,7 +6,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -42,6 +42,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -49,6 +50,10 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -62,6 +67,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -182,9 +188,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
 
 .c20 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c20 svg {
@@ -516,7 +526,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -552,6 +562,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -559,6 +570,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -572,6 +587,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -589,7 +605,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -617,7 +633,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 .c25 {
-  padding: 5px;
+  padding: 3px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -626,6 +642,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   -webkit-transition: 50ms border-color ease-in-out;
   transition: 50ms border-color ease-in-out;
   position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
 }
 
 .c25::before {
@@ -645,11 +664,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 .c22 {
-  padding: 0 20px;
+  padding: 20px 20px 0;
 }
 
 .c24 {
   cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
 .c16 {
@@ -760,9 +781,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 
 .c20 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c20 svg {
@@ -771,8 +796,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 
 .c27 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-left: 20px;
 }
 
@@ -1768,7 +1795,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -1804,6 +1831,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -1811,6 +1839,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -1824,6 +1856,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -1841,7 +1874,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -1869,7 +1902,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 .c25 {
-  padding: 5px;
+  padding: 3px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -1878,6 +1911,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   -webkit-transition: 50ms border-color ease-in-out;
   transition: 50ms border-color ease-in-out;
   position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
 }
 
 .c25::before {
@@ -1897,11 +1933,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 .c22 {
-  padding: 0 20px;
+  padding: 20px 20px 0;
 }
 
 .c24 {
   cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
 .c16 {
@@ -2012,9 +2050,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 
 .c20 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c20 svg {
@@ -2023,8 +2065,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 
 .c27 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-left: 20px;
 }
 
@@ -3020,7 +3064,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -3056,6 +3100,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -3063,6 +3108,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -3076,6 +3125,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -3093,7 +3143,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -3121,7 +3171,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 .c25 {
-  padding: 5px;
+  padding: 3px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -3130,6 +3180,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   -webkit-transition: 50ms border-color ease-in-out;
   transition: 50ms border-color ease-in-out;
   position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
 }
 
 .c25::before {
@@ -3149,11 +3202,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 .c22 {
-  padding: 0 20px;
+  padding: 20px 20px 0;
 }
 
 .c24 {
   cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
 .c16 {
@@ -3264,9 +3319,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 
 .c20 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c20 svg {
@@ -3275,8 +3334,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 
 .c27 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-left: 20px;
 }
 
@@ -4272,7 +4333,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -4308,6 +4369,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -4315,6 +4377,10 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -4328,6 +4394,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -4345,7 +4412,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -4373,7 +4440,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 .c25 {
-  padding: 5px;
+  padding: 3px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -4382,6 +4449,9 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   -webkit-transition: 50ms border-color ease-in-out;
   transition: 50ms border-color ease-in-out;
   position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
 }
 
 .c25::before {
@@ -4401,11 +4471,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 .c22 {
-  padding: 0 20px;
+  padding: 20px 20px 0;
 }
 
 .c24 {
   cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
 .c16 {
@@ -4516,9 +4588,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 
 .c20 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c20 svg {
@@ -4527,8 +4603,10 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 
 .c27 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-left: 20px;
 }
 
@@ -5524,7 +5602,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -5560,6 +5638,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -5567,6 +5646,10 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -5580,6 +5663,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -5700,9 +5784,13 @@ exports[`SnippetEditor closes when calling close() 2`] = `
 
 .c20 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c20 svg {
@@ -6405,7 +6493,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -6441,6 +6529,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -6448,6 +6537,10 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -6461,6 +6554,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -6478,7 +6572,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -6510,7 +6604,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -6538,7 +6632,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c25 {
-  padding: 5px;
+  padding: 3px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -6547,6 +6641,9 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   -webkit-transition: 50ms border-color ease-in-out;
   transition: 50ms border-color ease-in-out;
   position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
 }
 
 .c25::before {
@@ -6566,11 +6663,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c22 {
-  padding: 0 20px;
+  padding: 20px 20px 0;
 }
 
 .c24 {
   cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
 .c16 {
@@ -6681,9 +6780,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 
 .c20 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c20 svg {
@@ -6692,8 +6795,10 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 
 .c28 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-left: 20px;
 }
 
@@ -7689,7 +7794,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -7725,6 +7830,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -7732,6 +7838,10 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -7745,6 +7855,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -7762,7 +7873,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -7794,7 +7905,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -7822,7 +7933,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c25 {
-  padding: 5px;
+  padding: 3px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -7831,6 +7942,9 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   -webkit-transition: 50ms border-color ease-in-out;
   transition: 50ms border-color ease-in-out;
   position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
 }
 
 .c25::before {
@@ -7850,11 +7964,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c22 {
-  padding: 0 20px;
+  padding: 20px 20px 0;
 }
 
 .c24 {
   cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
 .c16 {
@@ -7965,9 +8081,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 
 .c20 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c20 svg {
@@ -7976,8 +8096,10 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 
 .c28 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-left: 20px;
 }
 
@@ -9054,7 +9176,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -9090,6 +9212,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -9097,6 +9220,10 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -9110,6 +9237,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -9230,9 +9358,13 @@ exports[`SnippetEditor highlights a focused field 1`] = `
 
 .c20 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c20 svg {
@@ -9483,7 +9615,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -9519,6 +9651,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -9526,6 +9659,10 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -9539,6 +9676,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -9659,9 +9797,13 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
 
 .c20 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c20 svg {
@@ -9912,7 +10054,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -9948,6 +10090,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c7 {
@@ -9955,6 +10098,10 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c10 {
@@ -9968,6 +10115,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -9985,7 +10133,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -10013,7 +10161,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
 }
 
 .c26 {
-  padding: 5px;
+  padding: 3px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -10022,6 +10170,9 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   -webkit-transition: 50ms border-color ease-in-out;
   transition: 50ms border-color ease-in-out;
   position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
 }
 
 .c26::before {
@@ -10037,7 +10188,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
 }
 
 .c28 {
-  padding: 5px;
+  padding: 3px;
   border: 1px solid #5b9dd9;
   box-shadow: 0 0 2px rgba(30,140,190,.8);
   background-color: #fff;
@@ -10046,6 +10197,9 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   -webkit-transition: 50ms border-color ease-in-out;
   transition: 50ms border-color ease-in-out;
   position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
 }
 
 .c28::before {
@@ -10065,11 +10219,13 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
 }
 
 .c23 {
-  padding: 0 20px;
+  padding: 20px 20px 0;
 }
 
 .c25 {
   cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
 .c17 {
@@ -10180,9 +10336,13 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
 
 .c21 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c21 svg {
@@ -10191,8 +10351,10 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
 
 .c29 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-left: 20px;
 }
 
@@ -11207,7 +11369,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -11243,6 +11405,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -11250,6 +11413,10 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c10 {
@@ -11263,6 +11430,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -11280,7 +11448,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -11308,7 +11476,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 }
 
 .c26 {
-  padding: 5px;
+  padding: 3px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -11317,6 +11485,9 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   -webkit-transition: 50ms border-color ease-in-out;
   transition: 50ms border-color ease-in-out;
   position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
 }
 
 .c26::before {
@@ -11332,7 +11503,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 }
 
 .c28 {
-  padding: 5px;
+  padding: 3px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -11341,6 +11512,9 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   -webkit-transition: 50ms border-color ease-in-out;
   transition: 50ms border-color ease-in-out;
   position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
 }
 
 .c28::before {
@@ -11360,11 +11534,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 }
 
 .c23 {
-  padding: 0 20px;
+  padding: 20px 20px 0;
 }
 
 .c25 {
   cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
 .c17 {
@@ -11475,9 +11651,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 
 .c21 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c21 svg {
@@ -11486,8 +11666,10 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 
 .c29 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-left: 20px;
 }
 
@@ -12504,7 +12686,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -12540,6 +12722,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -12547,6 +12730,10 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -12560,6 +12747,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -12577,7 +12765,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -12605,7 +12793,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 .c25 {
-  padding: 5px;
+  padding: 3px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -12614,6 +12802,9 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   -webkit-transition: 50ms border-color ease-in-out;
   transition: 50ms border-color ease-in-out;
   position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
 }
 
 .c25::before {
@@ -12633,11 +12824,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 .c22 {
-  padding: 0 20px;
+  padding: 20px 20px 0;
 }
 
 .c24 {
   cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
 .c16 {
@@ -12748,9 +12941,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 
 .c20 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c20 svg {
@@ -12759,8 +12956,10 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 
 .c27 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-left: 20px;
 }
 
@@ -13756,7 +13955,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -13792,6 +13991,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -13799,6 +13999,10 @@ exports[`SnippetEditor passes replacement variables to the title and description
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -13812,6 +14016,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -13829,7 +14034,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -13857,7 +14062,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 .c25 {
-  padding: 5px;
+  padding: 3px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -13866,6 +14071,9 @@ exports[`SnippetEditor passes replacement variables to the title and description
   -webkit-transition: 50ms border-color ease-in-out;
   transition: 50ms border-color ease-in-out;
   position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
 }
 
 .c25::before {
@@ -13885,11 +14093,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 .c22 {
-  padding: 0 20px;
+  padding: 20px 20px 0;
 }
 
 .c24 {
   cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
 .c16 {
@@ -14000,9 +14210,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
 
 .c20 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c20 svg {
@@ -14011,8 +14225,10 @@ exports[`SnippetEditor passes replacement variables to the title and description
 
 .c27 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-left: 20px;
 }
 
@@ -15191,6 +15407,10 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -15272,9 +15492,13 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
 
 .c20 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c20 svg {
@@ -15575,7 +15799,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -15611,6 +15835,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -15618,6 +15843,10 @@ exports[`SnippetEditor shows and editor 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -15631,6 +15860,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -15751,9 +15981,13 @@ exports[`SnippetEditor shows and editor 1`] = `
 
 .c20 {
   font-size: 0.8rem;
+  height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin: 10px 0 0 9px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
 }
 
 .c20 svg {

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -9,6 +9,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -50,7 +51,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -61,17 +62,18 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
@@ -80,55 +82,36 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   margin: 0;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -157,14 +140,51 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c21 {
   font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c21 svg {
+  margin-right: 7px;
+}
+
+.c11 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c11:hover,
+.c11:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c19 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -178,27 +198,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
+  background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c20 svg {
-  margin-right: 7px;
 }
 
 .c10 {
@@ -211,7 +217,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -219,7 +225,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -227,7 +233,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -236,7 +242,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -343,13 +349,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   >
     <button
       aria-pressed={true}
-      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c17"
+        className="yoast-svg-icon yoast-svg-icon-mobile c18"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -378,13 +384,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c19"
+        className="yoast-svg-icon yoast-svg-icon-desktop c20"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -414,13 +420,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+    className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
     onClick={[Function]}
     type="button"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c21"
+      className="yoast-svg-icon yoast-svg-icon-edit c22"
       fill={undefined}
       focusable="false"
       role="img"
@@ -529,6 +535,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -570,7 +577,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -581,17 +588,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
@@ -600,7 +608,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   margin: 0;
 }
 
-.c26 {
+.c27 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -613,27 +621,27 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border: 1px solid #ddd;
 }
 
-.c26::-webkit-progress-bar {
+.c27::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c26::-webkit-progress-value {
+.c27::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c26::-moz-progress-bar {
+.c27::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c26::-ms-fill {
+.c27::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
 
-.c25 {
-  padding: 3px;
+.c26 {
+  padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -647,7 +655,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   margin-top: 5px;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -659,69 +667,80 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   content: "";
 }
 
-.c23 {
-  margin: 1em 0;
+.c28 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
 }
 
-.c22 {
-  padding: 20px 20px 0;
+.c28::before {
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
 }
 
 .c24 {
+  margin: 32px 0;
+}
+
+.c23 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c25 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -750,14 +769,60 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c21 {
   font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c21 svg {
+  margin-right: 7px;
+}
+
+.c29 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c11 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c11:hover,
+.c11:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c19 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -771,36 +836,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
+  background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c20 svg {
-  margin-right: 7px;
-}
-
-.c27 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
 }
 
 .c10 {
@@ -813,7 +855,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -821,7 +863,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -829,7 +871,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -838,7 +880,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -1114,28 +1156,23 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
         <div
           className="c10"
         >
-          <Button
+          <ModeSwitcher__SwitcherButton
             aria-pressed={true}
             isActive={true}
             onClick={[Function]}
           >
             <Button
               aria-pressed={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
               className="c11"
               isActive={true}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c11 c12"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -1146,7 +1183,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c11 c12 Button-kDSBcD c13"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -1157,47 +1194,48 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={true}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={true}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="mobile"
-                          size="22px"
+                        <button
+                          aria-pressed={true}
+                          className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-mobile"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
                             size="22px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -1205,68 +1243,74 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Mobile preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c18"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Mobile preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Mobile preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
-          <Button
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
             aria-pressed={false}
             isActive={false}
             onClick={[Function]}
           >
             <Button
               aria-pressed={false}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={false}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 c12"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -1277,7 +1321,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 c12 Button-kDSBcD c13"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -1288,47 +1332,48 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={false}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={false}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="desktop"
-                          size="18px"
+                        <button
+                          aria-pressed={false}
+                          className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-desktop"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
                             size="18px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -1336,46 +1381,57 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Desktop preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c20"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Desktop preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Desktop preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
+          </ModeSwitcher__SwitcherButton>
         </div>
       </ModeSwitcher__Switcher>
     </ModeSwitcher>
@@ -1389,7 +1445,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -1400,7 +1456,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -1411,7 +1467,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -1422,7 +1478,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -1433,7 +1489,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -1441,7 +1497,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -1460,7 +1516,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -1572,18 +1628,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-title"
                     onClick={[Function]}
                   >
@@ -1595,7 +1651,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-title"
@@ -1618,7 +1674,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={600}
                     value={0}
                   />
@@ -1627,14 +1683,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-slug"
                     onClick={[Function]}
                   >
@@ -1646,7 +1702,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-slug"
@@ -1663,14 +1719,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-description"
                     onClick={[Function]}
                   >
@@ -1682,7 +1738,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c28"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-description"
@@ -1705,7 +1761,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={320}
                     value={0}
                   />
@@ -1723,7 +1779,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c27"
+        className="c29"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -1732,7 +1788,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c12"
+          className="c29 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -1741,7 +1797,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c29 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -1750,7 +1806,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -1759,13 +1815,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -1798,6 +1854,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -1839,7 +1896,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -1850,17 +1907,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
@@ -1869,7 +1927,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   margin: 0;
 }
 
-.c26 {
+.c27 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -1882,27 +1940,27 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border: 1px solid #ddd;
 }
 
-.c26::-webkit-progress-bar {
+.c27::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c26::-webkit-progress-value {
+.c27::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c26::-moz-progress-bar {
+.c27::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c26::-ms-fill {
+.c27::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
 
-.c25 {
-  padding: 3px;
+.c26 {
+  padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -1916,7 +1974,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   margin-top: 5px;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -1928,69 +1986,80 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   content: "";
 }
 
-.c23 {
-  margin: 1em 0;
+.c28 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
 }
 
-.c22 {
-  padding: 20px 20px 0;
+.c28::before {
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
 }
 
 .c24 {
+  margin: 32px 0;
+}
+
+.c23 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c25 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2019,14 +2088,60 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c21 {
   font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c21 svg {
+  margin-right: 7px;
+}
+
+.c29 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c11 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c11:hover,
+.c11:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c19 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -2040,36 +2155,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
+  background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c20 svg {
-  margin-right: 7px;
-}
-
-.c27 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
 }
 
 .c10 {
@@ -2082,7 +2174,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -2090,7 +2182,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -2098,7 +2190,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -2107,7 +2199,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -2383,28 +2475,23 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
         <div
           className="c10"
         >
-          <Button
+          <ModeSwitcher__SwitcherButton
             aria-pressed={true}
             isActive={true}
             onClick={[Function]}
           >
             <Button
               aria-pressed={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
               className="c11"
               isActive={true}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c11 c12"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -2415,7 +2502,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c11 c12 Button-kDSBcD c13"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -2426,47 +2513,48 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={true}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={true}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="mobile"
-                          size="22px"
+                        <button
+                          aria-pressed={true}
+                          className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-mobile"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
                             size="22px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -2474,68 +2562,74 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Mobile preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c18"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Mobile preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Mobile preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
-          <Button
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
             aria-pressed={false}
             isActive={false}
             onClick={[Function]}
           >
             <Button
               aria-pressed={false}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={false}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 c12"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -2546,7 +2640,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 c12 Button-kDSBcD c13"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -2557,47 +2651,48 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={false}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={false}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="desktop"
-                          size="18px"
+                        <button
+                          aria-pressed={false}
+                          className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-desktop"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
                             size="18px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -2605,46 +2700,57 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Desktop preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c20"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Desktop preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Desktop preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
+          </ModeSwitcher__SwitcherButton>
         </div>
       </ModeSwitcher__Switcher>
     </ModeSwitcher>
@@ -2658,7 +2764,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -2669,7 +2775,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -2680,7 +2786,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -2691,7 +2797,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -2702,7 +2808,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -2710,7 +2816,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -2729,7 +2835,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -2841,18 +2947,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-title"
                     onClick={[Function]}
                   >
@@ -2864,7 +2970,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-title"
@@ -2887,7 +2993,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={600}
                     value={0}
                   />
@@ -2896,14 +3002,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-slug"
                     onClick={[Function]}
                   >
@@ -2915,7 +3021,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-slug"
@@ -2932,14 +3038,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-description"
                     onClick={[Function]}
                   >
@@ -2951,7 +3057,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c28"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-description"
@@ -2974,7 +3080,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={320}
                     value={0}
                   />
@@ -2992,7 +3098,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c27"
+        className="c29"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -3001,7 +3107,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c12"
+          className="c29 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -3010,7 +3116,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c29 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -3019,7 +3125,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -3028,13 +3134,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -3067,6 +3173,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -3108,7 +3215,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -3119,17 +3226,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
@@ -3138,7 +3246,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   margin: 0;
 }
 
-.c26 {
+.c27 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -3151,27 +3259,27 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border: 1px solid #ddd;
 }
 
-.c26::-webkit-progress-bar {
+.c27::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c26::-webkit-progress-value {
+.c27::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c26::-moz-progress-bar {
+.c27::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c26::-ms-fill {
+.c27::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
 
-.c25 {
-  padding: 3px;
+.c26 {
+  padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -3185,7 +3293,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   margin-top: 5px;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -3197,69 +3305,80 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   content: "";
 }
 
-.c23 {
-  margin: 1em 0;
+.c28 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
 }
 
-.c22 {
-  padding: 20px 20px 0;
+.c28::before {
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
 }
 
 .c24 {
+  margin: 32px 0;
+}
+
+.c23 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c25 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3288,14 +3407,60 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c21 {
   font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c21 svg {
+  margin-right: 7px;
+}
+
+.c29 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c11 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c11:hover,
+.c11:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c19 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -3309,36 +3474,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
+  background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c20 svg {
-  margin-right: 7px;
-}
-
-.c27 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
 }
 
 .c10 {
@@ -3351,7 +3493,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -3359,7 +3501,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -3367,7 +3509,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -3376,7 +3518,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -3652,28 +3794,23 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
         <div
           className="c10"
         >
-          <Button
+          <ModeSwitcher__SwitcherButton
             aria-pressed={true}
             isActive={true}
             onClick={[Function]}
           >
             <Button
               aria-pressed={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
               className="c11"
               isActive={true}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c11 c12"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -3684,7 +3821,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c11 c12 Button-kDSBcD c13"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -3695,47 +3832,48 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={true}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={true}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="mobile"
-                          size="22px"
+                        <button
+                          aria-pressed={true}
+                          className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-mobile"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
                             size="22px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -3743,68 +3881,74 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Mobile preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c18"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Mobile preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Mobile preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
-          <Button
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
             aria-pressed={false}
             isActive={false}
             onClick={[Function]}
           >
             <Button
               aria-pressed={false}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={false}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 c12"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -3815,7 +3959,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 c12 Button-kDSBcD c13"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -3826,47 +3970,48 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={false}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={false}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="desktop"
-                          size="18px"
+                        <button
+                          aria-pressed={false}
+                          className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-desktop"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
                             size="18px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -3874,46 +4019,57 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Desktop preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c20"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Desktop preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Desktop preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
+          </ModeSwitcher__SwitcherButton>
         </div>
       </ModeSwitcher__Switcher>
     </ModeSwitcher>
@@ -3927,7 +4083,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -3938,7 +4094,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -3949,7 +4105,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -3960,7 +4116,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -3971,7 +4127,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -3979,7 +4135,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -3998,7 +4154,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -4110,18 +4266,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-title"
                     onClick={[Function]}
                   >
@@ -4133,7 +4289,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-title"
@@ -4156,7 +4312,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={600}
                     value={0}
                   />
@@ -4165,14 +4321,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-slug"
                     onClick={[Function]}
                   >
@@ -4184,7 +4340,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-slug"
@@ -4201,14 +4357,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-description"
                     onClick={[Function]}
                   >
@@ -4220,7 +4376,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c28"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-description"
@@ -4243,7 +4399,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={320}
                     value={0}
                   />
@@ -4261,7 +4417,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c27"
+        className="c29"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -4270,7 +4426,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c12"
+          className="c29 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -4279,7 +4435,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c29 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -4288,7 +4444,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -4297,13 +4453,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -4336,6 +4492,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -4377,7 +4534,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -4388,17 +4545,18 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
@@ -4407,7 +4565,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   margin: 0;
 }
 
-.c26 {
+.c27 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -4420,27 +4578,27 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border: 1px solid #ddd;
 }
 
-.c26::-webkit-progress-bar {
+.c27::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c26::-webkit-progress-value {
+.c27::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c26::-moz-progress-bar {
+.c27::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c26::-ms-fill {
+.c27::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
 
-.c25 {
-  padding: 3px;
+.c26 {
+  padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -4454,7 +4612,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   margin-top: 5px;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -4466,69 +4624,80 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   content: "";
 }
 
-.c23 {
-  margin: 1em 0;
+.c28 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
 }
 
-.c22 {
-  padding: 20px 20px 0;
+.c28::before {
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
 }
 
 .c24 {
+  margin: 32px 0;
+}
+
+.c23 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c25 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -4557,14 +4726,60 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c21 {
   font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c21 svg {
+  margin-right: 7px;
+}
+
+.c29 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c11 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c11:hover,
+.c11:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c19 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -4578,36 +4793,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
+  background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c20 svg {
-  margin-right: 7px;
-}
-
-.c27 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
 }
 
 .c10 {
@@ -4620,7 +4812,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -4628,7 +4820,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -4636,7 +4828,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -4645,7 +4837,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -4921,28 +5113,23 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         <div
           className="c10"
         >
-          <Button
+          <ModeSwitcher__SwitcherButton
             aria-pressed={true}
             isActive={true}
             onClick={[Function]}
           >
             <Button
               aria-pressed={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
               className="c11"
               isActive={true}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c11 c12"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -4953,7 +5140,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c11 c12 Button-kDSBcD c13"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -4964,47 +5151,48 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={true}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={true}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="mobile"
-                          size="22px"
+                        <button
+                          aria-pressed={true}
+                          className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-mobile"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
                             size="22px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -5012,68 +5200,74 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Mobile preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c18"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Mobile preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Mobile preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
-          <Button
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
             aria-pressed={false}
             isActive={false}
             onClick={[Function]}
           >
             <Button
               aria-pressed={false}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={false}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 c12"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -5084,7 +5278,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 c12 Button-kDSBcD c13"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -5095,47 +5289,48 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={false}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={false}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="desktop"
-                          size="18px"
+                        <button
+                          aria-pressed={false}
+                          className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-desktop"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
                             size="18px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -5143,46 +5338,57 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Desktop preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c20"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Desktop preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Desktop preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
+          </ModeSwitcher__SwitcherButton>
         </div>
       </ModeSwitcher__Switcher>
     </ModeSwitcher>
@@ -5196,7 +5402,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -5207,7 +5413,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -5218,7 +5424,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -5229,7 +5435,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -5240,7 +5446,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -5248,7 +5454,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -5267,7 +5473,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -5379,18 +5585,18 @@ exports[`SnippetEditor closes when calling close() 1`] = `
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-2-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-2-title"
                     onClick={[Function]}
                   >
@@ -5402,7 +5608,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-2-title"
@@ -5425,7 +5631,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={600}
                     value={0}
                   />
@@ -5434,14 +5640,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-2-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-2-slug"
                     onClick={[Function]}
                   >
@@ -5453,7 +5659,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-2-slug"
@@ -5470,14 +5676,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-2-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-2-description"
                     onClick={[Function]}
                   >
@@ -5489,7 +5695,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c28"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-2-description"
@@ -5512,7 +5718,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={320}
                     value={0}
                   />
@@ -5530,7 +5736,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c27"
+        className="c29"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -5539,7 +5745,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c12"
+          className="c29 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -5548,7 +5754,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c29 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -5557,7 +5763,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -5566,13 +5772,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -5605,6 +5811,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -5646,7 +5853,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -5657,17 +5864,18 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
@@ -5676,55 +5884,36 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   margin: 0;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -5753,14 +5942,51 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c21 {
   font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c21 svg {
+  margin-right: 7px;
+}
+
+.c11 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c11:hover,
+.c11:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c19 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -5774,27 +6000,13 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
+  background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c20 svg {
-  margin-right: 7px;
 }
 
 .c10 {
@@ -5807,7 +6019,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -5815,7 +6027,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -5823,7 +6035,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -5832,7 +6044,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -6108,28 +6320,23 @@ exports[`SnippetEditor closes when calling close() 2`] = `
         <div
           className="c10"
         >
-          <Button
+          <ModeSwitcher__SwitcherButton
             aria-pressed={true}
             isActive={true}
             onClick={[Function]}
           >
             <Button
               aria-pressed={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
               className="c11"
               isActive={true}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c11 c12"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -6140,7 +6347,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c11 c12 Button-kDSBcD c13"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -6151,47 +6358,48 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={true}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={true}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="mobile"
-                          size="22px"
+                        <button
+                          aria-pressed={true}
+                          className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-mobile"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
                             size="22px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -6199,68 +6407,74 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Mobile preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c18"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Mobile preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Mobile preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
-          <Button
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
             aria-pressed={false}
             isActive={false}
             onClick={[Function]}
           >
             <Button
               aria-pressed={false}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={false}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 c12"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -6271,7 +6485,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 c12 Button-kDSBcD c13"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -6282,47 +6496,48 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={false}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={false}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="desktop"
-                          size="18px"
+                        <button
+                          aria-pressed={false}
+                          className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-desktop"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
                             size="18px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -6330,46 +6545,57 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Desktop preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c20"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Desktop preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Desktop preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
+          </ModeSwitcher__SwitcherButton>
         </div>
       </ModeSwitcher__Switcher>
     </ModeSwitcher>
@@ -6383,7 +6609,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -6394,7 +6620,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -6405,7 +6631,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -6416,7 +6642,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -6427,7 +6653,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -6435,7 +6661,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
               >
                 <button
                   aria-expanded={false}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -6454,7 +6680,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -6496,6 +6722,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -6537,7 +6764,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -6548,23 +6775,56 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c29::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
 }
 
 .c27 {
@@ -6585,54 +6845,22 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c27::-webkit-progress-value {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c27::-moz-progress-bar {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
 }
 
 .c27::-ms-fill {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   border: 0;
 }
 
 .c26 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c26::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c26::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c26::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c26::-ms-fill {
-  background-color: #ee7c1b;
-  border: 0;
-}
-
-.c25 {
-  padding: 3px;
+  padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -6646,7 +6874,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   margin-top: 5px;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -6658,69 +6886,80 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   content: "";
 }
 
-.c23 {
-  margin: 1em 0;
+.c28 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
 }
 
-.c22 {
-  padding: 20px 20px 0;
+.c28::before {
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
 }
 
 .c24 {
+  margin: 32px 0;
+}
+
+.c23 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c25 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -6749,14 +6988,60 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c21 {
   font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c21 svg {
+  margin-right: 7px;
+}
+
+.c30 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c11 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c11:hover,
+.c11:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c19 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -6770,36 +7055,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
+  background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c20 svg {
-  margin-right: 7px;
-}
-
-.c28 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
 }
 
 .c10 {
@@ -6812,7 +7074,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -6820,7 +7082,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -6828,7 +7090,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -6837,7 +7099,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -7113,28 +7375,23 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         <div
           className="c10"
         >
-          <Button
+          <ModeSwitcher__SwitcherButton
             aria-pressed={true}
             isActive={true}
             onClick={[Function]}
           >
             <Button
               aria-pressed={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
               className="c11"
               isActive={true}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c11 c12"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -7145,7 +7402,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c11 c12 Button-kDSBcD c13"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -7156,47 +7413,48 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={true}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={true}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="mobile"
-                          size="22px"
+                        <button
+                          aria-pressed={true}
+                          className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-mobile"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
                             size="22px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -7204,68 +7462,74 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Mobile preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c18"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Mobile preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Mobile preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
-          <Button
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
             aria-pressed={false}
             isActive={false}
             onClick={[Function]}
           >
             <Button
               aria-pressed={false}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={false}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 c12"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -7276,7 +7540,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 c12 Button-kDSBcD c13"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -7287,47 +7551,48 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={false}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={false}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="desktop"
-                          size="18px"
+                        <button
+                          aria-pressed={false}
+                          className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-desktop"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
                             size="18px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -7335,46 +7600,57 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Desktop preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c20"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Desktop preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Desktop preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
+          </ModeSwitcher__SwitcherButton>
         </div>
       </ModeSwitcher__Switcher>
     </ModeSwitcher>
@@ -7388,7 +7664,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -7399,7 +7675,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -7410,7 +7686,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -7421,7 +7697,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -7432,7 +7708,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -7440,7 +7716,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -7459,7 +7735,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -7571,18 +7847,18 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-8-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-8-title"
                     onClick={[Function]}
                   >
@@ -7594,7 +7870,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-8-title"
@@ -7617,7 +7893,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={550}
                     value={361}
                   />
@@ -7626,14 +7902,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-8-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-8-slug"
                     onClick={[Function]}
                   >
@@ -7645,7 +7921,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-8-slug"
@@ -7662,14 +7938,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-8-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-8-description"
                     onClick={[Function]}
                   >
@@ -7681,7 +7957,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c28"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-8-description"
@@ -7704,7 +7980,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c27"
+                    className="c29"
                     max={320}
                     value={0}
                   />
@@ -7722,7 +7998,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c28"
+        className="c30"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -7731,7 +8007,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c28 Button-kDSBcD c12"
+          className="c30 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -7740,7 +8016,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c28 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c30 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -7749,7 +8025,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c28 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c30 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -7758,13 +8034,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c28 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c30 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c28 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c30 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -7797,6 +8073,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -7838,7 +8115,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -7849,55 +8126,24 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c26 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c26::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c26::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c26::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c26::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
 }
 
 .c27 {
@@ -7918,22 +8164,54 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c27::-webkit-progress-value {
-  background-color: #7ad03a;
+  background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c27::-moz-progress-bar {
-  background-color: #7ad03a;
+  background-color: #dc3232;
 }
 
 .c27::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #7ad03a;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #7ad03a;
+}
+
+.c29::-ms-fill {
   background-color: #7ad03a;
   border: 0;
 }
 
-.c25 {
-  padding: 3px;
+.c26 {
+  padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -7947,7 +8225,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   margin-top: 5px;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -7959,69 +8237,80 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   content: "";
 }
 
-.c23 {
-  margin: 1em 0;
+.c28 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
 }
 
-.c22 {
-  padding: 20px 20px 0;
+.c28::before {
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
 }
 
 .c24 {
+  margin: 32px 0;
+}
+
+.c23 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c25 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -8050,14 +8339,60 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c21 {
   font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c21 svg {
+  margin-right: 7px;
+}
+
+.c30 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c11 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c11:hover,
+.c11:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c19 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -8071,36 +8406,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
+  background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c20 svg {
-  margin-right: 7px;
-}
-
-.c28 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
 }
 
 .c10 {
@@ -8113,7 +8425,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -8121,7 +8433,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -8129,7 +8441,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -8138,7 +8450,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -8414,28 +8726,23 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         <div
           className="c10"
         >
-          <Button
+          <ModeSwitcher__SwitcherButton
             aria-pressed={true}
             isActive={true}
             onClick={[Function]}
           >
             <Button
               aria-pressed={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
               className="c11"
               isActive={true}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c11 c12"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -8446,7 +8753,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c11 c12 Button-kDSBcD c13"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -8457,47 +8764,48 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={true}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={true}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="mobile"
-                          size="22px"
+                        <button
+                          aria-pressed={true}
+                          className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-mobile"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
                             size="22px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -8505,68 +8813,74 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Mobile preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c18"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Mobile preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Mobile preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
-          <Button
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
             aria-pressed={false}
             isActive={false}
             onClick={[Function]}
           >
             <Button
               aria-pressed={false}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={false}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 c12"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -8577,7 +8891,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 c12 Button-kDSBcD c13"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -8588,47 +8902,48 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={false}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={false}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="desktop"
-                          size="18px"
+                        <button
+                          aria-pressed={false}
+                          className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-desktop"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
                             size="18px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -8636,46 +8951,57 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Desktop preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c20"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Desktop preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Desktop preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
+          </ModeSwitcher__SwitcherButton>
         </div>
       </ModeSwitcher__Switcher>
     </ModeSwitcher>
@@ -8689,7 +9015,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -8700,7 +9026,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -8711,7 +9037,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -8722,7 +9048,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -8733,7 +9059,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -8741,7 +9067,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -8760,7 +9086,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -8872,18 +9198,18 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-7-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-7-title"
                     onClick={[Function]}
                   >
@@ -8895,7 +9221,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-7-title"
@@ -8918,7 +9244,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={550}
                     value={100}
                   />
@@ -8927,14 +9253,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-7-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-7-slug"
                     onClick={[Function]}
                   >
@@ -8946,7 +9272,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-7-slug"
@@ -8963,14 +9289,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-7-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-7-description"
                     onClick={[Function]}
                   >
@@ -8982,7 +9308,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c28"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-7-description"
@@ -9005,7 +9331,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 >
                   <progress
                     aria-hidden="true"
-                    className="c27"
+                    className="c29"
                     max={650}
                     value={330}
                   />
@@ -9023,7 +9349,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c28"
+        className="c30"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -9032,7 +9358,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c28 Button-kDSBcD c12"
+          className="c30 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -9041,7 +9367,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c28 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c30 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -9050,7 +9376,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c28 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c30 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -9059,13 +9385,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c28 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c30 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c28 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c30 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -9179,6 +9505,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -9220,7 +9547,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -9231,1001 +9558,24 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c16 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c11 {
-  font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c13:hover {
-  color: #000;
-}
-
-.c14::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c14:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c15 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c15 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c18 {
-  font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c18:hover,
-.c18:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c20 svg {
-  margin-right: 7px;
-}
-
-.c10 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c17 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c19 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<div>
-  <section>
-    <div
-      className="c0"
-      onMouseLeave={undefined}
-      width={640}
-    >
-      <div
-        className="c1"
-      >
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          SEO title preview:
-        </span>
-        <div
-          className="c2"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          <div
-            className="c3 c4"
-          >
-            <span
-              className="c5"
-            >
-              Test title
-            </span>
-          </div>
-        </div>
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Url preview:
-        </span>
-        <div
-          className="c6"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          example.org › test-slug
-        </div>
-      </div>
-      <hr
-        className="c7"
-      />
-      <div
-        className="c1"
-      >
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Meta description preview:
-        </span>
-        <div
-          className="c8 c9"
-          color="#545454"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          Test description, %%replacement_variable%%
-        </div>
-      </div>
-    </div>
-  </section>
-  <div
-    className="c10"
-  >
-    <button
-      aria-pressed={true}
-      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-      onClick={[Function]}
-      type="button"
-    >
-      <svg
-        aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c17"
-        fill="currentColor"
-        focusable="false"
-        role="img"
-        size="22px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-        />
-      </svg>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Mobile preview
-      </span>
-    </button>
-    <button
-      aria-pressed={false}
-      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-      onClick={[Function]}
-      type="button"
-    >
-      <svg
-        aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c19"
-        fill="currentColor"
-        focusable="false"
-        role="img"
-        size="18px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-        />
-      </svg>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Desktop preview
-      </span>
-    </button>
-  </div>
-  <button
-    aria-expanded={false}
-    className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-    onClick={[Function]}
-    type="button"
-  >
-    <svg
-      aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c21"
-      fill={undefined}
-      focusable="false"
-      role="img"
-      size="16px"
-      viewBox="0 0 1792 1792"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-      />
-    </svg>
-    <span>
-      Edit snippet
-    </span>
-  </button>
-</div>
-`;
-
-exports[`SnippetEditor highlights a hovered field 1`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 16px;
-}
-
-.c6 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-  width: 100%;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.c9 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-}
-
-.c8 {
-  line-height: 1em;
-  max-height: 4em;
-  overflow: hidden;
-  font-size: 14px;
-}
-
-.c1 {
-  padding: 16px;
-}
-
-.c7 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
-}
-
-.c16 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c11 {
-  font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c13:hover {
-  color: #000;
-}
-
-.c14::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c14:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c15 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c15 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c18 {
-  font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c18:hover,
-.c18:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c20 svg {
-  margin-right: 7px;
-}
-
-.c10 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c17 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c19 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<div>
-  <section>
-    <div
-      className="c0"
-      onMouseLeave={undefined}
-      width={640}
-    >
-      <div
-        className="c1"
-      >
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          SEO title preview:
-        </span>
-        <div
-          className="c2"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          <div
-            className="c3 c4"
-          >
-            <span
-              className="c5"
-            >
-              Test title
-            </span>
-          </div>
-        </div>
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Url preview:
-        </span>
-        <div
-          className="c6"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          example.org › test-slug
-        </div>
-      </div>
-      <hr
-        className="c7"
-      />
-      <div
-        className="c1"
-      >
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Meta description preview:
-        </span>
-        <div
-          className="c8 c9"
-          color="#545454"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          Test description, %%replacement_variable%%
-        </div>
-      </div>
-    </div>
-  </section>
-  <div
-    className="c10"
-  >
-    <button
-      aria-pressed={true}
-      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-      onClick={[Function]}
-      type="button"
-    >
-      <svg
-        aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c17"
-        fill="currentColor"
-        focusable="false"
-        role="img"
-        size="22px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-        />
-      </svg>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Mobile preview
-      </span>
-    </button>
-    <button
-      aria-pressed={false}
-      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-      onClick={[Function]}
-      type="button"
-    >
-      <svg
-        aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c19"
-        fill="currentColor"
-        focusable="false"
-        role="img"
-        size="18px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-        />
-      </svg>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Desktop preview
-      </span>
-    </button>
-  </div>
-  <button
-    aria-expanded={false}
-    className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-    onClick={[Function]}
-    type="button"
-  >
-    <svg
-      aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c21"
-      fill={undefined}
-      focusable="false"
-      role="img"
-      size="16px"
-      viewBox="0 0 1792 1792"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-      />
-    </svg>
-    <span>
-      Edit snippet
-    </span>
-  </button>
-</div>
-`;
-
-exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 16px;
-}
-
-.c7 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-  width: 100%;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.c10 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-}
-
-.c9 {
-  line-height: 1em;
-  max-height: 4em;
-  overflow: hidden;
-  font-size: 14px;
-}
-
-.c1 {
-  padding: 16px;
-}
-
-.c8 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
-}
-
-.c27 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c27::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c27::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c27::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c27::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c26 {
-  padding: 3px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-}
-
-.c26::before {
-  display: block;
-  position: absolute;
-  top: 4px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c28 {
-  padding: 3px;
-  border: 1px solid #5b9dd9;
-  box-shadow: 0 0 2px rgba(30,140,190,.8);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-}
-
-.c28::before {
-  display: block;
-  position: absolute;
-  top: 4px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#1e8cbe%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c24 {
-  margin: 1em 0;
-}
-
-.c23 {
-  padding: 20px 20px 0;
-}
-
-.c25 {
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
 .c17 {
@@ -10237,25 +9587,6 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
 
 .c12 {
   font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c12:hover,
-.c12:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
 }
 
 .c13:active {
@@ -10311,29 +9642,6 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   align-self: center;
 }
 
-.c19 {
-  font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c19:hover,
-.c19:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
 .c21 {
   font-size: 0.8rem;
   height: 33px;
@@ -10349,16 +9657,53 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   margin-right: 7px;
 }
 
-.c29 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
+.c11 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
 }
 
-.c11 {
+.c11:hover,
+.c11:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c19 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c19:hover,
+.c19:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c10 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -10392,6 +9737,1035 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   flex: none;
 }
 
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c16::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<div>
+  <section>
+    <div
+      className="c0"
+      onMouseLeave={undefined}
+      width={640}
+    >
+      <div
+        className="c1"
+      >
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          SEO title preview:
+        </span>
+        <div
+          className="c2"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          <div
+            className="c3 c4"
+          >
+            <span
+              className="c5"
+            >
+              Test title
+            </span>
+          </div>
+        </div>
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          Url preview:
+        </span>
+        <div
+          className="c6"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          example.org › test-slug
+        </div>
+      </div>
+      <hr
+        className="c7"
+      />
+      <div
+        className="c1"
+      >
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          Meta description preview:
+        </span>
+        <div
+          className="c8 c9"
+          color="#545454"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          Test description, %%replacement_variable%%
+        </div>
+      </div>
+    </div>
+  </section>
+  <div
+    className="c10"
+  >
+    <button
+      aria-pressed={true}
+      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-mobile c18"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="22px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Mobile preview
+      </span>
+    </button>
+    <button
+      aria-pressed={false}
+      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-desktop c20"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="18px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Desktop preview
+      </span>
+    </button>
+  </div>
+  <button
+    aria-expanded={false}
+    className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      aria-hidden={true}
+      className="yoast-svg-icon yoast-svg-icon-edit c22"
+      fill={undefined}
+      focusable="false"
+      role="img"
+      size="16px"
+      viewBox="0 0 1792 1792"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+      />
+    </svg>
+    <span>
+      Edit snippet
+    </span>
+  </button>
+</div>
+`;
+
+exports[`SnippetEditor highlights a hovered field 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+}
+
+.c6 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c9 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+  font-size: 13px;
+}
+
+.c8 {
+  max-height: 4em;
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c1 {
+  padding: 8px 16px;
+}
+
+.c7 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c17 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c12 {
+  font-size: 0.8rem;
+}
+
+.c13:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c14:hover {
+  color: #000;
+}
+
+.c15::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c15:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c16 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c16 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c21 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c21 svg {
+  margin-right: 7px;
+}
+
+.c11 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c11:hover,
+.c11:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c19 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c19:hover,
+.c19:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c10 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c18 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c20 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c22 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c16::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<div>
+  <section>
+    <div
+      className="c0"
+      onMouseLeave={undefined}
+      width={640}
+    >
+      <div
+        className="c1"
+      >
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          SEO title preview:
+        </span>
+        <div
+          className="c2"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          <div
+            className="c3 c4"
+          >
+            <span
+              className="c5"
+            >
+              Test title
+            </span>
+          </div>
+        </div>
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          Url preview:
+        </span>
+        <div
+          className="c6"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          example.org › test-slug
+        </div>
+      </div>
+      <hr
+        className="c7"
+      />
+      <div
+        className="c1"
+      >
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          Meta description preview:
+        </span>
+        <div
+          className="c8 c9"
+          color="#545454"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          Test description, %%replacement_variable%%
+        </div>
+      </div>
+    </div>
+  </section>
+  <div
+    className="c10"
+  >
+    <button
+      aria-pressed={true}
+      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-mobile c18"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="22px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Mobile preview
+      </span>
+    </button>
+    <button
+      aria-pressed={false}
+      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-desktop c20"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="18px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Desktop preview
+      </span>
+    </button>
+  </div>
+  <button
+    aria-expanded={false}
+    className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      aria-hidden={true}
+      className="yoast-svg-icon yoast-svg-icon-edit c22"
+      fill={undefined}
+      focusable="false"
+      role="img"
+      size="16px"
+      viewBox="0 0 1792 1792"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+      />
+    </svg>
+    <span>
+      Edit snippet
+    </span>
+  </button>
+</div>
+`;
+
+exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+}
+
+.c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c10 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+  font-size: 13px;
+}
+
+.c9 {
+  max-height: 4em;
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c1 {
+  padding: 8px 16px;
+}
+
+.c8 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c28 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c28::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c28::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c28::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c28::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c27 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+}
+
+.c27::before {
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c30 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
+}
+
+.c30::before {
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c29 {
+  padding: 3px 5px;
+  border: 1px solid #5b9dd9;
+  box-shadow: 0 0 2px rgba(30,140,190,.8);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+}
+
+.c29::before {
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#1e8cbe%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c25 {
+  margin: 32px 0;
+}
+
+.c24 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c26 {
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c18 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c13 {
+  font-size: 0.8rem;
+}
+
+.c14:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c15:hover {
+  color: #000;
+}
+
+.c16::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c16:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c17 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c17 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c22 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c22 svg {
+  margin-right: 7px;
+}
+
+.c31 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c12 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c12:hover,
+.c12:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c20 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c20:hover,
+.c20:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c11 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c19 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c21 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 .c6::before {
   display: block;
   position: absolute;
@@ -10405,7 +10779,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c16::after {
+  .c17::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -10688,28 +11062,23 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
         <div
           className="c11"
         >
-          <Button
+          <ModeSwitcher__SwitcherButton
             aria-pressed={true}
             isActive={true}
             onClick={[Function]}
           >
             <Button
               aria-pressed={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
               className="c12"
               isActive={true}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c12 Button-kDSBcD c13"
+                className="c12 c13"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -10720,7 +11089,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                  className="c12 c13 Button-kDSBcD c14"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -10731,47 +11100,48 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                    className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={true}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={true}
-                        className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                        isActive={true}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="mobile"
-                          size="22px"
+                        <button
+                          aria-pressed={true}
+                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-mobile"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
                             size="22px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c18"
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -10779,68 +11149,74 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Mobile preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c19"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Mobile preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Mobile preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
-          <Button
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
             aria-pressed={false}
             isActive={false}
             onClick={[Function]}
           >
             <Button
               aria-pressed={false}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c19"
+              className="c20"
               isActive={false}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={false}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c19 Button-kDSBcD c13"
+                className="c20 c13"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -10851,7 +11227,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c19 Button-kDSBcD c13 Button-kDSBcD c14"
+                  className="c20 c13 Button-kDSBcD c14"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -10862,47 +11238,48 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                    className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={false}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={false}
-                        className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                        isActive={false}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="desktop"
-                          size="18px"
+                        <button
+                          aria-pressed={false}
+                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-desktop"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
                             size="18px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c20"
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -10910,46 +11287,57 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Desktop preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c21"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Desktop preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Desktop preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
+          </ModeSwitcher__SwitcherButton>
         </div>
       </ModeSwitcher__Switcher>
     </ModeSwitcher>
@@ -10963,7 +11351,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c21"
+        className="c22"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -10974,7 +11362,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c21 Button-kDSBcD c13"
+          className="c22 Button-kDSBcD c14"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -10985,7 +11373,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
+            className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -10996,7 +11384,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+              className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -11007,7 +11395,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -11015,7 +11403,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
               >
                 <button
                   aria-expanded={true}
-                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                   onClick={[Function]}
                   type="button"
                 >
@@ -11034,7 +11422,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c22"
+                        className="yoast-svg-icon yoast-svg-icon-edit c23"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -11146,18 +11534,18 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c23"
+            className="c24"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c24"
+                className="c25"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-4-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                     id="snippet-editor-field-4-title"
                     onClick={[Function]}
                   >
@@ -11169,7 +11557,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                   isHovered={false}
                 >
                   <div
-                    className="c26"
+                    className="c27"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-4-title"
@@ -11192,7 +11580,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                 >
                   <progress
                     aria-hidden="true"
-                    className="c27"
+                    className="c28"
                     max={600}
                     value={0}
                   />
@@ -11201,14 +11589,14 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c24"
+                className="c25"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-4-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                     id="snippet-editor-field-4-slug"
                     onClick={[Function]}
                   >
@@ -11220,7 +11608,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                   isHovered={false}
                 >
                   <div
-                    className="c28"
+                    className="c29"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-4-slug"
@@ -11237,14 +11625,14 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c24"
+                className="c25"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-4-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                     id="snippet-editor-field-4-description"
                     onClick={[Function]}
                   >
@@ -11256,7 +11644,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                   isHovered={false}
                 >
                   <div
-                    className="c26"
+                    className="c30"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-4-description"
@@ -11279,7 +11667,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                 >
                   <progress
                     aria-hidden="true"
-                    className="c27"
+                    className="c28"
                     max={320}
                     value={0}
                   />
@@ -11297,7 +11685,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c29"
+        className="c31"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -11306,7 +11694,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c29 Button-kDSBcD c13"
+          className="c31 Button-kDSBcD c14"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -11315,7 +11703,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c29 Button-kDSBcD c13 Button-kDSBcD c14"
+            className="c31 Button-kDSBcD c14 Button-kDSBcD c15"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -11324,7 +11712,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+              className="c31 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -11333,13 +11721,13 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                className="c31 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                  className="c31 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                   onClick={[Function]}
                   type="button"
                 >
@@ -11372,6 +11760,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -11413,7 +11802,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -11424,17 +11813,18 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c9 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
@@ -11443,7 +11833,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   margin: 0;
 }
 
-.c27 {
+.c28 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -11456,27 +11846,27 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   border: 1px solid #ddd;
 }
 
-.c27::-webkit-progress-bar {
+.c28::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c27::-webkit-progress-value {
+.c28::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c27::-moz-progress-bar {
+.c28::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c27::-ms-fill {
+.c28::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
 
-.c26 {
-  padding: 3px;
+.c27 {
+  padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -11490,7 +11880,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   margin-top: 5px;
 }
 
-.c26::before {
+.c27::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -11502,8 +11892,8 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   content: "";
 }
 
-.c28 {
-  padding: 3px;
+.c29 {
+  padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -11515,9 +11905,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   font-size: 14px;
   margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
 }
 
-.c28::before {
+.c29::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -11529,69 +11922,50 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   content: "";
 }
 
-.c24 {
-  margin: 1em 0;
-}
-
-.c23 {
-  padding: 20px 20px 0;
-}
-
 .c25 {
+  margin: 32px 0;
+}
+
+.c24 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c26 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c17 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c12 {
+.c13 {
   font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
 }
 
-.c12:hover,
-.c12:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c13:active {
+.c14:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c14:hover {
+.c15:hover {
   color: #000;
 }
 
-.c15::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c15:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c16 {
+.c17 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -11620,14 +11994,60 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   min-height: 32px;
 }
 
-.c16 svg {
+.c17 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c19 {
+.c22 {
   font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c22 svg {
+  margin-right: 7px;
+}
+
+.c30 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c12 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c12:hover,
+.c12:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -11641,36 +12061,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   border-radius: 0 3px 3px 0;
 }
 
-.c19:hover,
-.c19:focus {
+.c20:hover,
+.c20:focus {
+  background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
-}
-
-.c21 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c21 svg {
-  margin-right: 7px;
-}
-
-.c29 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
 }
 
 .c11 {
@@ -11683,7 +12080,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   vertical-align: top;
 }
 
-.c18 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -11691,7 +12088,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   flex: none;
 }
 
-.c20 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -11699,7 +12096,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   flex: none;
 }
 
-.c22 {
+.c23 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -11720,7 +12117,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c16::after {
+  .c17::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -12005,28 +12402,23 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
         <div
           className="c11"
         >
-          <Button
+          <ModeSwitcher__SwitcherButton
             aria-pressed={true}
             isActive={true}
             onClick={[Function]}
           >
             <Button
               aria-pressed={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
               className="c12"
               isActive={true}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c12 Button-kDSBcD c13"
+                className="c12 c13"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -12037,7 +12429,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                  className="c12 c13 Button-kDSBcD c14"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -12048,47 +12440,48 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                    className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={true}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={true}
-                        className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                        isActive={true}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="mobile"
-                          size="22px"
+                        <button
+                          aria-pressed={true}
+                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-mobile"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
                             size="22px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c18"
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -12096,68 +12489,74 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Mobile preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c19"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Mobile preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Mobile preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
-          <Button
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
             aria-pressed={false}
             isActive={false}
             onClick={[Function]}
           >
             <Button
               aria-pressed={false}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c19"
+              className="c20"
               isActive={false}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={false}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c19 Button-kDSBcD c13"
+                className="c20 c13"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -12168,7 +12567,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c19 Button-kDSBcD c13 Button-kDSBcD c14"
+                  className="c20 c13 Button-kDSBcD c14"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -12179,47 +12578,48 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                    className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={false}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={false}
-                        className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                        isActive={false}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="desktop"
-                          size="18px"
+                        <button
+                          aria-pressed={false}
+                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-desktop"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
                             size="18px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c20"
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -12227,46 +12627,57 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Desktop preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c21"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Desktop preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Desktop preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
+          </ModeSwitcher__SwitcherButton>
         </div>
       </ModeSwitcher__Switcher>
     </ModeSwitcher>
@@ -12280,7 +12691,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c21"
+        className="c22"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -12291,7 +12702,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c21 Button-kDSBcD c13"
+          className="c22 Button-kDSBcD c14"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -12302,7 +12713,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
+            className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -12313,7 +12724,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+              className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -12324,7 +12735,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -12332,7 +12743,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
               >
                 <button
                   aria-expanded={true}
-                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                   onClick={[Function]}
                   type="button"
                 >
@@ -12351,7 +12762,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c22"
+                        className="yoast-svg-icon yoast-svg-icon-edit c23"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -12463,18 +12874,18 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c23"
+            className="c24"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c24"
+                className="c25"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-3-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                     id="snippet-editor-field-3-title"
                     onClick={[Function]}
                   >
@@ -12486,7 +12897,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                   isHovered={false}
                 >
                   <div
-                    className="c26"
+                    className="c27"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-3-title"
@@ -12509,7 +12920,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 >
                   <progress
                     aria-hidden="true"
-                    className="c27"
+                    className="c28"
                     max={600}
                     value={0}
                   />
@@ -12518,14 +12929,14 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c24"
+                className="c25"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-3-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                     id="snippet-editor-field-3-slug"
                     onClick={[Function]}
                   >
@@ -12537,7 +12948,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                   isHovered={false}
                 >
                   <div
-                    className="c26"
+                    className="c27"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-3-slug"
@@ -12554,14 +12965,14 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c24"
+                className="c25"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-3-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                     id="snippet-editor-field-3-description"
                     onClick={[Function]}
                   >
@@ -12573,7 +12984,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                   isHovered={true}
                 >
                   <div
-                    className="c28"
+                    className="c29"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-3-description"
@@ -12596,7 +13007,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 >
                   <progress
                     aria-hidden="true"
-                    className="c27"
+                    className="c28"
                     max={320}
                     value={0}
                   />
@@ -12614,7 +13025,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c29"
+        className="c30"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -12623,7 +13034,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c29 Button-kDSBcD c13"
+          className="c30 Button-kDSBcD c14"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -12632,7 +13043,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c29 Button-kDSBcD c13 Button-kDSBcD c14"
+            className="c30 Button-kDSBcD c14 Button-kDSBcD c15"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -12641,7 +13052,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+              className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -12650,13 +13061,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                  className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                   onClick={[Function]}
                   type="button"
                 >
@@ -12689,6 +13100,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -12730,7 +13142,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -12741,17 +13153,18 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
@@ -12760,7 +13173,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   margin: 0;
 }
 
-.c26 {
+.c27 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -12773,27 +13186,27 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border: 1px solid #ddd;
 }
 
-.c26::-webkit-progress-bar {
+.c27::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c26::-webkit-progress-value {
+.c27::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c26::-moz-progress-bar {
+.c27::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c26::-ms-fill {
+.c27::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
 
-.c25 {
-  padding: 3px;
+.c26 {
+  padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -12807,7 +13220,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   margin-top: 5px;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -12819,69 +13232,80 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   content: "";
 }
 
-.c23 {
-  margin: 1em 0;
+.c28 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
 }
 
-.c22 {
-  padding: 20px 20px 0;
+.c28::before {
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
 }
 
 .c24 {
+  margin: 32px 0;
+}
+
+.c23 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c25 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -12910,14 +13334,60 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c21 {
   font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c21 svg {
+  margin-right: 7px;
+}
+
+.c29 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c11 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c11:hover,
+.c11:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c19 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -12931,36 +13401,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
+  background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c20 svg {
-  margin-right: 7px;
-}
-
-.c27 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
 }
 
 .c10 {
@@ -12973,7 +13420,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -12981,7 +13428,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -12989,7 +13436,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -12998,7 +13445,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -13274,28 +13721,23 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         <div
           className="c10"
         >
-          <Button
+          <ModeSwitcher__SwitcherButton
             aria-pressed={true}
             isActive={true}
             onClick={[Function]}
           >
             <Button
               aria-pressed={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
               className="c11"
               isActive={true}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c11 c12"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -13306,7 +13748,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c11 c12 Button-kDSBcD c13"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -13317,47 +13759,48 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={true}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={true}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="mobile"
-                          size="22px"
+                        <button
+                          aria-pressed={true}
+                          className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-mobile"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
                             size="22px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -13365,68 +13808,74 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Mobile preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c18"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Mobile preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Mobile preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
-          <Button
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
             aria-pressed={false}
             isActive={false}
             onClick={[Function]}
           >
             <Button
               aria-pressed={false}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={false}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 c12"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -13437,7 +13886,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 c12 Button-kDSBcD c13"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -13448,47 +13897,48 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={false}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={false}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="desktop"
-                          size="18px"
+                        <button
+                          aria-pressed={false}
+                          className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-desktop"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
                             size="18px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -13496,46 +13946,57 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Desktop preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c20"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Desktop preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Desktop preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
+          </ModeSwitcher__SwitcherButton>
         </div>
       </ModeSwitcher__Switcher>
     </ModeSwitcher>
@@ -13549,7 +14010,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -13560,7 +14021,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -13571,7 +14032,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -13582,7 +14043,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -13593,7 +14054,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -13601,7 +14062,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -13620,7 +14081,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -13732,18 +14193,18 @@ exports[`SnippetEditor opens when calling open() 1`] = `
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-1-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-1-title"
                     onClick={[Function]}
                   >
@@ -13755,7 +14216,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-1-title"
@@ -13778,7 +14239,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={600}
                     value={0}
                   />
@@ -13787,14 +14248,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-1-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-1-slug"
                     onClick={[Function]}
                   >
@@ -13806,7 +14267,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-1-slug"
@@ -13823,14 +14284,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-1-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-1-description"
                     onClick={[Function]}
                   >
@@ -13842,7 +14303,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c28"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-1-description"
@@ -13865,7 +14326,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={320}
                     value={0}
                   />
@@ -13883,7 +14344,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c27"
+        className="c29"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -13892,7 +14353,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c12"
+          className="c29 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -13901,7 +14362,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c29 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -13910,7 +14371,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -13919,13 +14380,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -13958,6 +14419,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -13999,7 +14461,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -14010,17 +14472,18 @@ exports[`SnippetEditor passes replacement variables to the title and description
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
@@ -14029,7 +14492,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   margin: 0;
 }
 
-.c26 {
+.c27 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -14042,27 +14505,27 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border: 1px solid #ddd;
 }
 
-.c26::-webkit-progress-bar {
+.c27::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c26::-webkit-progress-value {
+.c27::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c26::-moz-progress-bar {
+.c27::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c26::-ms-fill {
+.c27::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
 
-.c25 {
-  padding: 3px;
+.c26 {
+  padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
@@ -14076,7 +14539,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   margin-top: 5px;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -14088,69 +14551,80 @@ exports[`SnippetEditor passes replacement variables to the title and description
   content: "";
 }
 
-.c23 {
-  margin: 1em 0;
+.c28 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
 }
 
-.c22 {
-  padding: 20px 20px 0;
+.c28::before {
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
 }
 
 .c24 {
+  margin: 32px 0;
+}
+
+.c23 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c25 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -14179,14 +14653,60 @@ exports[`SnippetEditor passes replacement variables to the title and description
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c21 {
   font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c21 svg {
+  margin-right: 7px;
+}
+
+.c29 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c11 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c11:hover,
+.c11:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c19 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -14200,36 +14720,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
+  background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c20 svg {
-  margin-right: 7px;
-}
-
-.c27 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
 }
 
 .c10 {
@@ -14242,7 +14739,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -14250,7 +14747,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -14258,7 +14755,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -14267,7 +14764,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -14554,28 +15051,23 @@ exports[`SnippetEditor passes replacement variables to the title and description
         <div
           className="c10"
         >
-          <Button
+          <ModeSwitcher__SwitcherButton
             aria-pressed={true}
             isActive={true}
             onClick={[Function]}
           >
             <Button
               aria-pressed={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
               className="c11"
               isActive={true}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c11 c12"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -14586,7 +15078,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c11 c12 Button-kDSBcD c13"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -14597,47 +15089,48 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={true}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={true}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="mobile"
-                          size="22px"
+                        <button
+                          aria-pressed={true}
+                          className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-mobile"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
                             size="22px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -14645,68 +15138,74 @@ exports[`SnippetEditor passes replacement variables to the title and description
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Mobile preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c18"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Mobile preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Mobile preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
-          <Button
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
             aria-pressed={false}
             isActive={false}
             onClick={[Function]}
           >
             <Button
               aria-pressed={false}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
-              textColor="#555"
-              type="button"
             >
               <Button
                 aria-pressed={false}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 c12"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -14717,7 +15216,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 c12 Button-kDSBcD c13"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -14728,47 +15227,48 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
                     type="button"
                   >
-                    <Button__BaseButton
+                    <Button
                       aria-pressed={false}
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <button
+                      <Button__BaseButton
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                        isActive={false}
                         onClick={[Function]}
+                        textColor="#555"
                         type="button"
                       >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="desktop"
-                          size="18px"
+                        <button
+                          aria-pressed={false}
+                          className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-desktop"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
                             size="18px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
+                            <SvgIcon__StyledSvg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -14776,46 +15276,57 @@ exports[`SnippetEditor passes replacement variables to the title and description
                               viewBox="0 0 1792 1792"
                               xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Desktop preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c20"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
                             defaultMessage="Desktop preview"
                             id="snippetEditor.desktopPreview"
-                            values={Object {}}
                           >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
                                   }
-                                }
-                              >
-                                Desktop preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
                   </Button>
                 </Button>
               </Button>
             </Button>
-          </Button>
+          </ModeSwitcher__SwitcherButton>
         </div>
       </ModeSwitcher__Switcher>
     </ModeSwitcher>
@@ -14829,7 +15340,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -14840,7 +15351,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -14851,7 +15362,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -14862,7 +15373,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -14873,7 +15384,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -14881,7 +15392,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -14900,7 +15411,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -15034,18 +15545,18 @@ exports[`SnippetEditor passes replacement variables to the title and description
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-6-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-6-title"
                     onClick={[Function]}
                   >
@@ -15057,7 +15568,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-6-title"
@@ -15091,7 +15602,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={600}
                     value={0}
                   />
@@ -15100,14 +15611,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-6-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-6-slug"
                     onClick={[Function]}
                   >
@@ -15119,7 +15630,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-6-slug"
@@ -15136,14 +15647,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-6-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-6-description"
                     onClick={[Function]}
                   >
@@ -15155,7 +15666,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c28"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-6-description"
@@ -15189,7 +15700,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={320}
                     value={0}
                   />
@@ -15207,7 +15718,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c27"
+        className="c29"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -15216,7 +15727,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c12"
+          className="c29 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -15225,7 +15736,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c29 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -15234,7 +15745,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -15243,13 +15754,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -15407,7 +15918,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -15418,6 +15929,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
@@ -15430,32 +15942,36 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   vertical-align: top;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c12:active {
+.c12 {
+  font-size: 0.8rem;
+}
+
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -15484,13 +16000,13 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c20 {
+.c21 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -15501,12 +16017,11 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   padding-left: 8px;
 }
 
-.c20 svg {
+.c21 svg {
   margin-right: 7px;
 }
 
 .c11 {
-  font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -15522,14 +16037,14 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
 
 .c11:hover,
 .c11:focus {
+  background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c18 {
-  font-size: 0.8rem;
+.c19 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -15543,8 +16058,9 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
+  background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
@@ -15561,7 +16077,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -15569,7 +16085,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -15577,7 +16093,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -15586,7 +16102,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -15697,13 +16213,13 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   >
     <button
       aria-pressed={false}
-      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c17"
+        className="yoast-svg-icon yoast-svg-icon-mobile c18"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -15732,13 +16248,13 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
     </button>
     <button
       aria-pressed={true}
-      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c19"
+        className="yoast-svg-icon yoast-svg-icon-desktop c20"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -15768,13 +16284,13 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+    className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
     onClick={[Function]}
     type="button"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c21"
+      className="yoast-svg-icon yoast-svg-icon-edit c22"
       fill={undefined}
       focusable="false"
       role="img"
@@ -15802,6 +16318,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -15843,7 +16360,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -15854,17 +16371,18 @@ exports[`SnippetEditor shows and editor 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
@@ -15873,55 +16391,36 @@ exports[`SnippetEditor shows and editor 1`] = `
   margin: 0;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -15950,14 +16449,51 @@ exports[`SnippetEditor shows and editor 1`] = `
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c21 {
   font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c21 svg {
+  margin-right: 7px;
+}
+
+.c11 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c11:hover,
+.c11:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c19 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -15971,27 +16507,13 @@ exports[`SnippetEditor shows and editor 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
+  background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c20 svg {
-  margin-right: 7px;
 }
 
 .c10 {
@@ -16004,7 +16526,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -16012,7 +16534,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -16020,7 +16542,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -16029,7 +16551,7 @@ exports[`SnippetEditor shows and editor 1`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -16136,13 +16658,13 @@ exports[`SnippetEditor shows and editor 1`] = `
   >
     <button
       aria-pressed={true}
-      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c17"
+        className="yoast-svg-icon yoast-svg-icon-mobile c18"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -16171,13 +16693,13 @@ exports[`SnippetEditor shows and editor 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c19"
+        className="yoast-svg-icon yoast-svg-icon-desktop c20"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -16207,13 +16729,13 @@ exports[`SnippetEditor shows and editor 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+    className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
     onClick={[Function]}
     type="button"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c21"
+      className="yoast-svg-icon yoast-svg-icon-edit c22"
       fill={undefined}
       focusable="false"
       role="img"

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -658,7 +658,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 .c26::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -688,7 +688,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 .c28::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -1977,7 +1977,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 .c26::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -2007,7 +2007,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 .c28::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -3296,7 +3296,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 .c26::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -3326,7 +3326,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 .c28::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -4615,7 +4615,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 .c26::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -4645,7 +4645,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 .c28::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -6877,7 +6877,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 .c26::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -6907,7 +6907,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 .c28::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -8228,7 +8228,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 .c26::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -8258,7 +8258,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 .c28::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -10518,7 +10518,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
 .c27::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -10548,7 +10548,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
 .c30::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -10575,7 +10575,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
 .c29::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -11883,7 +11883,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 .c27::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -11913,7 +11913,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 .c29::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -13223,7 +13223,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 .c26::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -13253,7 +13253,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 .c28::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -14542,7 +14542,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
 .c26::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;
@@ -14572,7 +14572,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
 .c28::before {
   display: block;
   position: absolute;
-  top: 4px;
+  top: -1px;
   left: -25px;
   width: 24px;
   height: 24px;

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -54,6 +54,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -72,6 +73,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -600,6 +602,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -618,6 +621,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -1907,6 +1911,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -1925,6 +1930,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -3214,6 +3220,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -3232,6 +3239,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -4521,6 +4529,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -4539,6 +4548,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -5828,6 +5838,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -5846,6 +5857,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -6781,6 +6793,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -6799,6 +6812,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -8120,6 +8134,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -8138,6 +8153,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -9540,6 +9556,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -9558,6 +9575,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -10005,6 +10023,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -10023,6 +10042,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -10470,6 +10490,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c8 {
@@ -10488,6 +10509,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
 
 .c10 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c12 {
@@ -11820,6 +11842,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -11838,6 +11861,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 
 .c10 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c12 {
@@ -13147,6 +13171,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -13165,6 +13190,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -14454,6 +14480,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -14472,6 +14499,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -15805,6 +15833,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -15823,6 +15852,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -16363,6 +16393,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c8 {
@@ -16816,6 +16847,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -16834,6 +16866,7 @@ exports[`SnippetEditor shows and editor 1`] = `
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -53,12 +53,16 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c9 {
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -66,11 +70,11 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   font-size: 13px;
 }
 
-.c8 {
+.c9 {
   max-height: 4em;
 }
 
-.c10 {
+.c11 {
   overflow: hidden;
   font-size: 14px;
   line-height: 20px;
@@ -81,42 +85,42 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   padding: 8px 16px;
 }
 
-.c7 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
 }
 
-.c18 {
+.c19 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c13 {
+.c14 {
   font-size: 0.8rem;
 }
 
-.c14:active {
+.c15:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c15:hover {
+.c16:hover {
   color: #000;
 }
 
-.c16::-moz-focus-inner {
+.c17::-moz-focus-inner {
   border-width: 0;
 }
 
-.c16:focus {
+.c17:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c17 {
+.c18 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -145,13 +149,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   min-height: 32px;
 }
 
-.c17 svg {
+.c18 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c22 {
+.c23 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -162,11 +166,11 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   padding-left: 8px;
 }
 
-.c22 svg {
+.c23 svg {
   margin-right: 7px;
 }
 
-.c12 {
+.c13 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -180,8 +184,8 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c12:hover,
-.c12:focus {
+.c13:hover,
+.c13:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -190,7 +194,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   box-shadow: none;
 }
 
-.c20 {
+.c21 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -204,8 +208,8 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c20:hover,
-.c20:focus {
+.c21:hover,
+.c21:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -214,7 +218,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   box-shadow: none;
 }
 
-.c11 {
+.c12 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -224,7 +228,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   vertical-align: top;
 }
 
-.c19 {
+.c20 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -232,7 +236,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -240,7 +244,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   flex: none;
 }
 
-.c23 {
+.c24 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -249,7 +253,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c17::after {
+  .c18::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -312,15 +316,19 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
         </span>
         <div
           className="c6"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
         >
-          example.org › totally-different-url
+          <div
+            className="c7 c6"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            example.org › totally-different-url
+          </div>
         </div>
       </div>
       <hr
-        className="c7"
+        className="c8"
       />
       <div
         className="c1"
@@ -340,14 +348,14 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c8 c9"
+          className="c9 c10"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
         >
           <div
-            className="c10 c8 c9"
+            className="c11 c9 c10"
             color="#545454"
           >
             Totally different description
@@ -357,17 +365,17 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
     </div>
   </section>
   <div
-    className="c11"
+    className="c12"
   >
     <button
       aria-pressed={true}
-      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+      className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c19"
+        className="yoast-svg-icon yoast-svg-icon-mobile c20"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -396,13 +404,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+      className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c21"
+        className="yoast-svg-icon yoast-svg-icon-desktop c22"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -432,13 +440,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+    className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
     onClick={[Function]}
     type="button"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c23"
+      className="yoast-svg-icon yoast-svg-icon-edit c24"
       fill={undefined}
       focusable="false"
       role="img"
@@ -591,9744 +599,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c9 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-  font-size: 13px;
-}
-
-.c8 {
-  max-height: 4em;
-}
-
-.c10 {
-  overflow: hidden;
-  font-size: 14px;
-  line-height: 20px;
-  max-height: calc( 4em + 3px );
-}
-
-.c1 {
-  padding: 8px 16px;
-}
-
 .c7 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
-}
-
-.c28 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c28::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c28::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c28::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c28::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c27 {
-  padding: 3px 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-}
-
-.c27::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  padding: 3px 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-  min-height: 60px;
-  padding: 2px 6px;
-  line-height: 19.6px;
-}
-
-.c29::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c25 {
-  margin: 32px 0;
-}
-
-.c24 {
-  padding: 10px 20px 20px 20px;
-}
-
-.c26 {
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-}
-
-.c18 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c13 {
-  font-size: 0.8rem;
-}
-
-.c14:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c15:hover {
-  color: #000;
-}
-
-.c16::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c16:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c17 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c17 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c22 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c22 svg {
-  margin-right: 7px;
-}
-
-.c30 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
-}
-
-.c12 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c12:hover,
-.c12:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c20 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c20:hover,
-.c20:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c11 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c19 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c23 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c17::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<SnippetEditor
-  baseUrl="https://example.org/"
-  data={
-    Object {
-      "description": "Test description, %%replacement_variable%%",
-      "slug": "test-slug",
-      "title": "Test title",
-    }
-  }
-  date=""
-  descriptionLengthAssessment={
-    Object {
-      "actual": 0,
-      "max": 320,
-      "score": 0,
-    }
-  }
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "textComponent": "span",
-    }
-  }
-  mapDataToPreview={null}
-  mode="mobile"
-  onChange={[MockFunction]}
-  replacementVariables={Array []}
-  titleLengthAssessment={
-    Object {
-      "actual": 0,
-      "max": 600,
-      "score": 0,
-    }
-  }
->
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      isDescriptionGenerated={false}
-      keyword=""
-      locale="en_US"
-      mode="mobile"
-      onClick={[Function]}
-      onHover={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c0"
-            width={640}
-          >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="SEO title preview"
-                  id="snippetPreview.seoTitlePreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="SEO title preview"
-                    id="snippetPreview.seoTitlePreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        SEO title preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseTitle
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c2"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c3"
-                      >
-                        <div
-                          className="c3 c4"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c5"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Url preview"
-                  id="snippetPreview.urlPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Url preview"
-                    id="snippetPreview.urlPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Url preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseUrl
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c6"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    example.org › test-slug
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c7"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Meta description preview"
-                  id="snippetPreview.metaDescriptionPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Meta description preview"
-                    id="snippetPreview.metaDescriptionPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Meta description preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__MobileDescription
-                  isDescriptionGenerated={false}
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <SnippetPreview__DesktopDescription
-                    className="c8"
-                    isDescriptionGenerated={false}
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <div
-                      className="c8 c9"
-                      color="#545454"
-                      onClick={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseOver={[Function]}
-                    >
-                      <SnippetPreview__MobileDescriptionOverflowContainer
-                        innerRef={[Function]}
-                      >
-                        <SnippetPreview__MobileDescription
-                          className="c10"
-                          innerRef={[Function]}
-                        >
-                          <SnippetPreview__DesktopDescription
-                            className="c10 c8"
-                            innerRef={[Function]}
-                          >
-                            <div
-                              className="c10 c8 c9"
-                              color="#545454"
-                            >
-                              Test description, %%replacement_variable%%
-                            </div>
-                          </SnippetPreview__DesktopDescription>
-                        </SnippetPreview__MobileDescription>
-                      </SnippetPreview__MobileDescriptionOverflowContainer>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c11"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={true}
-              className="c12"
-              isActive={true}
-              onClick={[Function]}
-            >
-              <Button
-                aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c12 c13"
-                isActive={true}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={true}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c12 c13 Button-kDSBcD c14"
-                  isActive={true}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={true}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                    isActive={true}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button
-                      aria-pressed={true}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                      isActive={true}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <Button__BaseButton
-                        aria-pressed={true}
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                        isActive={true}
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <button
-                          aria-pressed={true}
-                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
-                          >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c19"
-                                fill="currentColor"
-                                focusable="false"
-                                role="img"
-                                size="22px"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <FormattedScreenReaderMessage
-                            defaultMessage="Mobile preview"
-                            id="snippetEditor.desktopPreview"
-                          >
-                            <FormattedMessage
-                              defaultMessage="Mobile preview"
-                              id="snippetEditor.desktopPreview"
-                              values={Object {}}
-                            >
-                              <ScreenReaderText>
-                                <span
-                                  className="screen-reader-text"
-                                  style={
-                                    Object {
-                                      "clip": "rect(1px, 1px, 1px, 1px)",
-                                      "height": "1px",
-                                      "overflow": "hidden",
-                                      "position": "absolute",
-                                      "width": "1px",
-                                    }
-                                  }
-                                >
-                                  Mobile preview
-                                </span>
-                              </ScreenReaderText>
-                            </FormattedMessage>
-                          </FormattedScreenReaderMessage>
-                        </button>
-                      </Button__BaseButton>
-                    </Button>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={false}
-              className="c20"
-              isActive={false}
-              onClick={[Function]}
-            >
-              <Button
-                aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c20 c13"
-                isActive={false}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={false}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c20 c13 Button-kDSBcD c14"
-                  isActive={false}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={false}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                    isActive={false}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button
-                      aria-pressed={false}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                      isActive={false}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <Button__BaseButton
-                        aria-pressed={false}
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                        isActive={false}
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <button
-                          aria-pressed={false}
-                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
-                          >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c21"
-                                fill="currentColor"
-                                focusable="false"
-                                role="img"
-                                size="18px"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <FormattedScreenReaderMessage
-                            defaultMessage="Desktop preview"
-                            id="snippetEditor.desktopPreview"
-                          >
-                            <FormattedMessage
-                              defaultMessage="Desktop preview"
-                              id="snippetEditor.desktopPreview"
-                              values={Object {}}
-                            >
-                              <ScreenReaderText>
-                                <span
-                                  className="screen-reader-text"
-                                  style={
-                                    Object {
-                                      "clip": "rect(1px, 1px, 1px, 1px)",
-                                      "height": "1px",
-                                      "overflow": "hidden",
-                                      "position": "absolute",
-                                      "width": "1px",
-                                    }
-                                  }
-                                >
-                                  Desktop preview
-                                </span>
-                              </ScreenReaderText>
-                            </FormattedMessage>
-                          </FormattedScreenReaderMessage>
-                        </button>
-                      </Button__BaseButton>
-                    </Button>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
-      <Button
-        aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c22"
-        innerRef={[Function]}
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          aria-expanded={true}
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c22 Button-kDSBcD c14"
-          innerRef={[Function]}
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            aria-expanded={true}
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
-            innerRef={[Function]}
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              aria-expanded={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-              innerRef={[Function]}
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                aria-expanded={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                innerRef={[Function]}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  aria-expanded={true}
-                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
-                  >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
-                      size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c23"
-                        focusable="false"
-                        role="img"
-                        size="16px"
-                        viewBox="0 0 1792 1792"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  <FormattedMessage
-                    defaultMessage="Edit snippet"
-                    id="snippetEditor.editSnippet"
-                    values={Object {}}
-                  >
-                    <span>
-                      Edit snippet
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
-        }
-      }
-      descriptionLengthAssessment={
-        Object {
-          "actual": 0,
-          "max": 320,
-          "score": 0,
-        }
-      }
-      hoveredField={null}
-      onChange={[MockFunction]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthAssessment={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 0,
-        }
-      }
-    >
-      <SnippetEditorFields__StyledEditor>
-        <section
-          className="c24"
-        >
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-5-title"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-5-title"
-                  onClick={[Function]}
-                >
-                  SEO title
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c27"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-5-title"
-                    content="Test title"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c28"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </SnippetEditorFields__FormSection>
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-5-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-5-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c27"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-5-slug"
-                    content="test-slug"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-            </div>
-          </SnippetEditorFields__FormSection>
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-5-description"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-5-description"
-                  onClick={[Function]}
-                >
-                  Meta description
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c29"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-5-description"
-                    content="Test description, %%replacement_variable%%"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={320}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c28"
-                  max={320}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </SnippetEditorFields__FormSection>
-        </section>
-      </SnippetEditorFields__StyledEditor>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
-      <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c30"
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c30 Button-kDSBcD c14"
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c30 Button-kDSBcD c14 Button-kDSBcD c15"
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <FormattedMessage
-                    defaultMessage="Close snippet editor"
-                    id="snippet-editor.close-editor"
-                    values={Object {}}
-                  >
-                    <span>
-                      Close snippet editor
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-  </div>
-</SnippetEditor>
-`;
-
-exports[`SnippetEditor calls callbacks when the editors are focused or changed 2`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-  font-size: 14px;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
-}
-
-.c6 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-  max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.c9 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-  font-size: 13px;
-}
-
-.c8 {
-  max-height: 4em;
-}
-
-.c10 {
-  overflow: hidden;
-  font-size: 14px;
-  line-height: 20px;
-  max-height: calc( 4em + 3px );
-}
-
-.c1 {
-  padding: 8px 16px;
-}
-
-.c7 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
-}
-
-.c28 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c28::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c28::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c28::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c28::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c27 {
-  padding: 3px 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-}
-
-.c27::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  padding: 3px 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-  min-height: 60px;
-  padding: 2px 6px;
-  line-height: 19.6px;
-}
-
-.c29::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c25 {
-  margin: 32px 0;
-}
-
-.c24 {
-  padding: 10px 20px 20px 20px;
-}
-
-.c26 {
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-}
-
-.c18 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c13 {
-  font-size: 0.8rem;
-}
-
-.c14:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c15:hover {
-  color: #000;
-}
-
-.c16::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c16:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c17 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c17 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c22 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c22 svg {
-  margin-right: 7px;
-}
-
-.c30 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
-}
-
-.c12 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c12:hover,
-.c12:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c20 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c20:hover,
-.c20:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c11 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c19 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c23 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c17::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<SnippetEditor
-  baseUrl="https://example.org/"
-  data={
-    Object {
-      "description": "Test description, %%replacement_variable%%",
-      "slug": "test-slug",
-      "title": "Test title",
-    }
-  }
-  date=""
-  descriptionLengthAssessment={
-    Object {
-      "actual": 0,
-      "max": 320,
-      "score": 0,
-    }
-  }
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "textComponent": "span",
-    }
-  }
-  mapDataToPreview={null}
-  mode="mobile"
-  onChange={[MockFunction]}
-  replacementVariables={Array []}
-  titleLengthAssessment={
-    Object {
-      "actual": 0,
-      "max": 600,
-      "score": 0,
-    }
-  }
->
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      isDescriptionGenerated={false}
-      keyword=""
-      locale="en_US"
-      mode="mobile"
-      onClick={[Function]}
-      onHover={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c0"
-            width={640}
-          >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="SEO title preview"
-                  id="snippetPreview.seoTitlePreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="SEO title preview"
-                    id="snippetPreview.seoTitlePreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        SEO title preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseTitle
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c2"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c3"
-                      >
-                        <div
-                          className="c3 c4"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c5"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Url preview"
-                  id="snippetPreview.urlPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Url preview"
-                    id="snippetPreview.urlPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Url preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseUrl
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c6"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    example.org › test-slug
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c7"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Meta description preview"
-                  id="snippetPreview.metaDescriptionPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Meta description preview"
-                    id="snippetPreview.metaDescriptionPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Meta description preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__MobileDescription
-                  isDescriptionGenerated={false}
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <SnippetPreview__DesktopDescription
-                    className="c8"
-                    isDescriptionGenerated={false}
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <div
-                      className="c8 c9"
-                      color="#545454"
-                      onClick={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseOver={[Function]}
-                    >
-                      <SnippetPreview__MobileDescriptionOverflowContainer
-                        innerRef={[Function]}
-                      >
-                        <SnippetPreview__MobileDescription
-                          className="c10"
-                          innerRef={[Function]}
-                        >
-                          <SnippetPreview__DesktopDescription
-                            className="c10 c8"
-                            innerRef={[Function]}
-                          >
-                            <div
-                              className="c10 c8 c9"
-                              color="#545454"
-                            >
-                              Test description, %%replacement_variable%%
-                            </div>
-                          </SnippetPreview__DesktopDescription>
-                        </SnippetPreview__MobileDescription>
-                      </SnippetPreview__MobileDescriptionOverflowContainer>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c11"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={true}
-              className="c12"
-              isActive={true}
-              onClick={[Function]}
-            >
-              <Button
-                aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c12 c13"
-                isActive={true}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={true}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c12 c13 Button-kDSBcD c14"
-                  isActive={true}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={true}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                    isActive={true}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button
-                      aria-pressed={true}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                      isActive={true}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <Button__BaseButton
-                        aria-pressed={true}
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                        isActive={true}
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <button
-                          aria-pressed={true}
-                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
-                          >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c19"
-                                fill="currentColor"
-                                focusable="false"
-                                role="img"
-                                size="22px"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <FormattedScreenReaderMessage
-                            defaultMessage="Mobile preview"
-                            id="snippetEditor.desktopPreview"
-                          >
-                            <FormattedMessage
-                              defaultMessage="Mobile preview"
-                              id="snippetEditor.desktopPreview"
-                              values={Object {}}
-                            >
-                              <ScreenReaderText>
-                                <span
-                                  className="screen-reader-text"
-                                  style={
-                                    Object {
-                                      "clip": "rect(1px, 1px, 1px, 1px)",
-                                      "height": "1px",
-                                      "overflow": "hidden",
-                                      "position": "absolute",
-                                      "width": "1px",
-                                    }
-                                  }
-                                >
-                                  Mobile preview
-                                </span>
-                              </ScreenReaderText>
-                            </FormattedMessage>
-                          </FormattedScreenReaderMessage>
-                        </button>
-                      </Button__BaseButton>
-                    </Button>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={false}
-              className="c20"
-              isActive={false}
-              onClick={[Function]}
-            >
-              <Button
-                aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c20 c13"
-                isActive={false}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={false}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c20 c13 Button-kDSBcD c14"
-                  isActive={false}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={false}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                    isActive={false}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button
-                      aria-pressed={false}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                      isActive={false}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <Button__BaseButton
-                        aria-pressed={false}
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                        isActive={false}
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <button
-                          aria-pressed={false}
-                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
-                          >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c21"
-                                fill="currentColor"
-                                focusable="false"
-                                role="img"
-                                size="18px"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <FormattedScreenReaderMessage
-                            defaultMessage="Desktop preview"
-                            id="snippetEditor.desktopPreview"
-                          >
-                            <FormattedMessage
-                              defaultMessage="Desktop preview"
-                              id="snippetEditor.desktopPreview"
-                              values={Object {}}
-                            >
-                              <ScreenReaderText>
-                                <span
-                                  className="screen-reader-text"
-                                  style={
-                                    Object {
-                                      "clip": "rect(1px, 1px, 1px, 1px)",
-                                      "height": "1px",
-                                      "overflow": "hidden",
-                                      "position": "absolute",
-                                      "width": "1px",
-                                    }
-                                  }
-                                >
-                                  Desktop preview
-                                </span>
-                              </ScreenReaderText>
-                            </FormattedMessage>
-                          </FormattedScreenReaderMessage>
-                        </button>
-                      </Button__BaseButton>
-                    </Button>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
-      <Button
-        aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c22"
-        innerRef={[Function]}
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          aria-expanded={true}
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c22 Button-kDSBcD c14"
-          innerRef={[Function]}
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            aria-expanded={true}
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
-            innerRef={[Function]}
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              aria-expanded={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-              innerRef={[Function]}
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                aria-expanded={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                innerRef={[Function]}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  aria-expanded={true}
-                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
-                  >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
-                      size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c23"
-                        focusable="false"
-                        role="img"
-                        size="16px"
-                        viewBox="0 0 1792 1792"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  <FormattedMessage
-                    defaultMessage="Edit snippet"
-                    id="snippetEditor.editSnippet"
-                    values={Object {}}
-                  >
-                    <span>
-                      Edit snippet
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
-        }
-      }
-      descriptionLengthAssessment={
-        Object {
-          "actual": 0,
-          "max": 320,
-          "score": 0,
-        }
-      }
-      hoveredField={null}
-      onChange={[MockFunction]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthAssessment={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 0,
-        }
-      }
-    >
-      <SnippetEditorFields__StyledEditor>
-        <section
-          className="c24"
-        >
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-5-title"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-5-title"
-                  onClick={[Function]}
-                >
-                  SEO title
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c27"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-5-title"
-                    content="Test title"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c28"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </SnippetEditorFields__FormSection>
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-5-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-5-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c27"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-5-slug"
-                    content="test-slug"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-            </div>
-          </SnippetEditorFields__FormSection>
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-5-description"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-5-description"
-                  onClick={[Function]}
-                >
-                  Meta description
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c29"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-5-description"
-                    content="Test description, %%replacement_variable%%"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={320}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c28"
-                  max={320}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </SnippetEditorFields__FormSection>
-        </section>
-      </SnippetEditorFields__StyledEditor>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
-      <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c30"
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c30 Button-kDSBcD c14"
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c30 Button-kDSBcD c14 Button-kDSBcD c15"
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <FormattedMessage
-                    defaultMessage="Close snippet editor"
-                    id="snippet-editor.close-editor"
-                    values={Object {}}
-                  >
-                    <span>
-                      Close snippet editor
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-  </div>
-</SnippetEditor>
-`;
-
-exports[`SnippetEditor calls callbacks when the editors are focused or changed 3`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-  font-size: 14px;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 16px;
-}
-
-.c6 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-  max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.c9 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-  font-size: 13px;
-}
-
-.c8 {
-  max-height: 4em;
-}
-
-.c10 {
-  overflow: hidden;
-  font-size: 14px;
-  line-height: 20px;
-  max-height: calc( 4em + 3px );
-}
-
-.c1 {
-  padding: 8px 16px;
-}
-
-.c7 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
-}
-
-.c28 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c28::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c28::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c28::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c28::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c27 {
-  padding: 3px 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-}
-
-.c27::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  padding: 3px 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-  min-height: 60px;
-  padding: 2px 6px;
-  line-height: 19.6px;
-}
-
-.c29::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c25 {
-  margin: 32px 0;
-}
-
-.c24 {
-  padding: 10px 20px 20px 20px;
-}
-
-.c26 {
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-}
-
-.c18 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c13 {
-  font-size: 0.8rem;
-}
-
-.c14:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c15:hover {
-  color: #000;
-}
-
-.c16::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c16:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c17 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c17 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c22 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c22 svg {
-  margin-right: 7px;
-}
-
-.c30 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
-}
-
-.c12 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c12:hover,
-.c12:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c20 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c20:hover,
-.c20:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c11 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c19 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c23 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c17::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<SnippetEditor
-  baseUrl="https://example.org/"
-  data={
-    Object {
-      "description": "Test description, %%replacement_variable%%",
-      "slug": "test-slug",
-      "title": "Test title",
-    }
-  }
-  date=""
-  descriptionLengthAssessment={
-    Object {
-      "actual": 0,
-      "max": 320,
-      "score": 0,
-    }
-  }
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "textComponent": "span",
-    }
-  }
-  mapDataToPreview={null}
-  mode="mobile"
-  onChange={[MockFunction]}
-  replacementVariables={Array []}
-  titleLengthAssessment={
-    Object {
-      "actual": 0,
-      "max": 600,
-      "score": 0,
-    }
-  }
->
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      isDescriptionGenerated={false}
-      keyword=""
-      locale="en_US"
-      mode="mobile"
-      onClick={[Function]}
-      onHover={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c0"
-            width={640}
-          >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="SEO title preview"
-                  id="snippetPreview.seoTitlePreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="SEO title preview"
-                    id="snippetPreview.seoTitlePreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        SEO title preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseTitle
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c2"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c3"
-                      >
-                        <div
-                          className="c3 c4"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c5"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Url preview"
-                  id="snippetPreview.urlPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Url preview"
-                    id="snippetPreview.urlPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Url preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseUrl
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c6"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    example.org › test-slug
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c7"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Meta description preview"
-                  id="snippetPreview.metaDescriptionPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Meta description preview"
-                    id="snippetPreview.metaDescriptionPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Meta description preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__MobileDescription
-                  isDescriptionGenerated={false}
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <SnippetPreview__DesktopDescription
-                    className="c8"
-                    isDescriptionGenerated={false}
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <div
-                      className="c8 c9"
-                      color="#545454"
-                      onClick={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseOver={[Function]}
-                    >
-                      <SnippetPreview__MobileDescriptionOverflowContainer
-                        innerRef={[Function]}
-                      >
-                        <SnippetPreview__MobileDescription
-                          className="c10"
-                          innerRef={[Function]}
-                        >
-                          <SnippetPreview__DesktopDescription
-                            className="c10 c8"
-                            innerRef={[Function]}
-                          >
-                            <div
-                              className="c10 c8 c9"
-                              color="#545454"
-                            >
-                              Test description, %%replacement_variable%%
-                            </div>
-                          </SnippetPreview__DesktopDescription>
-                        </SnippetPreview__MobileDescription>
-                      </SnippetPreview__MobileDescriptionOverflowContainer>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c11"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={true}
-              className="c12"
-              isActive={true}
-              onClick={[Function]}
-            >
-              <Button
-                aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c12 c13"
-                isActive={true}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={true}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c12 c13 Button-kDSBcD c14"
-                  isActive={true}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={true}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                    isActive={true}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button
-                      aria-pressed={true}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                      isActive={true}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <Button__BaseButton
-                        aria-pressed={true}
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                        isActive={true}
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <button
-                          aria-pressed={true}
-                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
-                          >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c19"
-                                fill="currentColor"
-                                focusable="false"
-                                role="img"
-                                size="22px"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <FormattedScreenReaderMessage
-                            defaultMessage="Mobile preview"
-                            id="snippetEditor.desktopPreview"
-                          >
-                            <FormattedMessage
-                              defaultMessage="Mobile preview"
-                              id="snippetEditor.desktopPreview"
-                              values={Object {}}
-                            >
-                              <ScreenReaderText>
-                                <span
-                                  className="screen-reader-text"
-                                  style={
-                                    Object {
-                                      "clip": "rect(1px, 1px, 1px, 1px)",
-                                      "height": "1px",
-                                      "overflow": "hidden",
-                                      "position": "absolute",
-                                      "width": "1px",
-                                    }
-                                  }
-                                >
-                                  Mobile preview
-                                </span>
-                              </ScreenReaderText>
-                            </FormattedMessage>
-                          </FormattedScreenReaderMessage>
-                        </button>
-                      </Button__BaseButton>
-                    </Button>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={false}
-              className="c20"
-              isActive={false}
-              onClick={[Function]}
-            >
-              <Button
-                aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c20 c13"
-                isActive={false}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={false}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c20 c13 Button-kDSBcD c14"
-                  isActive={false}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={false}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                    isActive={false}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button
-                      aria-pressed={false}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                      isActive={false}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <Button__BaseButton
-                        aria-pressed={false}
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                        isActive={false}
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <button
-                          aria-pressed={false}
-                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
-                          >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c21"
-                                fill="currentColor"
-                                focusable="false"
-                                role="img"
-                                size="18px"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <FormattedScreenReaderMessage
-                            defaultMessage="Desktop preview"
-                            id="snippetEditor.desktopPreview"
-                          >
-                            <FormattedMessage
-                              defaultMessage="Desktop preview"
-                              id="snippetEditor.desktopPreview"
-                              values={Object {}}
-                            >
-                              <ScreenReaderText>
-                                <span
-                                  className="screen-reader-text"
-                                  style={
-                                    Object {
-                                      "clip": "rect(1px, 1px, 1px, 1px)",
-                                      "height": "1px",
-                                      "overflow": "hidden",
-                                      "position": "absolute",
-                                      "width": "1px",
-                                    }
-                                  }
-                                >
-                                  Desktop preview
-                                </span>
-                              </ScreenReaderText>
-                            </FormattedMessage>
-                          </FormattedScreenReaderMessage>
-                        </button>
-                      </Button__BaseButton>
-                    </Button>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
-      <Button
-        aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c22"
-        innerRef={[Function]}
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          aria-expanded={true}
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c22 Button-kDSBcD c14"
-          innerRef={[Function]}
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            aria-expanded={true}
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
-            innerRef={[Function]}
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              aria-expanded={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-              innerRef={[Function]}
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                aria-expanded={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                innerRef={[Function]}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  aria-expanded={true}
-                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
-                  >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
-                      size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c23"
-                        focusable="false"
-                        role="img"
-                        size="16px"
-                        viewBox="0 0 1792 1792"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  <FormattedMessage
-                    defaultMessage="Edit snippet"
-                    id="snippetEditor.editSnippet"
-                    values={Object {}}
-                  >
-                    <span>
-                      Edit snippet
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
-        }
-      }
-      descriptionLengthAssessment={
-        Object {
-          "actual": 0,
-          "max": 320,
-          "score": 0,
-        }
-      }
-      hoveredField={null}
-      onChange={[MockFunction]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthAssessment={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 0,
-        }
-      }
-    >
-      <SnippetEditorFields__StyledEditor>
-        <section
-          className="c24"
-        >
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-5-title"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-5-title"
-                  onClick={[Function]}
-                >
-                  SEO title
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c27"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-5-title"
-                    content="Test title"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c28"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </SnippetEditorFields__FormSection>
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-5-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-5-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c27"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-5-slug"
-                    content="test-slug"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-            </div>
-          </SnippetEditorFields__FormSection>
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-5-description"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-5-description"
-                  onClick={[Function]}
-                >
-                  Meta description
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c29"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-5-description"
-                    content="Test description, %%replacement_variable%%"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={320}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c28"
-                  max={320}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </SnippetEditorFields__FormSection>
-        </section>
-      </SnippetEditorFields__StyledEditor>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
-      <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c30"
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c30 Button-kDSBcD c14"
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c30 Button-kDSBcD c14 Button-kDSBcD c15"
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <FormattedMessage
-                    defaultMessage="Close snippet editor"
-                    id="snippet-editor.close-editor"
-                    values={Object {}}
-                  >
-                    <span>
-                      Close snippet editor
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-  </div>
-</SnippetEditor>
-`;
-
-exports[`SnippetEditor closes when calling close() 1`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-  font-size: 14px;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 16px;
-}
-
-.c6 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-  max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.c9 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-  font-size: 13px;
-}
-
-.c8 {
-  max-height: 4em;
-}
-
-.c10 {
-  overflow: hidden;
-  font-size: 14px;
-  line-height: 20px;
-  max-height: calc( 4em + 3px );
-}
-
-.c1 {
-  padding: 8px 16px;
-}
-
-.c7 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
-}
-
-.c28 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c28::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c28::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c28::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c28::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c27 {
-  padding: 3px 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-}
-
-.c27::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  padding: 3px 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-  min-height: 60px;
-  padding: 2px 6px;
-  line-height: 19.6px;
-}
-
-.c29::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c25 {
-  margin: 32px 0;
-}
-
-.c24 {
-  padding: 10px 20px 20px 20px;
-}
-
-.c26 {
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-}
-
-.c18 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c13 {
-  font-size: 0.8rem;
-}
-
-.c14:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c15:hover {
-  color: #000;
-}
-
-.c16::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c16:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c17 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c17 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c22 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c22 svg {
-  margin-right: 7px;
-}
-
-.c30 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
-}
-
-.c12 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c12:hover,
-.c12:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c20 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c20:hover,
-.c20:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c11 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c19 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c23 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c17::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<SnippetEditor
-  baseUrl="https://example.org/"
-  data={
-    Object {
-      "description": "Test description, %%replacement_variable%%",
-      "slug": "test-slug",
-      "title": "Test title",
-    }
-  }
-  date=""
-  descriptionLengthAssessment={
-    Object {
-      "actual": 0,
-      "max": 320,
-      "score": 0,
-    }
-  }
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "textComponent": "span",
-    }
-  }
-  mapDataToPreview={null}
-  mode="mobile"
-  onChange={[Function]}
-  replacementVariables={Array []}
-  titleLengthAssessment={
-    Object {
-      "actual": 0,
-      "max": 600,
-      "score": 0,
-    }
-  }
->
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      isDescriptionGenerated={false}
-      keyword=""
-      locale="en_US"
-      mode="mobile"
-      onClick={[Function]}
-      onHover={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c0"
-            width={640}
-          >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="SEO title preview"
-                  id="snippetPreview.seoTitlePreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="SEO title preview"
-                    id="snippetPreview.seoTitlePreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        SEO title preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseTitle
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c2"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c3"
-                      >
-                        <div
-                          className="c3 c4"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c5"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Url preview"
-                  id="snippetPreview.urlPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Url preview"
-                    id="snippetPreview.urlPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Url preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseUrl
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c6"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    example.org › test-slug
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c7"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Meta description preview"
-                  id="snippetPreview.metaDescriptionPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Meta description preview"
-                    id="snippetPreview.metaDescriptionPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Meta description preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__MobileDescription
-                  isDescriptionGenerated={false}
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <SnippetPreview__DesktopDescription
-                    className="c8"
-                    isDescriptionGenerated={false}
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <div
-                      className="c8 c9"
-                      color="#545454"
-                      onClick={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseOver={[Function]}
-                    >
-                      <SnippetPreview__MobileDescriptionOverflowContainer
-                        innerRef={[Function]}
-                      >
-                        <SnippetPreview__MobileDescription
-                          className="c10"
-                          innerRef={[Function]}
-                        >
-                          <SnippetPreview__DesktopDescription
-                            className="c10 c8"
-                            innerRef={[Function]}
-                          >
-                            <div
-                              className="c10 c8 c9"
-                              color="#545454"
-                            >
-                              Test description, %%replacement_variable%%
-                            </div>
-                          </SnippetPreview__DesktopDescription>
-                        </SnippetPreview__MobileDescription>
-                      </SnippetPreview__MobileDescriptionOverflowContainer>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c11"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={true}
-              className="c12"
-              isActive={true}
-              onClick={[Function]}
-            >
-              <Button
-                aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c12 c13"
-                isActive={true}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={true}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c12 c13 Button-kDSBcD c14"
-                  isActive={true}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={true}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                    isActive={true}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button
-                      aria-pressed={true}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                      isActive={true}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <Button__BaseButton
-                        aria-pressed={true}
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                        isActive={true}
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <button
-                          aria-pressed={true}
-                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
-                          >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c19"
-                                fill="currentColor"
-                                focusable="false"
-                                role="img"
-                                size="22px"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <FormattedScreenReaderMessage
-                            defaultMessage="Mobile preview"
-                            id="snippetEditor.desktopPreview"
-                          >
-                            <FormattedMessage
-                              defaultMessage="Mobile preview"
-                              id="snippetEditor.desktopPreview"
-                              values={Object {}}
-                            >
-                              <ScreenReaderText>
-                                <span
-                                  className="screen-reader-text"
-                                  style={
-                                    Object {
-                                      "clip": "rect(1px, 1px, 1px, 1px)",
-                                      "height": "1px",
-                                      "overflow": "hidden",
-                                      "position": "absolute",
-                                      "width": "1px",
-                                    }
-                                  }
-                                >
-                                  Mobile preview
-                                </span>
-                              </ScreenReaderText>
-                            </FormattedMessage>
-                          </FormattedScreenReaderMessage>
-                        </button>
-                      </Button__BaseButton>
-                    </Button>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={false}
-              className="c20"
-              isActive={false}
-              onClick={[Function]}
-            >
-              <Button
-                aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c20 c13"
-                isActive={false}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={false}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c20 c13 Button-kDSBcD c14"
-                  isActive={false}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={false}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                    isActive={false}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button
-                      aria-pressed={false}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                      isActive={false}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <Button__BaseButton
-                        aria-pressed={false}
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                        isActive={false}
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <button
-                          aria-pressed={false}
-                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
-                          >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c21"
-                                fill="currentColor"
-                                focusable="false"
-                                role="img"
-                                size="18px"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <FormattedScreenReaderMessage
-                            defaultMessage="Desktop preview"
-                            id="snippetEditor.desktopPreview"
-                          >
-                            <FormattedMessage
-                              defaultMessage="Desktop preview"
-                              id="snippetEditor.desktopPreview"
-                              values={Object {}}
-                            >
-                              <ScreenReaderText>
-                                <span
-                                  className="screen-reader-text"
-                                  style={
-                                    Object {
-                                      "clip": "rect(1px, 1px, 1px, 1px)",
-                                      "height": "1px",
-                                      "overflow": "hidden",
-                                      "position": "absolute",
-                                      "width": "1px",
-                                    }
-                                  }
-                                >
-                                  Desktop preview
-                                </span>
-                              </ScreenReaderText>
-                            </FormattedMessage>
-                          </FormattedScreenReaderMessage>
-                        </button>
-                      </Button__BaseButton>
-                    </Button>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
-      <Button
-        aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c22"
-        innerRef={[Function]}
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          aria-expanded={true}
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c22 Button-kDSBcD c14"
-          innerRef={[Function]}
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            aria-expanded={true}
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
-            innerRef={[Function]}
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              aria-expanded={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-              innerRef={[Function]}
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                aria-expanded={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                innerRef={[Function]}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  aria-expanded={true}
-                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
-                  >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
-                      size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c23"
-                        focusable="false"
-                        role="img"
-                        size="16px"
-                        viewBox="0 0 1792 1792"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  <FormattedMessage
-                    defaultMessage="Edit snippet"
-                    id="snippetEditor.editSnippet"
-                    values={Object {}}
-                  >
-                    <span>
-                      Edit snippet
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
-        }
-      }
-      descriptionLengthAssessment={
-        Object {
-          "actual": 0,
-          "max": 320,
-          "score": 0,
-        }
-      }
-      hoveredField={null}
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthAssessment={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 0,
-        }
-      }
-    >
-      <SnippetEditorFields__StyledEditor>
-        <section
-          className="c24"
-        >
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-2-title"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-2-title"
-                  onClick={[Function]}
-                >
-                  SEO title
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c27"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-2-title"
-                    content="Test title"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c28"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </SnippetEditorFields__FormSection>
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-2-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-2-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c27"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-2-slug"
-                    content="test-slug"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-            </div>
-          </SnippetEditorFields__FormSection>
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-2-description"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-2-description"
-                  onClick={[Function]}
-                >
-                  Meta description
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c29"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-2-description"
-                    content="Test description, %%replacement_variable%%"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={320}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c28"
-                  max={320}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </SnippetEditorFields__FormSection>
-        </section>
-      </SnippetEditorFields__StyledEditor>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
-      <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c30"
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c30 Button-kDSBcD c14"
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c30 Button-kDSBcD c14 Button-kDSBcD c15"
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <FormattedMessage
-                    defaultMessage="Close snippet editor"
-                    id="snippet-editor.close-editor"
-                    values={Object {}}
-                  >
-                    <span>
-                      Close snippet editor
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-  </div>
-</SnippetEditor>
-`;
-
-exports[`SnippetEditor closes when calling close() 2`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-  font-size: 14px;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 16px;
-}
-
-.c6 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-  max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.c9 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-  font-size: 13px;
-}
-
-.c8 {
-  max-height: 4em;
-}
-
-.c10 {
-  overflow: hidden;
-  font-size: 14px;
-  line-height: 20px;
-  max-height: calc( 4em + 3px );
-}
-
-.c1 {
-  padding: 8px 16px;
-}
-
-.c7 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
-}
-
-.c18 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c13 {
-  font-size: 0.8rem;
-}
-
-.c14:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c15:hover {
-  color: #000;
-}
-
-.c16::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c16:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c17 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c17 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c22 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c22 svg {
-  margin-right: 7px;
-}
-
-.c12 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c12:hover,
-.c12:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c20 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c20:hover,
-.c20:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c11 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c19 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c23 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c17::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<SnippetEditor
-  baseUrl="https://example.org/"
-  data={
-    Object {
-      "description": "Test description, %%replacement_variable%%",
-      "slug": "test-slug",
-      "title": "Test title",
-    }
-  }
-  date=""
-  descriptionLengthAssessment={
-    Object {
-      "actual": 0,
-      "max": 320,
-      "score": 0,
-    }
-  }
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "textComponent": "span",
-    }
-  }
-  mapDataToPreview={null}
-  mode="mobile"
-  onChange={[Function]}
-  replacementVariables={Array []}
-  titleLengthAssessment={
-    Object {
-      "actual": 0,
-      "max": 600,
-      "score": 0,
-    }
-  }
->
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      isDescriptionGenerated={false}
-      keyword=""
-      locale="en_US"
-      mode="mobile"
-      onClick={[Function]}
-      onHover={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c0"
-            width={640}
-          >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="SEO title preview"
-                  id="snippetPreview.seoTitlePreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="SEO title preview"
-                    id="snippetPreview.seoTitlePreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        SEO title preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseTitle
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c2"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c3"
-                      >
-                        <div
-                          className="c3 c4"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c5"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Url preview"
-                  id="snippetPreview.urlPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Url preview"
-                    id="snippetPreview.urlPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Url preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseUrl
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c6"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    example.org › test-slug
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c7"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Meta description preview"
-                  id="snippetPreview.metaDescriptionPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Meta description preview"
-                    id="snippetPreview.metaDescriptionPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Meta description preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__MobileDescription
-                  isDescriptionGenerated={false}
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <SnippetPreview__DesktopDescription
-                    className="c8"
-                    isDescriptionGenerated={false}
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <div
-                      className="c8 c9"
-                      color="#545454"
-                      onClick={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseOver={[Function]}
-                    >
-                      <SnippetPreview__MobileDescriptionOverflowContainer
-                        innerRef={[Function]}
-                      >
-                        <SnippetPreview__MobileDescription
-                          className="c10"
-                          innerRef={[Function]}
-                        >
-                          <SnippetPreview__DesktopDescription
-                            className="c10 c8"
-                            innerRef={[Function]}
-                          >
-                            <div
-                              className="c10 c8 c9"
-                              color="#545454"
-                            >
-                              Test description, %%replacement_variable%%
-                            </div>
-                          </SnippetPreview__DesktopDescription>
-                        </SnippetPreview__MobileDescription>
-                      </SnippetPreview__MobileDescriptionOverflowContainer>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c11"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={true}
-              className="c12"
-              isActive={true}
-              onClick={[Function]}
-            >
-              <Button
-                aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c12 c13"
-                isActive={true}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={true}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c12 c13 Button-kDSBcD c14"
-                  isActive={true}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={true}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                    isActive={true}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button
-                      aria-pressed={true}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                      isActive={true}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <Button__BaseButton
-                        aria-pressed={true}
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                        isActive={true}
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <button
-                          aria-pressed={true}
-                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
-                          >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c19"
-                                fill="currentColor"
-                                focusable="false"
-                                role="img"
-                                size="22px"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <FormattedScreenReaderMessage
-                            defaultMessage="Mobile preview"
-                            id="snippetEditor.desktopPreview"
-                          >
-                            <FormattedMessage
-                              defaultMessage="Mobile preview"
-                              id="snippetEditor.desktopPreview"
-                              values={Object {}}
-                            >
-                              <ScreenReaderText>
-                                <span
-                                  className="screen-reader-text"
-                                  style={
-                                    Object {
-                                      "clip": "rect(1px, 1px, 1px, 1px)",
-                                      "height": "1px",
-                                      "overflow": "hidden",
-                                      "position": "absolute",
-                                      "width": "1px",
-                                    }
-                                  }
-                                >
-                                  Mobile preview
-                                </span>
-                              </ScreenReaderText>
-                            </FormattedMessage>
-                          </FormattedScreenReaderMessage>
-                        </button>
-                      </Button__BaseButton>
-                    </Button>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={false}
-              className="c20"
-              isActive={false}
-              onClick={[Function]}
-            >
-              <Button
-                aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c20 c13"
-                isActive={false}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={false}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c20 c13 Button-kDSBcD c14"
-                  isActive={false}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={false}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                    isActive={false}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button
-                      aria-pressed={false}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                      isActive={false}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <Button__BaseButton
-                        aria-pressed={false}
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                        isActive={false}
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <button
-                          aria-pressed={false}
-                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
-                          >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c21"
-                                fill="currentColor"
-                                focusable="false"
-                                role="img"
-                                size="18px"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <FormattedScreenReaderMessage
-                            defaultMessage="Desktop preview"
-                            id="snippetEditor.desktopPreview"
-                          >
-                            <FormattedMessage
-                              defaultMessage="Desktop preview"
-                              id="snippetEditor.desktopPreview"
-                              values={Object {}}
-                            >
-                              <ScreenReaderText>
-                                <span
-                                  className="screen-reader-text"
-                                  style={
-                                    Object {
-                                      "clip": "rect(1px, 1px, 1px, 1px)",
-                                      "height": "1px",
-                                      "overflow": "hidden",
-                                      "position": "absolute",
-                                      "width": "1px",
-                                    }
-                                  }
-                                >
-                                  Desktop preview
-                                </span>
-                              </ScreenReaderText>
-                            </FormattedMessage>
-                          </FormattedScreenReaderMessage>
-                        </button>
-                      </Button__BaseButton>
-                    </Button>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={false}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
-      <Button
-        aria-expanded={false}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c22"
-        innerRef={[Function]}
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          aria-expanded={false}
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c22 Button-kDSBcD c14"
-          innerRef={[Function]}
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            aria-expanded={false}
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
-            innerRef={[Function]}
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              aria-expanded={false}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-              innerRef={[Function]}
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                aria-expanded={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                innerRef={[Function]}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  aria-expanded={false}
-                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
-                  >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
-                      size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c23"
-                        focusable="false"
-                        role="img"
-                        size="16px"
-                        viewBox="0 0 1792 1792"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  <FormattedMessage
-                    defaultMessage="Edit snippet"
-                    id="snippetEditor.editSnippet"
-                    values={Object {}}
-                  >
-                    <span>
-                      Edit snippet
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-  </div>
-</SnippetEditor>
-`;
-
-exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-  font-size: 14px;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 16px;
-}
-
-.c6 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-  max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.c9 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-  font-size: 13px;
-}
-
-.c8 {
-  max-height: 4em;
-}
-
-.c10 {
-  overflow: hidden;
-  font-size: 14px;
-  line-height: 20px;
-  max-height: calc( 4em + 3px );
-}
-
-.c1 {
-  padding: 8px 16px;
-}
-
-.c7 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
-}
-
-.c30 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c30::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c30::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c30::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c30::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c28 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c28::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c28::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c28::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c28::-ms-fill {
-  background-color: #ee7c1b;
-  border: 0;
-}
-
-.c27 {
-  padding: 3px 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-}
-
-.c27::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  padding: 3px 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-  min-height: 60px;
-  padding: 2px 6px;
-  line-height: 19.6px;
-}
-
-.c29::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c25 {
-  margin: 32px 0;
-}
-
-.c24 {
-  padding: 10px 20px 20px 20px;
-}
-
-.c26 {
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-}
-
-.c18 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c13 {
-  font-size: 0.8rem;
-}
-
-.c14:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c15:hover {
-  color: #000;
-}
-
-.c16::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c16:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c17 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c17 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c22 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c22 svg {
-  margin-right: 7px;
-}
-
-.c31 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
-}
-
-.c12 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c12:hover,
-.c12:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c20 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c20:hover,
-.c20:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c11 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c19 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c23 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c17::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<SnippetEditor
-  baseUrl="https://example.org/"
-  data={
-    Object {
-      "description": "Test description, %%replacement_variable%%",
-      "slug": "test-slug",
-      "title": "Test title",
-    }
-  }
-  date=""
-  descriptionLengthAssessment={
-    Object {
-      "actual": 0,
-      "max": 320,
-      "score": 0,
-    }
-  }
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "textComponent": "span",
-    }
-  }
-  mapDataToPreview={null}
-  mode="mobile"
-  onChange={[Function]}
-  replacementVariables={Array []}
-  titleLengthAssessment={
-    Object {
-      "actual": 361,
-      "max": 550,
-      "score": 6,
-    }
-  }
->
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      isDescriptionGenerated={false}
-      keyword=""
-      locale="en_US"
-      mode="mobile"
-      onClick={[Function]}
-      onHover={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c0"
-            width={640}
-          >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="SEO title preview"
-                  id="snippetPreview.seoTitlePreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="SEO title preview"
-                    id="snippetPreview.seoTitlePreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        SEO title preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseTitle
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c2"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c3"
-                      >
-                        <div
-                          className="c3 c4"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c5"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Url preview"
-                  id="snippetPreview.urlPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Url preview"
-                    id="snippetPreview.urlPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Url preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseUrl
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c6"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    example.org › test-slug
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c7"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Meta description preview"
-                  id="snippetPreview.metaDescriptionPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Meta description preview"
-                    id="snippetPreview.metaDescriptionPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Meta description preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__MobileDescription
-                  isDescriptionGenerated={false}
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <SnippetPreview__DesktopDescription
-                    className="c8"
-                    isDescriptionGenerated={false}
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <div
-                      className="c8 c9"
-                      color="#545454"
-                      onClick={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseOver={[Function]}
-                    >
-                      <SnippetPreview__MobileDescriptionOverflowContainer
-                        innerRef={[Function]}
-                      >
-                        <SnippetPreview__MobileDescription
-                          className="c10"
-                          innerRef={[Function]}
-                        >
-                          <SnippetPreview__DesktopDescription
-                            className="c10 c8"
-                            innerRef={[Function]}
-                          >
-                            <div
-                              className="c10 c8 c9"
-                              color="#545454"
-                            >
-                              Test description, %%replacement_variable%%
-                            </div>
-                          </SnippetPreview__DesktopDescription>
-                        </SnippetPreview__MobileDescription>
-                      </SnippetPreview__MobileDescriptionOverflowContainer>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c11"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={true}
-              className="c12"
-              isActive={true}
-              onClick={[Function]}
-            >
-              <Button
-                aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c12 c13"
-                isActive={true}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={true}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c12 c13 Button-kDSBcD c14"
-                  isActive={true}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={true}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                    isActive={true}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button
-                      aria-pressed={true}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                      isActive={true}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <Button__BaseButton
-                        aria-pressed={true}
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                        isActive={true}
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <button
-                          aria-pressed={true}
-                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
-                          >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c19"
-                                fill="currentColor"
-                                focusable="false"
-                                role="img"
-                                size="22px"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <FormattedScreenReaderMessage
-                            defaultMessage="Mobile preview"
-                            id="snippetEditor.desktopPreview"
-                          >
-                            <FormattedMessage
-                              defaultMessage="Mobile preview"
-                              id="snippetEditor.desktopPreview"
-                              values={Object {}}
-                            >
-                              <ScreenReaderText>
-                                <span
-                                  className="screen-reader-text"
-                                  style={
-                                    Object {
-                                      "clip": "rect(1px, 1px, 1px, 1px)",
-                                      "height": "1px",
-                                      "overflow": "hidden",
-                                      "position": "absolute",
-                                      "width": "1px",
-                                    }
-                                  }
-                                >
-                                  Mobile preview
-                                </span>
-                              </ScreenReaderText>
-                            </FormattedMessage>
-                          </FormattedScreenReaderMessage>
-                        </button>
-                      </Button__BaseButton>
-                    </Button>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={false}
-              className="c20"
-              isActive={false}
-              onClick={[Function]}
-            >
-              <Button
-                aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c20 c13"
-                isActive={false}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={false}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c20 c13 Button-kDSBcD c14"
-                  isActive={false}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={false}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                    isActive={false}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button
-                      aria-pressed={false}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                      isActive={false}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <Button__BaseButton
-                        aria-pressed={false}
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                        isActive={false}
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <button
-                          aria-pressed={false}
-                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
-                          >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c21"
-                                fill="currentColor"
-                                focusable="false"
-                                role="img"
-                                size="18px"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <FormattedScreenReaderMessage
-                            defaultMessage="Desktop preview"
-                            id="snippetEditor.desktopPreview"
-                          >
-                            <FormattedMessage
-                              defaultMessage="Desktop preview"
-                              id="snippetEditor.desktopPreview"
-                              values={Object {}}
-                            >
-                              <ScreenReaderText>
-                                <span
-                                  className="screen-reader-text"
-                                  style={
-                                    Object {
-                                      "clip": "rect(1px, 1px, 1px, 1px)",
-                                      "height": "1px",
-                                      "overflow": "hidden",
-                                      "position": "absolute",
-                                      "width": "1px",
-                                    }
-                                  }
-                                >
-                                  Desktop preview
-                                </span>
-                              </ScreenReaderText>
-                            </FormattedMessage>
-                          </FormattedScreenReaderMessage>
-                        </button>
-                      </Button__BaseButton>
-                    </Button>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
-      <Button
-        aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c22"
-        innerRef={[Function]}
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          aria-expanded={true}
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c22 Button-kDSBcD c14"
-          innerRef={[Function]}
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            aria-expanded={true}
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
-            innerRef={[Function]}
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              aria-expanded={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-              innerRef={[Function]}
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                aria-expanded={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                innerRef={[Function]}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  aria-expanded={true}
-                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
-                  >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
-                      size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c23"
-                        focusable="false"
-                        role="img"
-                        size="16px"
-                        viewBox="0 0 1792 1792"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  <FormattedMessage
-                    defaultMessage="Edit snippet"
-                    id="snippetEditor.editSnippet"
-                    values={Object {}}
-                  >
-                    <span>
-                      Edit snippet
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
-        }
-      }
-      descriptionLengthAssessment={
-        Object {
-          "actual": 0,
-          "max": 320,
-          "score": 0,
-        }
-      }
-      hoveredField={null}
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthAssessment={
-        Object {
-          "actual": 361,
-          "max": 550,
-          "score": 6,
-        }
-      }
-    >
-      <SnippetEditorFields__StyledEditor>
-        <section
-          className="c24"
-        >
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-8-title"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-8-title"
-                  onClick={[Function]}
-                >
-                  SEO title
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c27"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-8-title"
-                    content="Test title"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={550}
-                progressColor="#ee7c1b"
-                value={361}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c28"
-                  max={550}
-                  value={361}
-                />
-              </ProgressBar>
-            </div>
-          </SnippetEditorFields__FormSection>
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-8-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-8-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c27"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-8-slug"
-                    content="test-slug"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-            </div>
-          </SnippetEditorFields__FormSection>
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-8-description"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-8-description"
-                  onClick={[Function]}
-                >
-                  Meta description
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c29"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-8-description"
-                    content="Test description, %%replacement_variable%%"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={320}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c30"
-                  max={320}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </SnippetEditorFields__FormSection>
-        </section>
-      </SnippetEditorFields__StyledEditor>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
-      <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c31"
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c31 Button-kDSBcD c14"
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c31 Button-kDSBcD c14 Button-kDSBcD c15"
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c31 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c31 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  className="c31 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <FormattedMessage
-                    defaultMessage="Close snippet editor"
-                    id="snippet-editor.close-editor"
-                    values={Object {}}
-                  >
-                    <span>
-                      Close snippet editor
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-  </div>
-</SnippetEditor>
-`;
-
-exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-  font-size: 14px;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 16px;
-}
-
-.c6 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-  max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.c9 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-  font-size: 13px;
-}
-
-.c8 {
-  max-height: 4em;
-}
-
-.c10 {
-  overflow: hidden;
-  font-size: 14px;
-  line-height: 20px;
-  max-height: calc( 4em + 3px );
-}
-
-.c1 {
-  padding: 8px 16px;
-}
-
-.c7 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
-}
-
-.c28 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c28::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c28::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c28::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c28::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c30 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c30::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c30::-webkit-progress-value {
-  background-color: #7ad03a;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c30::-moz-progress-bar {
-  background-color: #7ad03a;
-}
-
-.c30::-ms-fill {
-  background-color: #7ad03a;
-  border: 0;
-}
-
-.c27 {
-  padding: 3px 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-}
-
-.c27::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  padding: 3px 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-  min-height: 60px;
-  padding: 2px 6px;
-  line-height: 19.6px;
-}
-
-.c29::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c25 {
-  margin: 32px 0;
-}
-
-.c24 {
-  padding: 10px 20px 20px 20px;
-}
-
-.c26 {
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-}
-
-.c18 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c13 {
-  font-size: 0.8rem;
-}
-
-.c14:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c15:hover {
-  color: #000;
-}
-
-.c16::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c16:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c17 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c17 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c22 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c22 svg {
-  margin-right: 7px;
-}
-
-.c31 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
-}
-
-.c12 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c12:hover,
-.c12:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c20 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c20:hover,
-.c20:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c11 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c19 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c23 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c17::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<SnippetEditor
-  baseUrl="https://example.org/"
-  data={
-    Object {
-      "description": "Test description, %%replacement_variable%%",
-      "slug": "test-slug",
-      "title": "Test title",
-    }
-  }
-  date=""
-  descriptionLengthAssessment={
-    Object {
-      "actual": 330,
-      "max": 650,
-      "score": 9,
-    }
-  }
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "textComponent": "span",
-    }
-  }
-  mapDataToPreview={null}
-  mode="mobile"
-  onChange={[Function]}
-  replacementVariables={Array []}
-  titleLengthAssessment={
-    Object {
-      "actual": 100,
-      "max": 550,
-      "score": 3,
-    }
-  }
->
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      isDescriptionGenerated={false}
-      keyword=""
-      locale="en_US"
-      mode="mobile"
-      onClick={[Function]}
-      onHover={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c0"
-            width={640}
-          >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="SEO title preview"
-                  id="snippetPreview.seoTitlePreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="SEO title preview"
-                    id="snippetPreview.seoTitlePreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        SEO title preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseTitle
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c2"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c3"
-                      >
-                        <div
-                          className="c3 c4"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c5"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Url preview"
-                  id="snippetPreview.urlPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Url preview"
-                    id="snippetPreview.urlPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Url preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseUrl
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c6"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    example.org › test-slug
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c7"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Meta description preview"
-                  id="snippetPreview.metaDescriptionPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Meta description preview"
-                    id="snippetPreview.metaDescriptionPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Meta description preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__MobileDescription
-                  isDescriptionGenerated={false}
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <SnippetPreview__DesktopDescription
-                    className="c8"
-                    isDescriptionGenerated={false}
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <div
-                      className="c8 c9"
-                      color="#545454"
-                      onClick={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseOver={[Function]}
-                    >
-                      <SnippetPreview__MobileDescriptionOverflowContainer
-                        innerRef={[Function]}
-                      >
-                        <SnippetPreview__MobileDescription
-                          className="c10"
-                          innerRef={[Function]}
-                        >
-                          <SnippetPreview__DesktopDescription
-                            className="c10 c8"
-                            innerRef={[Function]}
-                          >
-                            <div
-                              className="c10 c8 c9"
-                              color="#545454"
-                            >
-                              Test description, %%replacement_variable%%
-                            </div>
-                          </SnippetPreview__DesktopDescription>
-                        </SnippetPreview__MobileDescription>
-                      </SnippetPreview__MobileDescriptionOverflowContainer>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c11"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={true}
-              className="c12"
-              isActive={true}
-              onClick={[Function]}
-            >
-              <Button
-                aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c12 c13"
-                isActive={true}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={true}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c12 c13 Button-kDSBcD c14"
-                  isActive={true}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={true}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                    isActive={true}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button
-                      aria-pressed={true}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                      isActive={true}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <Button__BaseButton
-                        aria-pressed={true}
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                        isActive={true}
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <button
-                          aria-pressed={true}
-                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
-                          >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c19"
-                                fill="currentColor"
-                                focusable="false"
-                                role="img"
-                                size="22px"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <FormattedScreenReaderMessage
-                            defaultMessage="Mobile preview"
-                            id="snippetEditor.desktopPreview"
-                          >
-                            <FormattedMessage
-                              defaultMessage="Mobile preview"
-                              id="snippetEditor.desktopPreview"
-                              values={Object {}}
-                            >
-                              <ScreenReaderText>
-                                <span
-                                  className="screen-reader-text"
-                                  style={
-                                    Object {
-                                      "clip": "rect(1px, 1px, 1px, 1px)",
-                                      "height": "1px",
-                                      "overflow": "hidden",
-                                      "position": "absolute",
-                                      "width": "1px",
-                                    }
-                                  }
-                                >
-                                  Mobile preview
-                                </span>
-                              </ScreenReaderText>
-                            </FormattedMessage>
-                          </FormattedScreenReaderMessage>
-                        </button>
-                      </Button__BaseButton>
-                    </Button>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={false}
-              className="c20"
-              isActive={false}
-              onClick={[Function]}
-            >
-              <Button
-                aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c20 c13"
-                isActive={false}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={false}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c20 c13 Button-kDSBcD c14"
-                  isActive={false}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={false}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                    isActive={false}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button
-                      aria-pressed={false}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                      isActive={false}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <Button__BaseButton
-                        aria-pressed={false}
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                        isActive={false}
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <button
-                          aria-pressed={false}
-                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
-                          >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c21"
-                                fill="currentColor"
-                                focusable="false"
-                                role="img"
-                                size="18px"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <FormattedScreenReaderMessage
-                            defaultMessage="Desktop preview"
-                            id="snippetEditor.desktopPreview"
-                          >
-                            <FormattedMessage
-                              defaultMessage="Desktop preview"
-                              id="snippetEditor.desktopPreview"
-                              values={Object {}}
-                            >
-                              <ScreenReaderText>
-                                <span
-                                  className="screen-reader-text"
-                                  style={
-                                    Object {
-                                      "clip": "rect(1px, 1px, 1px, 1px)",
-                                      "height": "1px",
-                                      "overflow": "hidden",
-                                      "position": "absolute",
-                                      "width": "1px",
-                                    }
-                                  }
-                                >
-                                  Desktop preview
-                                </span>
-                              </ScreenReaderText>
-                            </FormattedMessage>
-                          </FormattedScreenReaderMessage>
-                        </button>
-                      </Button__BaseButton>
-                    </Button>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
-      <Button
-        aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c22"
-        innerRef={[Function]}
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          aria-expanded={true}
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c22 Button-kDSBcD c14"
-          innerRef={[Function]}
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            aria-expanded={true}
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
-            innerRef={[Function]}
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              aria-expanded={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-              innerRef={[Function]}
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                aria-expanded={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                innerRef={[Function]}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  aria-expanded={true}
-                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
-                  >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
-                      size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c23"
-                        focusable="false"
-                        role="img"
-                        size="16px"
-                        viewBox="0 0 1792 1792"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  <FormattedMessage
-                    defaultMessage="Edit snippet"
-                    id="snippetEditor.editSnippet"
-                    values={Object {}}
-                  >
-                    <span>
-                      Edit snippet
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
-        }
-      }
-      descriptionLengthAssessment={
-        Object {
-          "actual": 330,
-          "max": 650,
-          "score": 9,
-        }
-      }
-      hoveredField={null}
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthAssessment={
-        Object {
-          "actual": 100,
-          "max": 550,
-          "score": 3,
-        }
-      }
-    >
-      <SnippetEditorFields__StyledEditor>
-        <section
-          className="c24"
-        >
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-7-title"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-7-title"
-                  onClick={[Function]}
-                >
-                  SEO title
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c27"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-7-title"
-                    content="Test title"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={550}
-                progressColor="#dc3232"
-                value={100}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c28"
-                  max={550}
-                  value={100}
-                />
-              </ProgressBar>
-            </div>
-          </SnippetEditorFields__FormSection>
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-7-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-7-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c27"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-7-slug"
-                    content="test-slug"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-            </div>
-          </SnippetEditorFields__FormSection>
-          <SnippetEditorFields__FormSection>
-            <div
-              className="c25"
-            >
-              <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-7-description"
-                onClick={[Function]}
-              >
-                <div
-                  className="c26"
-                  id="snippet-editor-field-7-description"
-                  onClick={[Function]}
-                >
-                  Meta description
-                </div>
-              </SnippetEditorFields__SimulatedLabel>
-              <SnippetEditorFields__InputContainer
-                isActive={false}
-                isHovered={false}
-              >
-                <div
-                  className="c29"
-                >
-                  <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-7-description"
-                    content="Test description, %%replacement_variable%%"
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    replacementVariables={Array []}
-                  >
-                    <div />
-                  </ReplacementVariableEditor>
-                </div>
-              </SnippetEditorFields__InputContainer>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={650}
-                progressColor="#7ad03a"
-                value={330}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c30"
-                  max={650}
-                  value={330}
-                />
-              </ProgressBar>
-            </div>
-          </SnippetEditorFields__FormSection>
-        </section>
-      </SnippetEditorFields__StyledEditor>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
-      <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c31"
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c31 Button-kDSBcD c14"
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c31 Button-kDSBcD c14 Button-kDSBcD c15"
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c31 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c31 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  className="c31 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <FormattedMessage
-                    defaultMessage="Close snippet editor"
-                    id="snippet-editor.close-editor"
-                    values={Object {}}
-                  >
-                    <span>
-                      Close snippet editor
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-  </div>
-</SnippetEditor>
-`;
-
-exports[`SnippetEditor doesn't remove the highlight if the wrong field is left 1`] = `
-<div>
-  <SnippetPreview
-    activeField={null}
-    breadcrumbs={null}
-    date=""
-    description="Test description, %%replacement_variable%%"
-    hoveredField="description"
-    isAmp={false}
-    isDescriptionGenerated={false}
-    keyword=""
-    locale="en_US"
-    mode="mobile"
-    onClick={[Function]}
-    onHover={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    title="Test title"
-    url="example.org/test-slug"
-  />
-  <ModeSwitcher
-    active="mobile"
-    onChange={[Function]}
-  />
-  <Button
-    aria-expanded={true}
-    innerRef={[Function]}
-    onClick={[Function]}
-  >
-    <SvgIcon
-      icon="edit"
-      size="16px"
-    />
-    <FormattedMessage
-      defaultMessage="Edit snippet"
-      id="snippetEditor.editSnippet"
-      values={Object {}}
-    />
-  </Button>
-  <React.Fragment>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
-        }
-      }
-      descriptionLengthAssessment={
-        Object {
-          "actual": 0,
-          "max": 320,
-          "score": 0,
-        }
-      }
-      hoveredField="description"
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthAssessment={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 0,
-        }
-      }
-    />
-    <Button
-      onClick={[Function]}
-    >
-      <FormattedMessage
-        defaultMessage="Close snippet editor"
-        id="snippet-editor.close-editor"
-        values={Object {}}
-      />
-    </Button>
-  </React.Fragment>
-</div>
-`;
-
-exports[`SnippetEditor highlights a focused field 1`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-  font-size: 14px;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 16px;
-}
-
-.c6 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-  max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.c9 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-  font-size: 13px;
-}
-
-.c8 {
-  max-height: 4em;
-}
-
-.c10 {
-  overflow: hidden;
-  font-size: 14px;
-  line-height: 20px;
-  max-height: calc( 4em + 3px );
-}
-
-.c1 {
-  padding: 8px 16px;
-}
-
-.c7 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
-}
-
-.c18 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c13 {
-  font-size: 0.8rem;
-}
-
-.c14:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c15:hover {
-  color: #000;
-}
-
-.c16::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c16:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c17 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c17 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c22 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c22 svg {
-  margin-right: 7px;
-}
-
-.c12 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c12:hover,
-.c12:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c20 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c20:hover,
-.c20:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c11 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c19 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c23 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c17::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<div>
-  <section>
-    <div
-      className="c0"
-      onMouseLeave={undefined}
-      width={640}
-    >
-      <div
-        className="c1"
-      >
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          SEO title preview:
-        </span>
-        <div
-          className="c2"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          <div
-            className="c3 c4"
-          >
-            <span
-              className="c5"
-            >
-              Test title
-            </span>
-          </div>
-        </div>
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Url preview:
-        </span>
-        <div
-          className="c6"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          example.org › test-slug
-        </div>
-      </div>
-      <hr
-        className="c7"
-      />
-      <div
-        className="c1"
-      >
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Meta description preview:
-        </span>
-        <div
-          className="c8 c9"
-          color="#545454"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          <div
-            className="c10 c8 c9"
-            color="#545454"
-          >
-            Test description, %%replacement_variable%%
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-  <div
-    className="c11"
-  >
-    <button
-      aria-pressed={true}
-      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-      onClick={[Function]}
-      type="button"
-    >
-      <svg
-        aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c19"
-        fill="currentColor"
-        focusable="false"
-        role="img"
-        size="22px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-        />
-      </svg>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Mobile preview
-      </span>
-    </button>
-    <button
-      aria-pressed={false}
-      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-      onClick={[Function]}
-      type="button"
-    >
-      <svg
-        aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c21"
-        fill="currentColor"
-        focusable="false"
-        role="img"
-        size="18px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-        />
-      </svg>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Desktop preview
-      </span>
-    </button>
-  </div>
-  <button
-    aria-expanded={false}
-    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-    onClick={[Function]}
-    type="button"
-  >
-    <svg
-      aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c23"
-      fill={undefined}
-      focusable="false"
-      role="img"
-      size="16px"
-      viewBox="0 0 1792 1792"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-      />
-    </svg>
-    <span>
-      Edit snippet
-    </span>
-  </button>
-</div>
-`;
-
-exports[`SnippetEditor highlights a hovered field 1`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-  font-size: 14px;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 16px;
-}
-
-.c6 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-  max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.c9 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-  font-size: 13px;
-}
-
-.c8 {
-  max-height: 4em;
-}
-
-.c10 {
-  overflow: hidden;
-  font-size: 14px;
-  line-height: 20px;
-  max-height: calc( 4em + 3px );
-}
-
-.c1 {
-  padding: 8px 16px;
-}
-
-.c7 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
-}
-
-.c18 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c13 {
-  font-size: 0.8rem;
-}
-
-.c14:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c15:hover {
-  color: #000;
-}
-
-.c16::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c16:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c17 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c17 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c22 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c22 svg {
-  margin-right: 7px;
-}
-
-.c12 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c12:hover,
-.c12:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c20 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c20:hover,
-.c20:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c11 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c19 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c23 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c17::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<div>
-  <section>
-    <div
-      className="c0"
-      onMouseLeave={undefined}
-      width={640}
-    >
-      <div
-        className="c1"
-      >
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          SEO title preview:
-        </span>
-        <div
-          className="c2"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          <div
-            className="c3 c4"
-          >
-            <span
-              className="c5"
-            >
-              Test title
-            </span>
-          </div>
-        </div>
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Url preview:
-        </span>
-        <div
-          className="c6"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          example.org › test-slug
-        </div>
-      </div>
-      <hr
-        className="c7"
-      />
-      <div
-        className="c1"
-      >
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Meta description preview:
-        </span>
-        <div
-          className="c8 c9"
-          color="#545454"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          <div
-            className="c10 c8 c9"
-            color="#545454"
-          >
-            Test description, %%replacement_variable%%
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-  <div
-    className="c11"
-  >
-    <button
-      aria-pressed={true}
-      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-      onClick={[Function]}
-      type="button"
-    >
-      <svg
-        aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c19"
-        fill="currentColor"
-        focusable="false"
-        role="img"
-        size="22px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-        />
-      </svg>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Mobile preview
-      </span>
-    </button>
-    <button
-      aria-pressed={false}
-      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-      onClick={[Function]}
-      type="button"
-    >
-      <svg
-        aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c21"
-        fill="currentColor"
-        focusable="false"
-        role="img"
-        size="18px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-        />
-      </svg>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Desktop preview
-      </span>
-    </button>
-  </div>
-  <button
-    aria-expanded={false}
-    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
-    onClick={[Function]}
-    type="button"
-  >
-    <svg
-      aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c23"
-      fill={undefined}
-      focusable="false"
-      role="img"
-      size="16px"
-      viewBox="0 0 1792 1792"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-      />
-    </svg>
-    <span>
-      Edit snippet
-    </span>
-  </button>
-</div>
-`;
-
-exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-  font-size: 14px;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 16px;
-}
-
-.c7 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-  max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
+  max-width: 100%;
 }
 
 .c10 {
@@ -10419,7 +696,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   content: "";
 }
 
-.c31 {
+.c30 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -10437,33 +714,6 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   line-height: 19.6px;
 }
 
-.c31::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c30 {
-  padding: 3px 5px;
-  border: 1px solid #5b9dd9;
-  box-shadow: 0 0 2px rgba(30,140,190,.8);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-}
-
 .c30::before {
   display: block;
   position: absolute;
@@ -10471,7 +721,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   left: -25px;
   width: 24px;
   height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#1e8cbe%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
   background-size: 25px;
   content: "";
 }
@@ -10569,7 +819,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   margin-right: 7px;
 }
 
-.c32 {
+.c31 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -10660,18 +910,6 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   flex: none;
 }
 
-.c6::before {
-  display: block;
-  position: absolute;
-  top: -3px;
-  left: -40px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#555%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E );
-  background-size: 25px;
-  content: "";
-}
-
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
   .c18::after {
     display: inline-block;
@@ -10724,7 +962,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   }
   mapDataToPreview={null}
   mode="mobile"
-  onChange={[Function]}
+  onChange={[MockFunction]}
   replacementVariables={Array []}
   titleLengthAssessment={
     Object {
@@ -10736,7 +974,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
 >
   <div>
     <SnippetPreview
-      activeField="url"
+      activeField={null}
       breadcrumbs={null}
       date=""
       description="Test description, %%replacement_variable%%"
@@ -10856,27 +1094,33 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                     </ScreenReaderText>
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
-                <SnippetPreview
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <SnippetPreview__BaseUrl
+                <SnippetPreview__BaseUrl>
+                  <div
                     className="c6"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
                   >
-                    <div
-                      className="c6 c7"
+                    <SnippetPreview__BaseUrlOverflowContainer
                       onClick={[Function]}
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      example.org › test-slug
-                    </div>
-                  </SnippetPreview__BaseUrl>
-                </SnippetPreview>
+                      <SnippetPreview__BaseUrl
+                        className="c7"
+                        onClick={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <div
+                          className="c7 c6"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrl>
+                    </SnippetPreview__BaseUrlOverflowContainer>
+                  </div>
+                </SnippetPreview__BaseUrl>
               </div>
             </SnippetPreview__MobilePartContainer>
             <SnippetPreview__Separator>
@@ -11364,7 +1608,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
       </Button>
     </Button>
     <SnippetEditorFields
-      activeField="slug"
+      activeField={null}
       data={
         Object {
           "description": "Test description, %%replacement_variable%%",
@@ -11380,7 +1624,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
         }
       }
       hoveredField={null}
-      onChange={[Function]}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={Array []}
       titleLengthAssessment={
@@ -11400,12 +1644,12 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
               className="c26"
             >
               <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-4-title"
+                id="snippet-editor-field-5-title"
                 onClick={[Function]}
               >
                 <div
                   className="c27"
-                  id="snippet-editor-field-4-title"
+                  id="snippet-editor-field-5-title"
                   onClick={[Function]}
                 >
                   SEO title
@@ -11419,7 +1663,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                   className="c28"
                 >
                   <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-4-title"
+                    ariaLabelledBy="snippet-editor-field-5-title"
                     content="Test title"
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -11451,26 +1695,26 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
               className="c26"
             >
               <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-4-slug"
+                id="snippet-editor-field-5-slug"
                 onClick={[Function]}
               >
                 <div
                   className="c27"
-                  id="snippet-editor-field-4-slug"
+                  id="snippet-editor-field-5-slug"
                   onClick={[Function]}
                 >
                   Slug
                 </div>
               </SnippetEditorFields__SimulatedLabel>
               <SnippetEditorFields__InputContainer
-                isActive={true}
+                isActive={false}
                 isHovered={false}
               >
                 <div
-                  className="c30"
+                  className="c28"
                 >
                   <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-4-slug"
+                    ariaLabelledBy="snippet-editor-field-5-slug"
                     content="test-slug"
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -11487,12 +1731,12 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
               className="c26"
             >
               <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-4-description"
+                id="snippet-editor-field-5-description"
                 onClick={[Function]}
               >
                 <div
                   className="c27"
-                  id="snippet-editor-field-4-description"
+                  id="snippet-editor-field-5-description"
                   onClick={[Function]}
                 >
                   Meta description
@@ -11503,10 +1747,10 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                 isHovered={false}
               >
                 <div
-                  className="c31"
+                  className="c30"
                 >
                   <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-4-description"
+                    ariaLabelledBy="snippet-editor-field-5-description"
                     content="Test description, %%replacement_variable%%"
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -11543,7 +1787,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c32"
+        className="c31"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -11552,7 +1796,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c32 Button-kDSBcD c15"
+          className="c31 Button-kDSBcD c15"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -11561,7 +1805,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c32 Button-kDSBcD c15 Button-kDSBcD c16"
+            className="c31 Button-kDSBcD c15 Button-kDSBcD c16"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -11570,7 +1814,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c32 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+              className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -11579,13 +1823,13 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c32 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c32 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                  className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                   onClick={[Function]}
                   type="button"
                 >
@@ -11609,7 +1853,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
 </SnippetEditor>
 `;
 
-exports[`SnippetEditor highlights the hovered field when onMouseOver() is called 1`] = `
+exports[`SnippetEditor calls callbacks when the editors are focused or changed 2`] = `
 .c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -11662,9 +1906,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 
 .c10 {
@@ -11690,7 +1938,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   padding: 8px 16px;
 }
 
-.c7 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
@@ -11780,7 +2028,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   left: -25px;
   width: 24px;
   height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#ccc%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
   background-size: 25px;
   content: "";
 }
@@ -11969,18 +2217,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   flex: none;
 }
 
-.c8::before {
-  display: block;
-  position: absolute;
-  top: -3px;
-  left: -40px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#ccc%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E );
-  background-size: 25px;
-  content: "";
-}
-
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
   .c18::after {
     display: inline-block;
@@ -12033,7 +2269,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   }
   mapDataToPreview={null}
   mode="mobile"
-  onChange={[Function]}
+  onChange={[MockFunction]}
   replacementVariables={Array []}
   titleLengthAssessment={
     Object {
@@ -12049,7 +2285,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
       breadcrumbs={null}
       date=""
       description="Test description, %%replacement_variable%%"
-      hoveredField="description"
+      hoveredField={null}
       isAmp={false}
       isDescriptionGenerated={false}
       keyword=""
@@ -12165,25 +2401,38 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                     </ScreenReaderText>
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseUrl
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
+                <SnippetPreview__BaseUrl>
                   <div
                     className="c6"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
                   >
-                    example.org › test-slug
+                    <SnippetPreview__BaseUrlOverflowContainer
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__BaseUrl
+                        className="c7"
+                        onClick={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <div
+                          className="c7 c6"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrl>
+                    </SnippetPreview__BaseUrlOverflowContainer>
                   </div>
                 </SnippetPreview__BaseUrl>
               </div>
             </SnippetPreview__MobilePartContainer>
             <SnippetPreview__Separator>
               <hr
-                className="c7"
+                className="c8"
               />
             </SnippetPreview__Separator>
             <SnippetPreview__MobilePartContainer>
@@ -12219,57 +2468,49 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                     </ScreenReaderText>
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
-                <SnippetPreview
+                <SnippetPreview__MobileDescription
                   isDescriptionGenerated={false}
                   onClick={[Function]}
                   onMouseLeave={[Function]}
                   onMouseOver={[Function]}
                 >
-                  <SnippetPreview__MobileDescription
-                    className="c8"
+                  <SnippetPreview__DesktopDescription
+                    className="c9"
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
                     onMouseOver={[Function]}
                   >
-                    <SnippetPreview__DesktopDescription
-                      className="c8 c9"
-                      isDescriptionGenerated={false}
+                    <div
+                      className="c9 c10"
+                      color="#545454"
                       onClick={[Function]}
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      <div
-                        className="c8 c9 c10"
-                        color="#545454"
-                        onClick={[Function]}
-                        onMouseLeave={[Function]}
-                        onMouseOver={[Function]}
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
                       >
-                        <SnippetPreview__MobileDescriptionOverflowContainer
+                        <SnippetPreview__MobileDescription
+                          className="c11"
                           innerRef={[Function]}
                         >
-                          <SnippetPreview__MobileDescription
-                            className="c11"
+                          <SnippetPreview__DesktopDescription
+                            className="c11 c9"
                             innerRef={[Function]}
                           >
-                            <SnippetPreview__DesktopDescription
-                              className="c11 c9"
-                              innerRef={[Function]}
+                            <div
+                              className="c11 c9 c10"
+                              color="#545454"
                             >
-                              <div
-                                className="c11 c9 c10"
-                                color="#545454"
-                              >
-                                Test description, %%replacement_variable%%
-                              </div>
-                            </SnippetPreview__DesktopDescription>
-                          </SnippetPreview__MobileDescription>
-                        </SnippetPreview__MobileDescriptionOverflowContainer>
-                      </div>
-                    </SnippetPreview__DesktopDescription>
-                  </SnippetPreview__MobileDescription>
-                </SnippetPreview>
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
+                    </div>
+                  </SnippetPreview__DesktopDescription>
+                </SnippetPreview__MobileDescription>
               </div>
             </SnippetPreview__MobilePartContainer>
           </div>
@@ -12689,8 +2930,8 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
           "score": 0,
         }
       }
-      hoveredField="description"
-      onChange={[Function]}
+      hoveredField={null}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={Array []}
       titleLengthAssessment={
@@ -12710,12 +2951,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
               className="c26"
             >
               <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-3-title"
+                id="snippet-editor-field-5-title"
                 onClick={[Function]}
               >
                 <div
                   className="c27"
-                  id="snippet-editor-field-3-title"
+                  id="snippet-editor-field-5-title"
                   onClick={[Function]}
                 >
                   SEO title
@@ -12729,7 +2970,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                   className="c28"
                 >
                   <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-3-title"
+                    ariaLabelledBy="snippet-editor-field-5-title"
                     content="Test title"
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -12761,12 +3002,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
               className="c26"
             >
               <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-3-slug"
+                id="snippet-editor-field-5-slug"
                 onClick={[Function]}
               >
                 <div
                   className="c27"
-                  id="snippet-editor-field-3-slug"
+                  id="snippet-editor-field-5-slug"
                   onClick={[Function]}
                 >
                   Slug
@@ -12780,7 +3021,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                   className="c28"
                 >
                   <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-3-slug"
+                    ariaLabelledBy="snippet-editor-field-5-slug"
                     content="test-slug"
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -12797,12 +3038,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
               className="c26"
             >
               <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-3-description"
+                id="snippet-editor-field-5-description"
                 onClick={[Function]}
               >
                 <div
                   className="c27"
-                  id="snippet-editor-field-3-description"
+                  id="snippet-editor-field-5-description"
                   onClick={[Function]}
                 >
                   Meta description
@@ -12810,13 +3051,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
               </SnippetEditorFields__SimulatedLabel>
               <SnippetEditorFields__InputContainer
                 isActive={false}
-                isHovered={true}
+                isHovered={false}
               >
                 <div
                   className="c30"
                 >
                   <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-3-description"
+                    ariaLabelledBy="snippet-editor-field-5-description"
                     content="Test description, %%replacement_variable%%"
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -12919,7 +3160,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 </SnippetEditor>
 `;
 
-exports[`SnippetEditor opens when calling open() 1`] = `
+exports[`SnippetEditor calls callbacks when the editors are focused or changed 3`] = `
 .c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -12972,12 +3213,16 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c9 {
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -12985,11 +3230,11 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   font-size: 13px;
 }
 
-.c8 {
+.c9 {
   max-height: 4em;
 }
 
-.c10 {
+.c11 {
   overflow: hidden;
   font-size: 14px;
   line-height: 20px;
@@ -13000,13 +3245,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   padding: 8px 16px;
 }
 
-.c7 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
 }
 
-.c28 {
+.c29 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -13019,26 +3264,26 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border: 1px solid #ddd;
 }
 
-.c28::-webkit-progress-bar {
+.c29::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c28::-webkit-progress-value {
+.c29::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c28::-moz-progress-bar {
+.c29::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c28::-ms-fill {
+.c29::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
 
-.c27 {
+.c28 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -13053,7 +3298,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   margin-top: 5px;
 }
 
-.c27::before {
+.c28::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -13065,7 +3310,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   content: "";
 }
 
-.c29 {
+.c30 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -13083,7 +3328,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   line-height: 19.6px;
 }
 
-.c29::before {
+.c30::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -13095,50 +3340,50 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   content: "";
 }
 
-.c25 {
+.c26 {
   margin: 32px 0;
 }
 
-.c24 {
+.c25 {
   padding: 10px 20px 20px 20px;
 }
 
-.c26 {
+.c27 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c18 {
+.c19 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c13 {
+.c14 {
   font-size: 0.8rem;
 }
 
-.c14:active {
+.c15:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c15:hover {
+.c16:hover {
   color: #000;
 }
 
-.c16::-moz-focus-inner {
+.c17::-moz-focus-inner {
   border-width: 0;
 }
 
-.c16:focus {
+.c17:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c17 {
+.c18 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -13167,13 +3412,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   min-height: 32px;
 }
 
-.c17 svg {
+.c18 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c22 {
+.c23 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -13184,11 +3429,11 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   padding-left: 8px;
 }
 
-.c22 svg {
+.c23 svg {
   margin-right: 7px;
 }
 
-.c30 {
+.c31 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -13197,7 +3442,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   margin-left: 20px;
 }
 
-.c12 {
+.c13 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -13211,8 +3456,8 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c12:hover,
-.c12:focus {
+.c13:hover,
+.c13:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -13221,7 +3466,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   box-shadow: none;
 }
 
-.c20 {
+.c21 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -13235,8 +3480,8 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c20:hover,
-.c20:focus {
+.c21:hover,
+.c21:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -13245,7 +3490,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   box-shadow: none;
 }
 
-.c11 {
+.c12 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -13255,7 +3500,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   vertical-align: top;
 }
 
-.c19 {
+.c20 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -13263,7 +3508,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -13271,7 +3516,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   flex: none;
 }
 
-.c23 {
+.c24 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -13280,7 +3525,1314 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c17::after {
+  .c18::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<SnippetEditor
+  baseUrl="https://example.org/"
+  data={
+    Object {
+      "description": "Test description, %%replacement_variable%%",
+      "slug": "test-slug",
+      "title": "Test title",
+    }
+  }
+  date=""
+  descriptionLengthAssessment={
+    Object {
+      "actual": 0,
+      "max": 320,
+      "score": 0,
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "textComponent": "span",
+    }
+  }
+  mapDataToPreview={null}
+  mode="mobile"
+  onChange={[MockFunction]}
+  replacementVariables={Array []}
+  titleLengthAssessment={
+    Object {
+      "actual": 0,
+      "max": 600,
+      "score": 0,
+    }
+  }
+>
+  <div>
+    <SnippetPreview
+      activeField={null}
+      breadcrumbs={null}
+      date=""
+      description="Test description, %%replacement_variable%%"
+      hoveredField={null}
+      isAmp={false}
+      isDescriptionGenerated={false}
+      keyword=""
+      locale="en_US"
+      mode="mobile"
+      onClick={[Function]}
+      onHover={[Function]}
+      onMouseLeave={[Function]}
+      onMouseOver={[Function]}
+      title="Test title"
+      url="example.org/test-slug"
+    >
+      <section>
+        <SnippetPreview__MobileContainer
+          padding={20}
+          width={640}
+        >
+          <div
+            className="c0"
+            width={640}
+          >
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="SEO title preview"
+                  id="snippetPreview.seoTitlePreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="SEO title preview"
+                    id="snippetPreview.seoTitlePreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        SEO title preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseTitle
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <div
+                    className="c2"
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <SnippetPreview__TitleBounded>
+                      <SnippetPreview__Title
+                        className="c3"
+                      >
+                        <div
+                          className="c3 c4"
+                        >
+                          <SnippetPreview__TitleUnboundedMobile
+                            innerRef={[Function]}
+                          >
+                            <span
+                              className="c5"
+                            >
+                              Test title
+                            </span>
+                          </SnippetPreview__TitleUnboundedMobile>
+                        </div>
+                      </SnippetPreview__Title>
+                    </SnippetPreview__TitleBounded>
+                  </div>
+                </SnippetPreview__BaseTitle>
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Url preview"
+                  id="snippetPreview.urlPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Url preview"
+                    id="snippetPreview.urlPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Url preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseUrl>
+                  <div
+                    className="c6"
+                  >
+                    <SnippetPreview__BaseUrlOverflowContainer
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__BaseUrl
+                        className="c7"
+                        onClick={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <div
+                          className="c7 c6"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrl>
+                    </SnippetPreview__BaseUrlOverflowContainer>
+                  </div>
+                </SnippetPreview__BaseUrl>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+            <SnippetPreview__Separator>
+              <hr
+                className="c8"
+              />
+            </SnippetPreview__Separator>
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Meta description preview"
+                  id="snippetPreview.metaDescriptionPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Meta description preview"
+                    id="snippetPreview.metaDescriptionPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Meta description preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__MobileDescription
+                  isDescriptionGenerated={false}
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <SnippetPreview__DesktopDescription
+                    className="c9"
+                    isDescriptionGenerated={false}
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <div
+                      className="c9 c10"
+                      color="#545454"
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c11"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c11 c9"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c11 c9 c10"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
+                    </div>
+                  </SnippetPreview__DesktopDescription>
+                </SnippetPreview__MobileDescription>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+          </div>
+        </SnippetPreview__MobileContainer>
+      </section>
+    </SnippetPreview>
+    <ModeSwitcher
+      active="mobile"
+      onChange={[Function]}
+    >
+      <ModeSwitcher__Switcher>
+        <div
+          className="c12"
+        >
+          <ModeSwitcher__SwitcherButton
+            aria-pressed={true}
+            isActive={true}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={true}
+              className="c13"
+              isActive={true}
+              onClick={[Function]}
+            >
+              <Button
+                aria-pressed={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c13 c14"
+                isActive={true}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={true}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c13 c14 Button-kDSBcD c15"
+                  isActive={true}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={true}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                    isActive={true}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button
+                      aria-pressed={true}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                      isActive={true}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <Button__BaseButton
+                        aria-pressed={true}
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                        isActive={true}
+                        onClick={[Function]}
+                        textColor="#555"
+                        type="button"
+                      >
+                        <button
+                          aria-pressed={true}
+                          className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
+                            size="22px"
+                          >
+                            <SvgIcon__StyledSvg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="22px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c20"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
+                            defaultMessage="Mobile preview"
+                            id="snippetEditor.desktopPreview"
+                          >
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
+                                  }
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
+            aria-pressed={false}
+            isActive={false}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={false}
+              className="c21"
+              isActive={false}
+              onClick={[Function]}
+            >
+              <Button
+                aria-pressed={false}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c21 c14"
+                isActive={false}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={false}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c21 c14 Button-kDSBcD c15"
+                  isActive={false}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={false}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                    isActive={false}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button
+                      aria-pressed={false}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                      isActive={false}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <Button__BaseButton
+                        aria-pressed={false}
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                        isActive={false}
+                        onClick={[Function]}
+                        textColor="#555"
+                        type="button"
+                      >
+                        <button
+                          aria-pressed={false}
+                          className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
+                            size="18px"
+                          >
+                            <SvgIcon__StyledSvg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="18px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c22"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
+                            defaultMessage="Desktop preview"
+                            id="snippetEditor.desktopPreview"
+                          >
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
+                                  }
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </ModeSwitcher__SwitcherButton>
+        </div>
+      </ModeSwitcher__Switcher>
+    </ModeSwitcher>
+    <Button
+      aria-expanded={true}
+      innerRef={[Function]}
+      onClick={[Function]}
+    >
+      <Button
+        aria-expanded={true}
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c23"
+        innerRef={[Function]}
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          aria-expanded={true}
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c23 Button-kDSBcD c15"
+          innerRef={[Function]}
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            aria-expanded={true}
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c23 Button-kDSBcD c15 Button-kDSBcD c16"
+            innerRef={[Function]}
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              aria-expanded={true}
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+              innerRef={[Function]}
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                aria-expanded={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                innerRef={[Function]}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  aria-expanded={true}
+                  className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <SvgIcon
+                    icon="edit"
+                    size="16px"
+                  >
+                    <SvgIcon__StyledSvg
+                      aria-hidden={true}
+                      className="yoast-svg-icon yoast-svg-icon-edit"
+                      focusable="false"
+                      role="img"
+                      size="16px"
+                      viewBox="0 0 1792 1792"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="yoast-svg-icon yoast-svg-icon-edit c24"
+                        focusable="false"
+                        role="img"
+                        size="16px"
+                        viewBox="0 0 1792 1792"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                        />
+                      </svg>
+                    </SvgIcon__StyledSvg>
+                  </SvgIcon>
+                  <FormattedMessage
+                    defaultMessage="Edit snippet"
+                    id="snippetEditor.editSnippet"
+                    values={Object {}}
+                  >
+                    <span>
+                      Edit snippet
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+    <SnippetEditorFields
+      activeField={null}
+      data={
+        Object {
+          "description": "Test description, %%replacement_variable%%",
+          "slug": "test-slug",
+          "title": "Test title",
+        }
+      }
+      descriptionLengthAssessment={
+        Object {
+          "actual": 0,
+          "max": 320,
+          "score": 0,
+        }
+      }
+      hoveredField={null}
+      onChange={[MockFunction]}
+      onFocus={[Function]}
+      replacementVariables={Array []}
+      titleLengthAssessment={
+        Object {
+          "actual": 0,
+          "max": 600,
+          "score": 0,
+        }
+      }
+    >
+      <SnippetEditorFields__StyledEditor>
+        <section
+          className="c25"
+        >
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c26"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-5-title"
+                onClick={[Function]}
+              >
+                <div
+                  className="c27"
+                  id="snippet-editor-field-5-title"
+                  onClick={[Function]}
+                >
+                  SEO title
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c28"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-5-title"
+                    content="Test title"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+              <ProgressBar
+                aria-hidden="true"
+                backgroundColor="#f7f7f7"
+                borderColor="#ddd"
+                max={600}
+                progressColor="#dc3232"
+                value={0}
+              >
+                <progress
+                  aria-hidden="true"
+                  className="c29"
+                  max={600}
+                  value={0}
+                />
+              </ProgressBar>
+            </div>
+          </SnippetEditorFields__FormSection>
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c26"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-5-slug"
+                onClick={[Function]}
+              >
+                <div
+                  className="c27"
+                  id="snippet-editor-field-5-slug"
+                  onClick={[Function]}
+                >
+                  Slug
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c28"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-5-slug"
+                    content="test-slug"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+            </div>
+          </SnippetEditorFields__FormSection>
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c26"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-5-description"
+                onClick={[Function]}
+              >
+                <div
+                  className="c27"
+                  id="snippet-editor-field-5-description"
+                  onClick={[Function]}
+                >
+                  Meta description
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c30"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-5-description"
+                    content="Test description, %%replacement_variable%%"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+              <ProgressBar
+                aria-hidden="true"
+                backgroundColor="#f7f7f7"
+                borderColor="#ddd"
+                max={320}
+                progressColor="#dc3232"
+                value={0}
+              >
+                <progress
+                  aria-hidden="true"
+                  className="c29"
+                  max={320}
+                  value={0}
+                />
+              </ProgressBar>
+            </div>
+          </SnippetEditorFields__FormSection>
+        </section>
+      </SnippetEditorFields__StyledEditor>
+    </SnippetEditorFields>
+    <Button
+      onClick={[Function]}
+    >
+      <Button
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c31"
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c31 Button-kDSBcD c15"
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c31 Button-kDSBcD c15 Button-kDSBcD c16"
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <FormattedMessage
+                    defaultMessage="Close snippet editor"
+                    id="snippet-editor.close-editor"
+                    values={Object {}}
+                  >
+                    <span>
+                      Close snippet editor
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+  </div>
+</SnippetEditor>
+`;
+
+exports[`SnippetEditor closes when calling close() 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+}
+
+.c6 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+  font-size: 13px;
+}
+
+.c9 {
+  max-height: 4em;
+}
+
+.c11 {
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 20px;
+  max-height: calc( 4em + 3px );
+}
+
+.c1 {
+  padding: 8px 16px;
+}
+
+.c8 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c29::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c28 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+}
+
+.c28::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c30 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
+}
+
+.c30::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c26 {
+  margin: 32px 0;
+}
+
+.c25 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c27 {
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c19 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c14 {
+  font-size: 0.8rem;
+}
+
+.c15:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c16:hover {
+  color: #000;
+}
+
+.c17::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c17:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c18 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c18 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c23 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c23 svg {
+  margin-right: 7px;
+}
+
+.c31 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c13 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c13:hover,
+.c13:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c21 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c21:hover,
+.c21:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c12 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c20 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c22 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c24 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c18::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -13463,25 +5015,38 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     </ScreenReaderText>
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseUrl
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
+                <SnippetPreview__BaseUrl>
                   <div
                     className="c6"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
                   >
-                    example.org › test-slug
+                    <SnippetPreview__BaseUrlOverflowContainer
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__BaseUrl
+                        className="c7"
+                        onClick={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <div
+                          className="c7 c6"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrl>
+                    </SnippetPreview__BaseUrlOverflowContainer>
                   </div>
                 </SnippetPreview__BaseUrl>
               </div>
             </SnippetPreview__MobilePartContainer>
             <SnippetPreview__Separator>
               <hr
-                className="c7"
+                className="c8"
               />
             </SnippetPreview__Separator>
             <SnippetPreview__MobilePartContainer>
@@ -13524,14 +5089,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   onMouseOver={[Function]}
                 >
                   <SnippetPreview__DesktopDescription
-                    className="c8"
+                    className="c9"
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
                     onMouseOver={[Function]}
                   >
                     <div
-                      className="c8 c9"
+                      className="c9 c10"
                       color="#545454"
                       onClick={[Function]}
                       onMouseLeave={[Function]}
@@ -13541,15 +5106,15 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         innerRef={[Function]}
                       >
                         <SnippetPreview__MobileDescription
-                          className="c10"
+                          className="c11"
                           innerRef={[Function]}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c10 c8"
+                            className="c11 c9"
                             innerRef={[Function]}
                           >
                             <div
-                              className="c10 c8 c9"
+                              className="c11 c9 c10"
                               color="#545454"
                             >
                               Test description, %%replacement_variable%%
@@ -13572,7 +5137,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c11"
+          className="c12"
         >
           <ModeSwitcher__SwitcherButton
             aria-pressed={true}
@@ -13581,7 +5146,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           >
             <Button
               aria-pressed={true}
-              className="c12"
+              className="c13"
               isActive={true}
               onClick={[Function]}
             >
@@ -13590,7 +5155,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c12 c13"
+                className="c13 c14"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -13601,7 +5166,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c12 c13 Button-kDSBcD c14"
+                  className="c13 c14 Button-kDSBcD c15"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -13612,7 +5177,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                    className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -13623,7 +5188,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                      className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -13634,7 +5199,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                        className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -13642,7 +5207,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       >
                         <button
                           aria-pressed={true}
-                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                          className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                           onClick={[Function]}
                           type="button"
                         >
@@ -13663,7 +5228,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c19"
+                                className="yoast-svg-icon yoast-svg-icon-mobile c20"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -13719,7 +5284,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           >
             <Button
               aria-pressed={false}
-              className="c20"
+              className="c21"
               isActive={false}
               onClick={[Function]}
             >
@@ -13728,7 +5293,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 c13"
+                className="c21 c14"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -13739,7 +5304,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c20 c13 Button-kDSBcD c14"
+                  className="c21 c14 Button-kDSBcD c15"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -13750,7 +5315,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                    className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -13761,7 +5326,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                      className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -13772,7 +5337,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                        className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
@@ -13780,7 +5345,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       >
                         <button
                           aria-pressed={false}
-                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                          className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                           onClick={[Function]}
                           type="button"
                         >
@@ -13801,7 +5366,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c21"
+                                className="yoast-svg-icon yoast-svg-icon-desktop c22"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -13863,7 +5428,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c22"
+        className="c23"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -13874,7 +5439,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c22 Button-kDSBcD c14"
+          className="c23 Button-kDSBcD c15"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -13885,7 +5450,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
+            className="c23 Button-kDSBcD c15 Button-kDSBcD c16"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -13896,7 +5461,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+              className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -13907,7 +5472,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -13915,7 +5480,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               >
                 <button
                   aria-expanded={true}
-                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                  className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                   onClick={[Function]}
                   type="button"
                 >
@@ -13934,7 +5499,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c23"
+                        className="yoast-svg-icon yoast-svg-icon-edit c24"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -13993,19 +5558,19 @@ exports[`SnippetEditor opens when calling open() 1`] = `
     >
       <SnippetEditorFields__StyledEditor>
         <section
-          className="c24"
+          className="c25"
         >
           <SnippetEditorFields__FormSection>
             <div
-              className="c25"
+              className="c26"
             >
               <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-1-title"
+                id="snippet-editor-field-2-title"
                 onClick={[Function]}
               >
                 <div
-                  className="c26"
-                  id="snippet-editor-field-1-title"
+                  className="c27"
+                  id="snippet-editor-field-2-title"
                   onClick={[Function]}
                 >
                   SEO title
@@ -14016,10 +5581,10 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 isHovered={false}
               >
                 <div
-                  className="c27"
+                  className="c28"
                 >
                   <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-1-title"
+                    ariaLabelledBy="snippet-editor-field-2-title"
                     content="Test title"
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -14039,7 +5604,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               >
                 <progress
                   aria-hidden="true"
-                  className="c28"
+                  className="c29"
                   max={600}
                   value={0}
                 />
@@ -14048,15 +5613,15 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c25"
+              className="c26"
             >
               <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-1-slug"
+                id="snippet-editor-field-2-slug"
                 onClick={[Function]}
               >
                 <div
-                  className="c26"
-                  id="snippet-editor-field-1-slug"
+                  className="c27"
+                  id="snippet-editor-field-2-slug"
                   onClick={[Function]}
                 >
                   Slug
@@ -14067,10 +5632,10 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 isHovered={false}
               >
                 <div
-                  className="c27"
+                  className="c28"
                 >
                   <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-1-slug"
+                    ariaLabelledBy="snippet-editor-field-2-slug"
                     content="test-slug"
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -14084,15 +5649,15 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c25"
+              className="c26"
             >
               <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-1-description"
+                id="snippet-editor-field-2-description"
                 onClick={[Function]}
               >
                 <div
-                  className="c26"
-                  id="snippet-editor-field-1-description"
+                  className="c27"
+                  id="snippet-editor-field-2-description"
                   onClick={[Function]}
                 >
                   Meta description
@@ -14103,10 +5668,10 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 isHovered={false}
               >
                 <div
-                  className="c29"
+                  className="c30"
                 >
                   <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-1-description"
+                    ariaLabelledBy="snippet-editor-field-2-description"
                     content="Test description, %%replacement_variable%%"
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -14126,7 +5691,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               >
                 <progress
                   aria-hidden="true"
-                  className="c28"
+                  className="c29"
                   max={320}
                   value={0}
                 />
@@ -14143,7 +5708,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c30"
+        className="c31"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -14152,7 +5717,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c30 Button-kDSBcD c14"
+          className="c31 Button-kDSBcD c15"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -14161,7 +5726,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c30 Button-kDSBcD c14 Button-kDSBcD c15"
+            className="c31 Button-kDSBcD c15 Button-kDSBcD c16"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -14170,7 +5735,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+              className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -14179,13 +5744,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                  className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                   onClick={[Function]}
                   type="button"
                 >
@@ -14209,7 +5774,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 </SnippetEditor>
 `;
 
-exports[`SnippetEditor passes replacement variables to the title and description editor 1`] = `
+exports[`SnippetEditor closes when calling close() 2`] = `
 .c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -14262,12 +5827,16 @@ exports[`SnippetEditor passes replacement variables to the title and description
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c9 {
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -14275,11 +5844,11 @@ exports[`SnippetEditor passes replacement variables to the title and description
   font-size: 13px;
 }
 
-.c8 {
+.c9 {
   max-height: 4em;
 }
 
-.c10 {
+.c11 {
   overflow: hidden;
   font-size: 14px;
   line-height: 20px;
@@ -14290,145 +5859,42 @@ exports[`SnippetEditor passes replacement variables to the title and description
   padding: 8px 16px;
 }
 
-.c7 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
 }
 
-.c28 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c28::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c28::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c28::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c28::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c27 {
-  padding: 3px 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-}
-
-.c27::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  padding: 3px 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  margin-top: 5px;
-  min-height: 60px;
-  padding: 2px 6px;
-  line-height: 19.6px;
-}
-
-.c29::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c25 {
-  margin: 32px 0;
-}
-
-.c24 {
-  padding: 10px 20px 20px 20px;
-}
-
-.c26 {
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-}
-
-.c18 {
+.c19 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c13 {
+.c14 {
   font-size: 0.8rem;
 }
 
-.c14:active {
+.c15:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c15:hover {
+.c16:hover {
   color: #000;
 }
 
-.c16::-moz-focus-inner {
+.c17::-moz-focus-inner {
   border-width: 0;
 }
 
-.c16:focus {
+.c17:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c17 {
+.c18 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -14457,13 +5923,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
   min-height: 32px;
 }
 
-.c17 svg {
+.c18 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c22 {
+.c23 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -14474,20 +5940,11 @@ exports[`SnippetEditor passes replacement variables to the title and description
   padding-left: 8px;
 }
 
-.c22 svg {
+.c23 svg {
   margin-right: 7px;
 }
 
-.c30 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-left: 20px;
-}
-
-.c12 {
+.c13 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -14501,8 +5958,8 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border-radius: 3px 0 0 3px;
 }
 
-.c12:hover,
-.c12:focus {
+.c13:hover,
+.c13:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -14511,7 +5968,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   box-shadow: none;
 }
 
-.c20 {
+.c21 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -14525,8 +5982,8 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border-radius: 0 3px 3px 0;
 }
 
-.c20:hover,
-.c20:focus {
+.c21:hover,
+.c21:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -14535,7 +5992,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   box-shadow: none;
 }
 
-.c11 {
+.c12 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -14545,7 +6002,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   vertical-align: top;
 }
 
-.c19 {
+.c20 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -14553,7 +6010,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -14561,7 +6018,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   flex: none;
 }
 
-.c23 {
+.c24 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -14570,7 +6027,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c17::after {
+  .c18::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -14622,18 +6079,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   mapDataToPreview={null}
   mode="mobile"
   onChange={[Function]}
-  replacementVariables={
-    Array [
-      Object {
-        "name": "title",
-        "value": "Title!!!",
-      },
-      Object {
-        "name": "excerpt",
-        "value": "Excerpt!!!",
-      },
-    ]
-  }
+  replacementVariables={Array []}
   titleLengthAssessment={
     Object {
       "actual": 0,
@@ -14764,25 +6210,38 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     </ScreenReaderText>
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseUrl
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
+                <SnippetPreview__BaseUrl>
                   <div
                     className="c6"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
                   >
-                    example.org › test-slug
+                    <SnippetPreview__BaseUrlOverflowContainer
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__BaseUrl
+                        className="c7"
+                        onClick={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <div
+                          className="c7 c6"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrl>
+                    </SnippetPreview__BaseUrlOverflowContainer>
                   </div>
                 </SnippetPreview__BaseUrl>
               </div>
             </SnippetPreview__MobilePartContainer>
             <SnippetPreview__Separator>
               <hr
-                className="c7"
+                className="c8"
               />
             </SnippetPreview__Separator>
             <SnippetPreview__MobilePartContainer>
@@ -14825,14 +6284,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   onMouseOver={[Function]}
                 >
                   <SnippetPreview__DesktopDescription
-                    className="c8"
+                    className="c9"
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
                     onMouseOver={[Function]}
                   >
                     <div
-                      className="c8 c9"
+                      className="c9 c10"
                       color="#545454"
                       onClick={[Function]}
                       onMouseLeave={[Function]}
@@ -14842,15 +6301,15 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         innerRef={[Function]}
                       >
                         <SnippetPreview__MobileDescription
-                          className="c10"
+                          className="c11"
                           innerRef={[Function]}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c10 c8"
+                            className="c11 c9"
                             innerRef={[Function]}
                           >
                             <div
-                              className="c10 c8 c9"
+                              className="c11 c9 c10"
                               color="#545454"
                             >
                               Test description, %%replacement_variable%%
@@ -14873,7 +6332,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c11"
+          className="c12"
         >
           <ModeSwitcher__SwitcherButton
             aria-pressed={true}
@@ -14882,7 +6341,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           >
             <Button
               aria-pressed={true}
-              className="c12"
+              className="c13"
               isActive={true}
               onClick={[Function]}
             >
@@ -14891,7 +6350,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c12 c13"
+                className="c13 c14"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -14902,7 +6361,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c12 c13 Button-kDSBcD c14"
+                  className="c13 c14 Button-kDSBcD c15"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -14913,7 +6372,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                    className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -14924,7 +6383,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                      className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -14935,7 +6394,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                        className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -14943,7 +6402,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       >
                         <button
                           aria-pressed={true}
-                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                          className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                           onClick={[Function]}
                           type="button"
                         >
@@ -14964,7 +6423,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c19"
+                                className="yoast-svg-icon yoast-svg-icon-mobile c20"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -15020,7 +6479,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           >
             <Button
               aria-pressed={false}
-              className="c20"
+              className="c21"
               isActive={false}
               onClick={[Function]}
             >
@@ -15029,7 +6488,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 c13"
+                className="c21 c14"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -15040,7 +6499,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c20 c13 Button-kDSBcD c14"
+                  className="c21 c14 Button-kDSBcD c15"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -15051,7 +6510,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                    className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -15062,7 +6521,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                      className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -15073,7 +6532,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                        className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
@@ -15081,7 +6540,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       >
                         <button
                           aria-pressed={false}
-                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                          className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                           onClick={[Function]}
                           type="button"
                         >
@@ -15102,7 +6561,1104 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c21"
+                                className="yoast-svg-icon yoast-svg-icon-desktop c22"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
+                            defaultMessage="Desktop preview"
+                            id="snippetEditor.desktopPreview"
+                          >
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
+                                  }
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </ModeSwitcher__SwitcherButton>
+        </div>
+      </ModeSwitcher__Switcher>
+    </ModeSwitcher>
+    <Button
+      aria-expanded={false}
+      innerRef={[Function]}
+      onClick={[Function]}
+    >
+      <Button
+        aria-expanded={false}
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c23"
+        innerRef={[Function]}
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          aria-expanded={false}
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c23 Button-kDSBcD c15"
+          innerRef={[Function]}
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            aria-expanded={false}
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c23 Button-kDSBcD c15 Button-kDSBcD c16"
+            innerRef={[Function]}
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              aria-expanded={false}
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+              innerRef={[Function]}
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                aria-expanded={false}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                innerRef={[Function]}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  aria-expanded={false}
+                  className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <SvgIcon
+                    icon="edit"
+                    size="16px"
+                  >
+                    <SvgIcon__StyledSvg
+                      aria-hidden={true}
+                      className="yoast-svg-icon yoast-svg-icon-edit"
+                      focusable="false"
+                      role="img"
+                      size="16px"
+                      viewBox="0 0 1792 1792"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="yoast-svg-icon yoast-svg-icon-edit c24"
+                        focusable="false"
+                        role="img"
+                        size="16px"
+                        viewBox="0 0 1792 1792"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                        />
+                      </svg>
+                    </SvgIcon__StyledSvg>
+                  </SvgIcon>
+                  <FormattedMessage
+                    defaultMessage="Edit snippet"
+                    id="snippetEditor.editSnippet"
+                    values={Object {}}
+                  >
+                    <span>
+                      Edit snippet
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+  </div>
+</SnippetEditor>
+`;
+
+exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+}
+
+.c6 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+  font-size: 13px;
+}
+
+.c9 {
+  max-height: 4em;
+}
+
+.c11 {
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 20px;
+  max-height: calc( 4em + 3px );
+}
+
+.c1 {
+  padding: 8px 16px;
+}
+
+.c8 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c31 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c31::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c31::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c31::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c31::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c29::-ms-fill {
+  background-color: #ee7c1b;
+  border: 0;
+}
+
+.c28 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+}
+
+.c28::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c30 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
+}
+
+.c30::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c26 {
+  margin: 32px 0;
+}
+
+.c25 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c27 {
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c19 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c14 {
+  font-size: 0.8rem;
+}
+
+.c15:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c16:hover {
+  color: #000;
+}
+
+.c17::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c17:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c18 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c18 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c23 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c23 svg {
+  margin-right: 7px;
+}
+
+.c32 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c13 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c13:hover,
+.c13:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c21 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c21:hover,
+.c21:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c12 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c20 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c22 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c24 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c18::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<SnippetEditor
+  baseUrl="https://example.org/"
+  data={
+    Object {
+      "description": "Test description, %%replacement_variable%%",
+      "slug": "test-slug",
+      "title": "Test title",
+    }
+  }
+  date=""
+  descriptionLengthAssessment={
+    Object {
+      "actual": 0,
+      "max": 320,
+      "score": 0,
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "textComponent": "span",
+    }
+  }
+  mapDataToPreview={null}
+  mode="mobile"
+  onChange={[Function]}
+  replacementVariables={Array []}
+  titleLengthAssessment={
+    Object {
+      "actual": 361,
+      "max": 550,
+      "score": 6,
+    }
+  }
+>
+  <div>
+    <SnippetPreview
+      activeField={null}
+      breadcrumbs={null}
+      date=""
+      description="Test description, %%replacement_variable%%"
+      hoveredField={null}
+      isAmp={false}
+      isDescriptionGenerated={false}
+      keyword=""
+      locale="en_US"
+      mode="mobile"
+      onClick={[Function]}
+      onHover={[Function]}
+      onMouseLeave={[Function]}
+      onMouseOver={[Function]}
+      title="Test title"
+      url="example.org/test-slug"
+    >
+      <section>
+        <SnippetPreview__MobileContainer
+          padding={20}
+          width={640}
+        >
+          <div
+            className="c0"
+            width={640}
+          >
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="SEO title preview"
+                  id="snippetPreview.seoTitlePreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="SEO title preview"
+                    id="snippetPreview.seoTitlePreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        SEO title preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseTitle
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <div
+                    className="c2"
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <SnippetPreview__TitleBounded>
+                      <SnippetPreview__Title
+                        className="c3"
+                      >
+                        <div
+                          className="c3 c4"
+                        >
+                          <SnippetPreview__TitleUnboundedMobile
+                            innerRef={[Function]}
+                          >
+                            <span
+                              className="c5"
+                            >
+                              Test title
+                            </span>
+                          </SnippetPreview__TitleUnboundedMobile>
+                        </div>
+                      </SnippetPreview__Title>
+                    </SnippetPreview__TitleBounded>
+                  </div>
+                </SnippetPreview__BaseTitle>
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Url preview"
+                  id="snippetPreview.urlPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Url preview"
+                    id="snippetPreview.urlPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Url preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseUrl>
+                  <div
+                    className="c6"
+                  >
+                    <SnippetPreview__BaseUrlOverflowContainer
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__BaseUrl
+                        className="c7"
+                        onClick={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <div
+                          className="c7 c6"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrl>
+                    </SnippetPreview__BaseUrlOverflowContainer>
+                  </div>
+                </SnippetPreview__BaseUrl>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+            <SnippetPreview__Separator>
+              <hr
+                className="c8"
+              />
+            </SnippetPreview__Separator>
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Meta description preview"
+                  id="snippetPreview.metaDescriptionPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Meta description preview"
+                    id="snippetPreview.metaDescriptionPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Meta description preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__MobileDescription
+                  isDescriptionGenerated={false}
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <SnippetPreview__DesktopDescription
+                    className="c9"
+                    isDescriptionGenerated={false}
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <div
+                      className="c9 c10"
+                      color="#545454"
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c11"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c11 c9"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c11 c9 c10"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
+                    </div>
+                  </SnippetPreview__DesktopDescription>
+                </SnippetPreview__MobileDescription>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+          </div>
+        </SnippetPreview__MobileContainer>
+      </section>
+    </SnippetPreview>
+    <ModeSwitcher
+      active="mobile"
+      onChange={[Function]}
+    >
+      <ModeSwitcher__Switcher>
+        <div
+          className="c12"
+        >
+          <ModeSwitcher__SwitcherButton
+            aria-pressed={true}
+            isActive={true}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={true}
+              className="c13"
+              isActive={true}
+              onClick={[Function]}
+            >
+              <Button
+                aria-pressed={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c13 c14"
+                isActive={true}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={true}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c13 c14 Button-kDSBcD c15"
+                  isActive={true}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={true}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                    isActive={true}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button
+                      aria-pressed={true}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                      isActive={true}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <Button__BaseButton
+                        aria-pressed={true}
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                        isActive={true}
+                        onClick={[Function]}
+                        textColor="#555"
+                        type="button"
+                      >
+                        <button
+                          aria-pressed={true}
+                          className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
+                            size="22px"
+                          >
+                            <SvgIcon__StyledSvg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="22px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c20"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
+                            defaultMessage="Mobile preview"
+                            id="snippetEditor.desktopPreview"
+                          >
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
+                                  }
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
+            aria-pressed={false}
+            isActive={false}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={false}
+              className="c21"
+              isActive={false}
+              onClick={[Function]}
+            >
+              <Button
+                aria-pressed={false}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c21 c14"
+                isActive={false}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={false}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c21 c14 Button-kDSBcD c15"
+                  isActive={false}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={false}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                    isActive={false}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button
+                      aria-pressed={false}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                      isActive={false}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <Button__BaseButton
+                        aria-pressed={false}
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                        isActive={false}
+                        onClick={[Function]}
+                        textColor="#555"
+                        type="button"
+                      >
+                        <button
+                          aria-pressed={false}
+                          className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
+                            size="18px"
+                          >
+                            <SvgIcon__StyledSvg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="18px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c22"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -15164,7 +7720,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c22"
+        className="c23"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -15175,7 +7731,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c22 Button-kDSBcD c14"
+          className="c23 Button-kDSBcD c15"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -15186,7 +7742,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
+            className="c23 Button-kDSBcD c15 Button-kDSBcD c16"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -15197,7 +7753,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+              className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -15208,7 +7764,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -15216,7 +7772,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               >
                 <button
                   aria-expanded={true}
-                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                  className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                   onClick={[Function]}
                   type="button"
                 >
@@ -15235,7 +7791,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c23"
+                        className="yoast-svg-icon yoast-svg-icon-edit c24"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -15283,41 +7839,30 @@ exports[`SnippetEditor passes replacement variables to the title and description
       hoveredField={null}
       onChange={[Function]}
       onFocus={[Function]}
-      replacementVariables={
-        Array [
-          Object {
-            "name": "title",
-            "value": "Title!!!",
-          },
-          Object {
-            "name": "excerpt",
-            "value": "Excerpt!!!",
-          },
-        ]
-      }
+      replacementVariables={Array []}
       titleLengthAssessment={
         Object {
-          "actual": 0,
-          "max": 600,
-          "score": 0,
+          "actual": 361,
+          "max": 550,
+          "score": 6,
         }
       }
     >
       <SnippetEditorFields__StyledEditor>
         <section
-          className="c24"
+          className="c25"
         >
           <SnippetEditorFields__FormSection>
             <div
-              className="c25"
+              className="c26"
             >
               <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-6-title"
+                id="snippet-editor-field-8-title"
                 onClick={[Function]}
               >
                 <div
-                  className="c26"
-                  id="snippet-editor-field-6-title"
+                  className="c27"
+                  id="snippet-editor-field-8-title"
                   onClick={[Function]}
                 >
                   SEO title
@@ -15328,25 +7873,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 isHovered={false}
               >
                 <div
-                  className="c27"
+                  className="c28"
                 >
                   <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-6-title"
+                    ariaLabelledBy="snippet-editor-field-8-title"
                     content="Test title"
                     onChange={[Function]}
                     onFocus={[Function]}
-                    replacementVariables={
-                      Array [
-                        Object {
-                          "name": "title",
-                          "value": "Title!!!",
-                        },
-                        Object {
-                          "name": "excerpt",
-                          "value": "Excerpt!!!",
-                        },
-                      ]
-                    }
+                    replacementVariables={Array []}
                   >
                     <div />
                   </ReplacementVariableEditor>
@@ -15356,30 +7890,30 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 aria-hidden="true"
                 backgroundColor="#f7f7f7"
                 borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
+                max={550}
+                progressColor="#ee7c1b"
+                value={361}
               >
                 <progress
                   aria-hidden="true"
-                  className="c28"
-                  max={600}
-                  value={0}
+                  className="c29"
+                  max={550}
+                  value={361}
                 />
               </ProgressBar>
             </div>
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c25"
+              className="c26"
             >
               <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-6-slug"
+                id="snippet-editor-field-8-slug"
                 onClick={[Function]}
               >
                 <div
-                  className="c26"
-                  id="snippet-editor-field-6-slug"
+                  className="c27"
+                  id="snippet-editor-field-8-slug"
                   onClick={[Function]}
                 >
                   Slug
@@ -15390,10 +7924,10 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 isHovered={false}
               >
                 <div
-                  className="c27"
+                  className="c28"
                 >
                   <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-6-slug"
+                    ariaLabelledBy="snippet-editor-field-8-slug"
                     content="test-slug"
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -15407,15 +7941,15 @@ exports[`SnippetEditor passes replacement variables to the title and description
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c25"
+              className="c26"
             >
               <SnippetEditorFields__SimulatedLabel
-                id="snippet-editor-field-6-description"
+                id="snippet-editor-field-8-description"
                 onClick={[Function]}
               >
                 <div
-                  className="c26"
-                  id="snippet-editor-field-6-description"
+                  className="c27"
+                  id="snippet-editor-field-8-description"
                   onClick={[Function]}
                 >
                   Meta description
@@ -15426,25 +7960,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 isHovered={false}
               >
                 <div
-                  className="c29"
+                  className="c30"
                 >
                   <ReplacementVariableEditor
-                    ariaLabelledBy="snippet-editor-field-6-description"
+                    ariaLabelledBy="snippet-editor-field-8-description"
                     content="Test description, %%replacement_variable%%"
                     onChange={[Function]}
                     onFocus={[Function]}
-                    replacementVariables={
-                      Array [
-                        Object {
-                          "name": "title",
-                          "value": "Title!!!",
-                        },
-                        Object {
-                          "name": "excerpt",
-                          "value": "Excerpt!!!",
-                        },
-                      ]
-                    }
+                    replacementVariables={Array []}
                   >
                     <div />
                   </ReplacementVariableEditor>
@@ -15460,7 +7983,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               >
                 <progress
                   aria-hidden="true"
-                  className="c28"
+                  className="c31"
                   max={320}
                   value={0}
                 />
@@ -15477,7 +8000,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c30"
+        className="c32"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -15486,7 +8009,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c30 Button-kDSBcD c14"
+          className="c32 Button-kDSBcD c15"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -15495,7 +8018,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c30 Button-kDSBcD c14 Button-kDSBcD c15"
+            className="c32 Button-kDSBcD c15 Button-kDSBcD c16"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -15504,7 +8027,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+              className="c32 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -15513,13 +8036,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                className="c32 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                  className="c32 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                   onClick={[Function]}
                   type="button"
                 >
@@ -15543,7 +8066,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
 </SnippetEditor>
 `;
 
-exports[`SnippetEditor passes the date prop 1`] = `
+exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = `
 .c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -15596,12 +8119,16 @@ exports[`SnippetEditor passes the date prop 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c9 {
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -15609,11 +8136,11 @@ exports[`SnippetEditor passes the date prop 1`] = `
   font-size: 13px;
 }
 
-.c8 {
+.c9 {
   max-height: 4em;
 }
 
-.c10 {
+.c11 {
   overflow: hidden;
   font-size: 14px;
   line-height: 20px;
@@ -15624,11 +8151,1427 @@ exports[`SnippetEditor passes the date prop 1`] = `
   padding: 8px 16px;
 }
 
-.c11 {
-  color: #808080;
+.c8 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c29::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c31 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c31::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c31::-webkit-progress-value {
+  background-color: #7ad03a;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c31::-moz-progress-bar {
+  background-color: #7ad03a;
+}
+
+.c31::-ms-fill {
+  background-color: #7ad03a;
+  border: 0;
+}
+
+.c28 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+}
+
+.c28::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c30 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
+}
+
+.c30::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c26 {
+  margin: 32px 0;
+}
+
+.c25 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c27 {
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c19 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c14 {
+  font-size: 0.8rem;
+}
+
+.c15:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c16:hover {
+  color: #000;
+}
+
+.c17::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c17:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c18 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c18 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c23 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c23 svg {
+  margin-right: 7px;
+}
+
+.c32 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c13 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c13:hover,
+.c13:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c21 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c21:hover,
+.c21:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c12 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c20 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c22 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c24 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c18::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<SnippetEditor
+  baseUrl="https://example.org/"
+  data={
+    Object {
+      "description": "Test description, %%replacement_variable%%",
+      "slug": "test-slug",
+      "title": "Test title",
+    }
+  }
+  date=""
+  descriptionLengthAssessment={
+    Object {
+      "actual": 330,
+      "max": 650,
+      "score": 9,
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "textComponent": "span",
+    }
+  }
+  mapDataToPreview={null}
+  mode="mobile"
+  onChange={[Function]}
+  replacementVariables={Array []}
+  titleLengthAssessment={
+    Object {
+      "actual": 100,
+      "max": 550,
+      "score": 3,
+    }
+  }
+>
+  <div>
+    <SnippetPreview
+      activeField={null}
+      breadcrumbs={null}
+      date=""
+      description="Test description, %%replacement_variable%%"
+      hoveredField={null}
+      isAmp={false}
+      isDescriptionGenerated={false}
+      keyword=""
+      locale="en_US"
+      mode="mobile"
+      onClick={[Function]}
+      onHover={[Function]}
+      onMouseLeave={[Function]}
+      onMouseOver={[Function]}
+      title="Test title"
+      url="example.org/test-slug"
+    >
+      <section>
+        <SnippetPreview__MobileContainer
+          padding={20}
+          width={640}
+        >
+          <div
+            className="c0"
+            width={640}
+          >
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="SEO title preview"
+                  id="snippetPreview.seoTitlePreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="SEO title preview"
+                    id="snippetPreview.seoTitlePreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        SEO title preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseTitle
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <div
+                    className="c2"
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <SnippetPreview__TitleBounded>
+                      <SnippetPreview__Title
+                        className="c3"
+                      >
+                        <div
+                          className="c3 c4"
+                        >
+                          <SnippetPreview__TitleUnboundedMobile
+                            innerRef={[Function]}
+                          >
+                            <span
+                              className="c5"
+                            >
+                              Test title
+                            </span>
+                          </SnippetPreview__TitleUnboundedMobile>
+                        </div>
+                      </SnippetPreview__Title>
+                    </SnippetPreview__TitleBounded>
+                  </div>
+                </SnippetPreview__BaseTitle>
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Url preview"
+                  id="snippetPreview.urlPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Url preview"
+                    id="snippetPreview.urlPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Url preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseUrl>
+                  <div
+                    className="c6"
+                  >
+                    <SnippetPreview__BaseUrlOverflowContainer
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__BaseUrl
+                        className="c7"
+                        onClick={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <div
+                          className="c7 c6"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrl>
+                    </SnippetPreview__BaseUrlOverflowContainer>
+                  </div>
+                </SnippetPreview__BaseUrl>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+            <SnippetPreview__Separator>
+              <hr
+                className="c8"
+              />
+            </SnippetPreview__Separator>
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Meta description preview"
+                  id="snippetPreview.metaDescriptionPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Meta description preview"
+                    id="snippetPreview.metaDescriptionPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Meta description preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__MobileDescription
+                  isDescriptionGenerated={false}
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <SnippetPreview__DesktopDescription
+                    className="c9"
+                    isDescriptionGenerated={false}
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <div
+                      className="c9 c10"
+                      color="#545454"
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c11"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c11 c9"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c11 c9 c10"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
+                    </div>
+                  </SnippetPreview__DesktopDescription>
+                </SnippetPreview__MobileDescription>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+          </div>
+        </SnippetPreview__MobileContainer>
+      </section>
+    </SnippetPreview>
+    <ModeSwitcher
+      active="mobile"
+      onChange={[Function]}
+    >
+      <ModeSwitcher__Switcher>
+        <div
+          className="c12"
+        >
+          <ModeSwitcher__SwitcherButton
+            aria-pressed={true}
+            isActive={true}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={true}
+              className="c13"
+              isActive={true}
+              onClick={[Function]}
+            >
+              <Button
+                aria-pressed={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c13 c14"
+                isActive={true}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={true}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c13 c14 Button-kDSBcD c15"
+                  isActive={true}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={true}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                    isActive={true}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button
+                      aria-pressed={true}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                      isActive={true}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <Button__BaseButton
+                        aria-pressed={true}
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                        isActive={true}
+                        onClick={[Function]}
+                        textColor="#555"
+                        type="button"
+                      >
+                        <button
+                          aria-pressed={true}
+                          className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
+                            size="22px"
+                          >
+                            <SvgIcon__StyledSvg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="22px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c20"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
+                            defaultMessage="Mobile preview"
+                            id="snippetEditor.desktopPreview"
+                          >
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
+                                  }
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
+            aria-pressed={false}
+            isActive={false}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={false}
+              className="c21"
+              isActive={false}
+              onClick={[Function]}
+            >
+              <Button
+                aria-pressed={false}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c21 c14"
+                isActive={false}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={false}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c21 c14 Button-kDSBcD c15"
+                  isActive={false}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={false}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                    isActive={false}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button
+                      aria-pressed={false}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                      isActive={false}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <Button__BaseButton
+                        aria-pressed={false}
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                        isActive={false}
+                        onClick={[Function]}
+                        textColor="#555"
+                        type="button"
+                      >
+                        <button
+                          aria-pressed={false}
+                          className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
+                            size="18px"
+                          >
+                            <SvgIcon__StyledSvg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="18px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c22"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
+                            defaultMessage="Desktop preview"
+                            id="snippetEditor.desktopPreview"
+                          >
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
+                                  }
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </ModeSwitcher__SwitcherButton>
+        </div>
+      </ModeSwitcher__Switcher>
+    </ModeSwitcher>
+    <Button
+      aria-expanded={true}
+      innerRef={[Function]}
+      onClick={[Function]}
+    >
+      <Button
+        aria-expanded={true}
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c23"
+        innerRef={[Function]}
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          aria-expanded={true}
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c23 Button-kDSBcD c15"
+          innerRef={[Function]}
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            aria-expanded={true}
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c23 Button-kDSBcD c15 Button-kDSBcD c16"
+            innerRef={[Function]}
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              aria-expanded={true}
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+              innerRef={[Function]}
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                aria-expanded={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                innerRef={[Function]}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  aria-expanded={true}
+                  className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <SvgIcon
+                    icon="edit"
+                    size="16px"
+                  >
+                    <SvgIcon__StyledSvg
+                      aria-hidden={true}
+                      className="yoast-svg-icon yoast-svg-icon-edit"
+                      focusable="false"
+                      role="img"
+                      size="16px"
+                      viewBox="0 0 1792 1792"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="yoast-svg-icon yoast-svg-icon-edit c24"
+                        focusable="false"
+                        role="img"
+                        size="16px"
+                        viewBox="0 0 1792 1792"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                        />
+                      </svg>
+                    </SvgIcon__StyledSvg>
+                  </SvgIcon>
+                  <FormattedMessage
+                    defaultMessage="Edit snippet"
+                    id="snippetEditor.editSnippet"
+                    values={Object {}}
+                  >
+                    <span>
+                      Edit snippet
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+    <SnippetEditorFields
+      activeField={null}
+      data={
+        Object {
+          "description": "Test description, %%replacement_variable%%",
+          "slug": "test-slug",
+          "title": "Test title",
+        }
+      }
+      descriptionLengthAssessment={
+        Object {
+          "actual": 330,
+          "max": 650,
+          "score": 9,
+        }
+      }
+      hoveredField={null}
+      onChange={[Function]}
+      onFocus={[Function]}
+      replacementVariables={Array []}
+      titleLengthAssessment={
+        Object {
+          "actual": 100,
+          "max": 550,
+          "score": 3,
+        }
+      }
+    >
+      <SnippetEditorFields__StyledEditor>
+        <section
+          className="c25"
+        >
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c26"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-7-title"
+                onClick={[Function]}
+              >
+                <div
+                  className="c27"
+                  id="snippet-editor-field-7-title"
+                  onClick={[Function]}
+                >
+                  SEO title
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c28"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-7-title"
+                    content="Test title"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+              <ProgressBar
+                aria-hidden="true"
+                backgroundColor="#f7f7f7"
+                borderColor="#ddd"
+                max={550}
+                progressColor="#dc3232"
+                value={100}
+              >
+                <progress
+                  aria-hidden="true"
+                  className="c29"
+                  max={550}
+                  value={100}
+                />
+              </ProgressBar>
+            </div>
+          </SnippetEditorFields__FormSection>
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c26"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-7-slug"
+                onClick={[Function]}
+              >
+                <div
+                  className="c27"
+                  id="snippet-editor-field-7-slug"
+                  onClick={[Function]}
+                >
+                  Slug
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c28"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-7-slug"
+                    content="test-slug"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+            </div>
+          </SnippetEditorFields__FormSection>
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c26"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-7-description"
+                onClick={[Function]}
+              >
+                <div
+                  className="c27"
+                  id="snippet-editor-field-7-description"
+                  onClick={[Function]}
+                >
+                  Meta description
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c30"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-7-description"
+                    content="Test description, %%replacement_variable%%"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+              <ProgressBar
+                aria-hidden="true"
+                backgroundColor="#f7f7f7"
+                borderColor="#ddd"
+                max={650}
+                progressColor="#7ad03a"
+                value={330}
+              >
+                <progress
+                  aria-hidden="true"
+                  className="c31"
+                  max={650}
+                  value={330}
+                />
+              </ProgressBar>
+            </div>
+          </SnippetEditorFields__FormSection>
+        </section>
+      </SnippetEditorFields__StyledEditor>
+    </SnippetEditorFields>
+    <Button
+      onClick={[Function]}
+    >
+      <Button
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c32"
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c32 Button-kDSBcD c15"
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c32 Button-kDSBcD c15 Button-kDSBcD c16"
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c32 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c32 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  className="c32 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <FormattedMessage
+                    defaultMessage="Close snippet editor"
+                    id="snippet-editor.close-editor"
+                    values={Object {}}
+                  >
+                    <span>
+                      Close snippet editor
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+  </div>
+</SnippetEditor>
+`;
+
+exports[`SnippetEditor doesn't remove the highlight if the wrong field is left 1`] = `
+<div>
+  <SnippetPreview
+    activeField={null}
+    breadcrumbs={null}
+    date=""
+    description="Test description, %%replacement_variable%%"
+    hoveredField="description"
+    isAmp={false}
+    isDescriptionGenerated={false}
+    keyword=""
+    locale="en_US"
+    mode="mobile"
+    onClick={[Function]}
+    onHover={[Function]}
+    onMouseLeave={[Function]}
+    onMouseOver={[Function]}
+    title="Test title"
+    url="example.org/test-slug"
+  />
+  <ModeSwitcher
+    active="mobile"
+    onChange={[Function]}
+  />
+  <Button
+    aria-expanded={true}
+    innerRef={[Function]}
+    onClick={[Function]}
+  >
+    <SvgIcon
+      icon="edit"
+      size="16px"
+    />
+    <FormattedMessage
+      defaultMessage="Edit snippet"
+      id="snippetEditor.editSnippet"
+      values={Object {}}
+    />
+  </Button>
+  <React.Fragment>
+    <SnippetEditorFields
+      activeField={null}
+      data={
+        Object {
+          "description": "Test description, %%replacement_variable%%",
+          "slug": "test-slug",
+          "title": "Test title",
+        }
+      }
+      descriptionLengthAssessment={
+        Object {
+          "actual": 0,
+          "max": 320,
+          "score": 0,
+        }
+      }
+      hoveredField="description"
+      onChange={[Function]}
+      onFocus={[Function]}
+      replacementVariables={Array []}
+      titleLengthAssessment={
+        Object {
+          "actual": 0,
+          "max": 600,
+          "score": 0,
+        }
+      }
+    />
+    <Button
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Close snippet editor"
+        id="snippet-editor.close-editor"
+        values={Object {}}
+      />
+    </Button>
+  </React.Fragment>
+</div>
+`;
+
+exports[`SnippetEditor highlights a focused field 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+}
+
+.c6 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
 }
 
 .c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+  font-size: 13px;
+}
+
+.c9 {
+  max-height: 4em;
+}
+
+.c11 {
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 20px;
+  max-height: calc( 4em + 3px );
+}
+
+.c1 {
+  padding: 8px 16px;
+}
+
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
@@ -15859,15 +9802,19 @@ exports[`SnippetEditor passes the date prop 1`] = `
         </span>
         <div
           className="c6"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
         >
-          example.org › test-slug
+          <div
+            className="c7 c6"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            example.org › test-slug
+          </div>
         </div>
       </div>
       <hr
-        className="c7"
+        className="c8"
       />
       <div
         className="c1"
@@ -15887,22 +9834,16 @@ exports[`SnippetEditor passes the date prop 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c8 c9"
+          className="c9 c10"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
         >
           <div
-            className="c10 c8 c9"
+            className="c11 c9 c10"
             color="#545454"
           >
-            <span
-              className="c11"
-            >
-              date string
-               - 
-            </span>
             Test description, %%replacement_variable%%
           </div>
         </div>
@@ -15992,6 +9933,6281 @@ exports[`SnippetEditor passes the date prop 1`] = `
     <svg
       aria-hidden={true}
       className="yoast-svg-icon yoast-svg-icon-edit c24"
+      fill={undefined}
+      focusable="false"
+      role="img"
+      size="16px"
+      viewBox="0 0 1792 1792"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+      />
+    </svg>
+    <span>
+      Edit snippet
+    </span>
+  </button>
+</div>
+`;
+
+exports[`SnippetEditor highlights a hovered field 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+}
+
+.c6 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+  font-size: 13px;
+}
+
+.c9 {
+  max-height: 4em;
+}
+
+.c11 {
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 20px;
+  max-height: calc( 4em + 3px );
+}
+
+.c1 {
+  padding: 8px 16px;
+}
+
+.c8 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c19 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c14 {
+  font-size: 0.8rem;
+}
+
+.c15:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c16:hover {
+  color: #000;
+}
+
+.c17::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c17:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c18 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c18 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c23 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c23 svg {
+  margin-right: 7px;
+}
+
+.c13 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c13:hover,
+.c13:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c21 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c21:hover,
+.c21:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c12 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c20 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c22 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c24 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c18::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<div>
+  <section>
+    <div
+      className="c0"
+      onMouseLeave={undefined}
+      width={640}
+    >
+      <div
+        className="c1"
+      >
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          SEO title preview:
+        </span>
+        <div
+          className="c2"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          <div
+            className="c3 c4"
+          >
+            <span
+              className="c5"
+            >
+              Test title
+            </span>
+          </div>
+        </div>
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          Url preview:
+        </span>
+        <div
+          className="c6"
+        >
+          <div
+            className="c7 c6"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            example.org › test-slug
+          </div>
+        </div>
+      </div>
+      <hr
+        className="c8"
+      />
+      <div
+        className="c1"
+      >
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          Meta description preview:
+        </span>
+        <div
+          className="c9 c10"
+          color="#545454"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          <div
+            className="c11 c9 c10"
+            color="#545454"
+          >
+            Test description, %%replacement_variable%%
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <div
+    className="c12"
+  >
+    <button
+      aria-pressed={true}
+      className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-mobile c20"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="22px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Mobile preview
+      </span>
+    </button>
+    <button
+      aria-pressed={false}
+      className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-desktop c22"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="18px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Desktop preview
+      </span>
+    </button>
+  </div>
+  <button
+    aria-expanded={false}
+    className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      aria-hidden={true}
+      className="yoast-svg-icon yoast-svg-icon-edit c24"
+      fill={undefined}
+      focusable="false"
+      role="img"
+      size="16px"
+      viewBox="0 0 1792 1792"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+      />
+    </svg>
+    <span>
+      Edit snippet
+    </span>
+  </button>
+</div>
+`;
+
+exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+}
+
+.c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+}
+
+.c8 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c11 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+  font-size: 13px;
+}
+
+.c10 {
+  max-height: 4em;
+}
+
+.c12 {
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 20px;
+  max-height: calc( 4em + 3px );
+}
+
+.c1 {
+  padding: 8px 16px;
+}
+
+.c9 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c30 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c30::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c30::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c30::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c30::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c29 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+}
+
+.c29::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c32 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
+}
+
+.c32::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c31 {
+  padding: 3px 5px;
+  border: 1px solid #5b9dd9;
+  box-shadow: 0 0 2px rgba(30,140,190,.8);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+}
+
+.c31::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#1e8cbe%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c27 {
+  margin: 32px 0;
+}
+
+.c26 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c28 {
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c20 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c15 {
+  font-size: 0.8rem;
+}
+
+.c16:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c17:hover {
+  color: #000;
+}
+
+.c18::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c18:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c19 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c19 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c24 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c24 svg {
+  margin-right: 7px;
+}
+
+.c33 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c14 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c14:hover,
+.c14:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c22 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c22:hover,
+.c22:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c13 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c21 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c23 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c25 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c6::before {
+  display: block;
+  position: absolute;
+  top: -3px;
+  left: -40px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#555%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c19::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<SnippetEditor
+  baseUrl="https://example.org/"
+  data={
+    Object {
+      "description": "Test description, %%replacement_variable%%",
+      "slug": "test-slug",
+      "title": "Test title",
+    }
+  }
+  date=""
+  descriptionLengthAssessment={
+    Object {
+      "actual": 0,
+      "max": 320,
+      "score": 0,
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "textComponent": "span",
+    }
+  }
+  mapDataToPreview={null}
+  mode="mobile"
+  onChange={[Function]}
+  replacementVariables={Array []}
+  titleLengthAssessment={
+    Object {
+      "actual": 0,
+      "max": 600,
+      "score": 0,
+    }
+  }
+>
+  <div>
+    <SnippetPreview
+      activeField="url"
+      breadcrumbs={null}
+      date=""
+      description="Test description, %%replacement_variable%%"
+      hoveredField={null}
+      isAmp={false}
+      isDescriptionGenerated={false}
+      keyword=""
+      locale="en_US"
+      mode="mobile"
+      onClick={[Function]}
+      onHover={[Function]}
+      onMouseLeave={[Function]}
+      onMouseOver={[Function]}
+      title="Test title"
+      url="example.org/test-slug"
+    >
+      <section>
+        <SnippetPreview__MobileContainer
+          padding={20}
+          width={640}
+        >
+          <div
+            className="c0"
+            width={640}
+          >
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="SEO title preview"
+                  id="snippetPreview.seoTitlePreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="SEO title preview"
+                    id="snippetPreview.seoTitlePreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        SEO title preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseTitle
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <div
+                    className="c2"
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <SnippetPreview__TitleBounded>
+                      <SnippetPreview__Title
+                        className="c3"
+                      >
+                        <div
+                          className="c3 c4"
+                        >
+                          <SnippetPreview__TitleUnboundedMobile
+                            innerRef={[Function]}
+                          >
+                            <span
+                              className="c5"
+                            >
+                              Test title
+                            </span>
+                          </SnippetPreview__TitleUnboundedMobile>
+                        </div>
+                      </SnippetPreview__Title>
+                    </SnippetPreview__TitleBounded>
+                  </div>
+                </SnippetPreview__BaseTitle>
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Url preview"
+                  id="snippetPreview.urlPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Url preview"
+                    id="snippetPreview.urlPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Url preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview>
+                  <SnippetPreview__BaseUrl
+                    className="c6"
+                  >
+                    <div
+                      className="c6 c7"
+                    >
+                      <SnippetPreview__BaseUrlOverflowContainer
+                        onClick={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <SnippetPreview__BaseUrl
+                          className="c8"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                        >
+                          <div
+                            className="c8 c7"
+                            onClick={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseOver={[Function]}
+                          >
+                            example.org › test-slug
+                          </div>
+                        </SnippetPreview__BaseUrl>
+                      </SnippetPreview__BaseUrlOverflowContainer>
+                    </div>
+                  </SnippetPreview__BaseUrl>
+                </SnippetPreview>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+            <SnippetPreview__Separator>
+              <hr
+                className="c9"
+              />
+            </SnippetPreview__Separator>
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Meta description preview"
+                  id="snippetPreview.metaDescriptionPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Meta description preview"
+                    id="snippetPreview.metaDescriptionPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Meta description preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__MobileDescription
+                  isDescriptionGenerated={false}
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <SnippetPreview__DesktopDescription
+                    className="c10"
+                    isDescriptionGenerated={false}
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <div
+                      className="c10 c11"
+                      color="#545454"
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c12"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c12 c10"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c12 c10 c11"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
+                    </div>
+                  </SnippetPreview__DesktopDescription>
+                </SnippetPreview__MobileDescription>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+          </div>
+        </SnippetPreview__MobileContainer>
+      </section>
+    </SnippetPreview>
+    <ModeSwitcher
+      active="mobile"
+      onChange={[Function]}
+    >
+      <ModeSwitcher__Switcher>
+        <div
+          className="c13"
+        >
+          <ModeSwitcher__SwitcherButton
+            aria-pressed={true}
+            isActive={true}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={true}
+              className="c14"
+              isActive={true}
+              onClick={[Function]}
+            >
+              <Button
+                aria-pressed={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c14 c15"
+                isActive={true}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={true}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c14 c15 Button-kDSBcD c16"
+                  isActive={true}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={true}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c14 c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                    isActive={true}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button
+                      aria-pressed={true}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c14 c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                      isActive={true}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <Button__BaseButton
+                        aria-pressed={true}
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c14 c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19"
+                        isActive={true}
+                        onClick={[Function]}
+                        textColor="#555"
+                        type="button"
+                      >
+                        <button
+                          aria-pressed={true}
+                          className="c14 c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19 c20"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
+                            size="22px"
+                          >
+                            <SvgIcon__StyledSvg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="22px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c21"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
+                            defaultMessage="Mobile preview"
+                            id="snippetEditor.desktopPreview"
+                          >
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
+                                  }
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
+            aria-pressed={false}
+            isActive={false}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={false}
+              className="c22"
+              isActive={false}
+              onClick={[Function]}
+            >
+              <Button
+                aria-pressed={false}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c22 c15"
+                isActive={false}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={false}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c22 c15 Button-kDSBcD c16"
+                  isActive={false}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={false}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c22 c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                    isActive={false}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button
+                      aria-pressed={false}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c22 c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                      isActive={false}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <Button__BaseButton
+                        aria-pressed={false}
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c22 c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19"
+                        isActive={false}
+                        onClick={[Function]}
+                        textColor="#555"
+                        type="button"
+                      >
+                        <button
+                          aria-pressed={false}
+                          className="c22 c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19 c20"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
+                            size="18px"
+                          >
+                            <SvgIcon__StyledSvg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="18px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c23"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
+                            defaultMessage="Desktop preview"
+                            id="snippetEditor.desktopPreview"
+                          >
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
+                                  }
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </ModeSwitcher__SwitcherButton>
+        </div>
+      </ModeSwitcher__Switcher>
+    </ModeSwitcher>
+    <Button
+      aria-expanded={true}
+      innerRef={[Function]}
+      onClick={[Function]}
+    >
+      <Button
+        aria-expanded={true}
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c24"
+        innerRef={[Function]}
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          aria-expanded={true}
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c24 Button-kDSBcD c16"
+          innerRef={[Function]}
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            aria-expanded={true}
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c24 Button-kDSBcD c16 Button-kDSBcD c17"
+            innerRef={[Function]}
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              aria-expanded={true}
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c24 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+              innerRef={[Function]}
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                aria-expanded={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c24 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19"
+                innerRef={[Function]}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  aria-expanded={true}
+                  className="c24 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19 c20"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <SvgIcon
+                    icon="edit"
+                    size="16px"
+                  >
+                    <SvgIcon__StyledSvg
+                      aria-hidden={true}
+                      className="yoast-svg-icon yoast-svg-icon-edit"
+                      focusable="false"
+                      role="img"
+                      size="16px"
+                      viewBox="0 0 1792 1792"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="yoast-svg-icon yoast-svg-icon-edit c25"
+                        focusable="false"
+                        role="img"
+                        size="16px"
+                        viewBox="0 0 1792 1792"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                        />
+                      </svg>
+                    </SvgIcon__StyledSvg>
+                  </SvgIcon>
+                  <FormattedMessage
+                    defaultMessage="Edit snippet"
+                    id="snippetEditor.editSnippet"
+                    values={Object {}}
+                  >
+                    <span>
+                      Edit snippet
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+    <SnippetEditorFields
+      activeField="slug"
+      data={
+        Object {
+          "description": "Test description, %%replacement_variable%%",
+          "slug": "test-slug",
+          "title": "Test title",
+        }
+      }
+      descriptionLengthAssessment={
+        Object {
+          "actual": 0,
+          "max": 320,
+          "score": 0,
+        }
+      }
+      hoveredField={null}
+      onChange={[Function]}
+      onFocus={[Function]}
+      replacementVariables={Array []}
+      titleLengthAssessment={
+        Object {
+          "actual": 0,
+          "max": 600,
+          "score": 0,
+        }
+      }
+    >
+      <SnippetEditorFields__StyledEditor>
+        <section
+          className="c26"
+        >
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c27"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-4-title"
+                onClick={[Function]}
+              >
+                <div
+                  className="c28"
+                  id="snippet-editor-field-4-title"
+                  onClick={[Function]}
+                >
+                  SEO title
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c29"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-4-title"
+                    content="Test title"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+              <ProgressBar
+                aria-hidden="true"
+                backgroundColor="#f7f7f7"
+                borderColor="#ddd"
+                max={600}
+                progressColor="#dc3232"
+                value={0}
+              >
+                <progress
+                  aria-hidden="true"
+                  className="c30"
+                  max={600}
+                  value={0}
+                />
+              </ProgressBar>
+            </div>
+          </SnippetEditorFields__FormSection>
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c27"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-4-slug"
+                onClick={[Function]}
+              >
+                <div
+                  className="c28"
+                  id="snippet-editor-field-4-slug"
+                  onClick={[Function]}
+                >
+                  Slug
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={true}
+                isHovered={false}
+              >
+                <div
+                  className="c31"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-4-slug"
+                    content="test-slug"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+            </div>
+          </SnippetEditorFields__FormSection>
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c27"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-4-description"
+                onClick={[Function]}
+              >
+                <div
+                  className="c28"
+                  id="snippet-editor-field-4-description"
+                  onClick={[Function]}
+                >
+                  Meta description
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c32"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-4-description"
+                    content="Test description, %%replacement_variable%%"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+              <ProgressBar
+                aria-hidden="true"
+                backgroundColor="#f7f7f7"
+                borderColor="#ddd"
+                max={320}
+                progressColor="#dc3232"
+                value={0}
+              >
+                <progress
+                  aria-hidden="true"
+                  className="c30"
+                  max={320}
+                  value={0}
+                />
+              </ProgressBar>
+            </div>
+          </SnippetEditorFields__FormSection>
+        </section>
+      </SnippetEditorFields__StyledEditor>
+    </SnippetEditorFields>
+    <Button
+      onClick={[Function]}
+    >
+      <Button
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c33"
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c33 Button-kDSBcD c16"
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c33 Button-kDSBcD c16 Button-kDSBcD c17"
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c33 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c33 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19"
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  className="c33 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19 c20"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <FormattedMessage
+                    defaultMessage="Close snippet editor"
+                    id="snippet-editor.close-editor"
+                    values={Object {}}
+                  >
+                    <span>
+                      Close snippet editor
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+  </div>
+</SnippetEditor>
+`;
+
+exports[`SnippetEditor highlights the hovered field when onMouseOver() is called 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+}
+
+.c6 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c11 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+  font-size: 13px;
+}
+
+.c10 {
+  max-height: 4em;
+}
+
+.c12 {
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 20px;
+  max-height: calc( 4em + 3px );
+}
+
+.c1 {
+  padding: 8px 16px;
+}
+
+.c8 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c30 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c30::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c30::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c30::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c30::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c29 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+}
+
+.c29::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c31 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
+}
+
+.c31::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#ccc%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c27 {
+  margin: 32px 0;
+}
+
+.c26 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c28 {
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c20 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c15 {
+  font-size: 0.8rem;
+}
+
+.c16:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c17:hover {
+  color: #000;
+}
+
+.c18::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c18:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c19 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c19 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c24 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c24 svg {
+  margin-right: 7px;
+}
+
+.c32 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c14 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c14:hover,
+.c14:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c22 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c22:hover,
+.c22:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c13 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c21 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c23 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c25 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c9::before {
+  display: block;
+  position: absolute;
+  top: -3px;
+  left: -40px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#ccc%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c19::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<SnippetEditor
+  baseUrl="https://example.org/"
+  data={
+    Object {
+      "description": "Test description, %%replacement_variable%%",
+      "slug": "test-slug",
+      "title": "Test title",
+    }
+  }
+  date=""
+  descriptionLengthAssessment={
+    Object {
+      "actual": 0,
+      "max": 320,
+      "score": 0,
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "textComponent": "span",
+    }
+  }
+  mapDataToPreview={null}
+  mode="mobile"
+  onChange={[Function]}
+  replacementVariables={Array []}
+  titleLengthAssessment={
+    Object {
+      "actual": 0,
+      "max": 600,
+      "score": 0,
+    }
+  }
+>
+  <div>
+    <SnippetPreview
+      activeField={null}
+      breadcrumbs={null}
+      date=""
+      description="Test description, %%replacement_variable%%"
+      hoveredField="description"
+      isAmp={false}
+      isDescriptionGenerated={false}
+      keyword=""
+      locale="en_US"
+      mode="mobile"
+      onClick={[Function]}
+      onHover={[Function]}
+      onMouseLeave={[Function]}
+      onMouseOver={[Function]}
+      title="Test title"
+      url="example.org/test-slug"
+    >
+      <section>
+        <SnippetPreview__MobileContainer
+          padding={20}
+          width={640}
+        >
+          <div
+            className="c0"
+            width={640}
+          >
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="SEO title preview"
+                  id="snippetPreview.seoTitlePreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="SEO title preview"
+                    id="snippetPreview.seoTitlePreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        SEO title preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseTitle
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <div
+                    className="c2"
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <SnippetPreview__TitleBounded>
+                      <SnippetPreview__Title
+                        className="c3"
+                      >
+                        <div
+                          className="c3 c4"
+                        >
+                          <SnippetPreview__TitleUnboundedMobile
+                            innerRef={[Function]}
+                          >
+                            <span
+                              className="c5"
+                            >
+                              Test title
+                            </span>
+                          </SnippetPreview__TitleUnboundedMobile>
+                        </div>
+                      </SnippetPreview__Title>
+                    </SnippetPreview__TitleBounded>
+                  </div>
+                </SnippetPreview__BaseTitle>
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Url preview"
+                  id="snippetPreview.urlPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Url preview"
+                    id="snippetPreview.urlPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Url preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseUrl>
+                  <div
+                    className="c6"
+                  >
+                    <SnippetPreview__BaseUrlOverflowContainer
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__BaseUrl
+                        className="c7"
+                        onClick={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <div
+                          className="c7 c6"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrl>
+                    </SnippetPreview__BaseUrlOverflowContainer>
+                  </div>
+                </SnippetPreview__BaseUrl>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+            <SnippetPreview__Separator>
+              <hr
+                className="c8"
+              />
+            </SnippetPreview__Separator>
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Meta description preview"
+                  id="snippetPreview.metaDescriptionPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Meta description preview"
+                    id="snippetPreview.metaDescriptionPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Meta description preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview
+                  isDescriptionGenerated={false}
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <SnippetPreview__MobileDescription
+                    className="c9"
+                    isDescriptionGenerated={false}
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <SnippetPreview__DesktopDescription
+                      className="c9 c10"
+                      isDescriptionGenerated={false}
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <div
+                        className="c9 c10 c11"
+                        color="#545454"
+                        onClick={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <SnippetPreview__MobileDescriptionOverflowContainer
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__MobileDescription
+                            className="c12"
+                            innerRef={[Function]}
+                          >
+                            <SnippetPreview__DesktopDescription
+                              className="c12 c10"
+                              innerRef={[Function]}
+                            >
+                              <div
+                                className="c12 c10 c11"
+                                color="#545454"
+                              >
+                                Test description, %%replacement_variable%%
+                              </div>
+                            </SnippetPreview__DesktopDescription>
+                          </SnippetPreview__MobileDescription>
+                        </SnippetPreview__MobileDescriptionOverflowContainer>
+                      </div>
+                    </SnippetPreview__DesktopDescription>
+                  </SnippetPreview__MobileDescription>
+                </SnippetPreview>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+          </div>
+        </SnippetPreview__MobileContainer>
+      </section>
+    </SnippetPreview>
+    <ModeSwitcher
+      active="mobile"
+      onChange={[Function]}
+    >
+      <ModeSwitcher__Switcher>
+        <div
+          className="c13"
+        >
+          <ModeSwitcher__SwitcherButton
+            aria-pressed={true}
+            isActive={true}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={true}
+              className="c14"
+              isActive={true}
+              onClick={[Function]}
+            >
+              <Button
+                aria-pressed={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c14 c15"
+                isActive={true}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={true}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c14 c15 Button-kDSBcD c16"
+                  isActive={true}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={true}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c14 c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                    isActive={true}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button
+                      aria-pressed={true}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c14 c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                      isActive={true}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <Button__BaseButton
+                        aria-pressed={true}
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c14 c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19"
+                        isActive={true}
+                        onClick={[Function]}
+                        textColor="#555"
+                        type="button"
+                      >
+                        <button
+                          aria-pressed={true}
+                          className="c14 c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19 c20"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
+                            size="22px"
+                          >
+                            <SvgIcon__StyledSvg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="22px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c21"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
+                            defaultMessage="Mobile preview"
+                            id="snippetEditor.desktopPreview"
+                          >
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
+                                  }
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
+            aria-pressed={false}
+            isActive={false}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={false}
+              className="c22"
+              isActive={false}
+              onClick={[Function]}
+            >
+              <Button
+                aria-pressed={false}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c22 c15"
+                isActive={false}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={false}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c22 c15 Button-kDSBcD c16"
+                  isActive={false}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={false}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c22 c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                    isActive={false}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button
+                      aria-pressed={false}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c22 c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                      isActive={false}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <Button__BaseButton
+                        aria-pressed={false}
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c22 c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19"
+                        isActive={false}
+                        onClick={[Function]}
+                        textColor="#555"
+                        type="button"
+                      >
+                        <button
+                          aria-pressed={false}
+                          className="c22 c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19 c20"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
+                            size="18px"
+                          >
+                            <SvgIcon__StyledSvg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="18px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c23"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
+                            defaultMessage="Desktop preview"
+                            id="snippetEditor.desktopPreview"
+                          >
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
+                                  }
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </ModeSwitcher__SwitcherButton>
+        </div>
+      </ModeSwitcher__Switcher>
+    </ModeSwitcher>
+    <Button
+      aria-expanded={true}
+      innerRef={[Function]}
+      onClick={[Function]}
+    >
+      <Button
+        aria-expanded={true}
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c24"
+        innerRef={[Function]}
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          aria-expanded={true}
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c24 Button-kDSBcD c16"
+          innerRef={[Function]}
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            aria-expanded={true}
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c24 Button-kDSBcD c16 Button-kDSBcD c17"
+            innerRef={[Function]}
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              aria-expanded={true}
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c24 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+              innerRef={[Function]}
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                aria-expanded={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c24 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19"
+                innerRef={[Function]}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  aria-expanded={true}
+                  className="c24 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19 c20"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <SvgIcon
+                    icon="edit"
+                    size="16px"
+                  >
+                    <SvgIcon__StyledSvg
+                      aria-hidden={true}
+                      className="yoast-svg-icon yoast-svg-icon-edit"
+                      focusable="false"
+                      role="img"
+                      size="16px"
+                      viewBox="0 0 1792 1792"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="yoast-svg-icon yoast-svg-icon-edit c25"
+                        focusable="false"
+                        role="img"
+                        size="16px"
+                        viewBox="0 0 1792 1792"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                        />
+                      </svg>
+                    </SvgIcon__StyledSvg>
+                  </SvgIcon>
+                  <FormattedMessage
+                    defaultMessage="Edit snippet"
+                    id="snippetEditor.editSnippet"
+                    values={Object {}}
+                  >
+                    <span>
+                      Edit snippet
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+    <SnippetEditorFields
+      activeField={null}
+      data={
+        Object {
+          "description": "Test description, %%replacement_variable%%",
+          "slug": "test-slug",
+          "title": "Test title",
+        }
+      }
+      descriptionLengthAssessment={
+        Object {
+          "actual": 0,
+          "max": 320,
+          "score": 0,
+        }
+      }
+      hoveredField="description"
+      onChange={[Function]}
+      onFocus={[Function]}
+      replacementVariables={Array []}
+      titleLengthAssessment={
+        Object {
+          "actual": 0,
+          "max": 600,
+          "score": 0,
+        }
+      }
+    >
+      <SnippetEditorFields__StyledEditor>
+        <section
+          className="c26"
+        >
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c27"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-3-title"
+                onClick={[Function]}
+              >
+                <div
+                  className="c28"
+                  id="snippet-editor-field-3-title"
+                  onClick={[Function]}
+                >
+                  SEO title
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c29"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-3-title"
+                    content="Test title"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+              <ProgressBar
+                aria-hidden="true"
+                backgroundColor="#f7f7f7"
+                borderColor="#ddd"
+                max={600}
+                progressColor="#dc3232"
+                value={0}
+              >
+                <progress
+                  aria-hidden="true"
+                  className="c30"
+                  max={600}
+                  value={0}
+                />
+              </ProgressBar>
+            </div>
+          </SnippetEditorFields__FormSection>
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c27"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-3-slug"
+                onClick={[Function]}
+              >
+                <div
+                  className="c28"
+                  id="snippet-editor-field-3-slug"
+                  onClick={[Function]}
+                >
+                  Slug
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c29"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-3-slug"
+                    content="test-slug"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+            </div>
+          </SnippetEditorFields__FormSection>
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c27"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-3-description"
+                onClick={[Function]}
+              >
+                <div
+                  className="c28"
+                  id="snippet-editor-field-3-description"
+                  onClick={[Function]}
+                >
+                  Meta description
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={true}
+              >
+                <div
+                  className="c31"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-3-description"
+                    content="Test description, %%replacement_variable%%"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+              <ProgressBar
+                aria-hidden="true"
+                backgroundColor="#f7f7f7"
+                borderColor="#ddd"
+                max={320}
+                progressColor="#dc3232"
+                value={0}
+              >
+                <progress
+                  aria-hidden="true"
+                  className="c30"
+                  max={320}
+                  value={0}
+                />
+              </ProgressBar>
+            </div>
+          </SnippetEditorFields__FormSection>
+        </section>
+      </SnippetEditorFields__StyledEditor>
+    </SnippetEditorFields>
+    <Button
+      onClick={[Function]}
+    >
+      <Button
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c32"
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c32 Button-kDSBcD c16"
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c32 Button-kDSBcD c16 Button-kDSBcD c17"
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c32 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c32 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19"
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  className="c32 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19 c20"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <FormattedMessage
+                    defaultMessage="Close snippet editor"
+                    id="snippet-editor.close-editor"
+                    values={Object {}}
+                  >
+                    <span>
+                      Close snippet editor
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+  </div>
+</SnippetEditor>
+`;
+
+exports[`SnippetEditor opens when calling open() 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+}
+
+.c6 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+  font-size: 13px;
+}
+
+.c9 {
+  max-height: 4em;
+}
+
+.c11 {
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 20px;
+  max-height: calc( 4em + 3px );
+}
+
+.c1 {
+  padding: 8px 16px;
+}
+
+.c8 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c29::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c28 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+}
+
+.c28::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c30 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
+}
+
+.c30::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c26 {
+  margin: 32px 0;
+}
+
+.c25 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c27 {
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c19 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c14 {
+  font-size: 0.8rem;
+}
+
+.c15:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c16:hover {
+  color: #000;
+}
+
+.c17::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c17:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c18 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c18 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c23 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c23 svg {
+  margin-right: 7px;
+}
+
+.c31 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c13 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c13:hover,
+.c13:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c21 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c21:hover,
+.c21:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c12 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c20 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c22 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c24 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c18::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<SnippetEditor
+  baseUrl="https://example.org/"
+  data={
+    Object {
+      "description": "Test description, %%replacement_variable%%",
+      "slug": "test-slug",
+      "title": "Test title",
+    }
+  }
+  date=""
+  descriptionLengthAssessment={
+    Object {
+      "actual": 0,
+      "max": 320,
+      "score": 0,
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "textComponent": "span",
+    }
+  }
+  mapDataToPreview={null}
+  mode="mobile"
+  onChange={[Function]}
+  replacementVariables={Array []}
+  titleLengthAssessment={
+    Object {
+      "actual": 0,
+      "max": 600,
+      "score": 0,
+    }
+  }
+>
+  <div>
+    <SnippetPreview
+      activeField={null}
+      breadcrumbs={null}
+      date=""
+      description="Test description, %%replacement_variable%%"
+      hoveredField={null}
+      isAmp={false}
+      isDescriptionGenerated={false}
+      keyword=""
+      locale="en_US"
+      mode="mobile"
+      onClick={[Function]}
+      onHover={[Function]}
+      onMouseLeave={[Function]}
+      onMouseOver={[Function]}
+      title="Test title"
+      url="example.org/test-slug"
+    >
+      <section>
+        <SnippetPreview__MobileContainer
+          padding={20}
+          width={640}
+        >
+          <div
+            className="c0"
+            width={640}
+          >
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="SEO title preview"
+                  id="snippetPreview.seoTitlePreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="SEO title preview"
+                    id="snippetPreview.seoTitlePreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        SEO title preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseTitle
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <div
+                    className="c2"
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <SnippetPreview__TitleBounded>
+                      <SnippetPreview__Title
+                        className="c3"
+                      >
+                        <div
+                          className="c3 c4"
+                        >
+                          <SnippetPreview__TitleUnboundedMobile
+                            innerRef={[Function]}
+                          >
+                            <span
+                              className="c5"
+                            >
+                              Test title
+                            </span>
+                          </SnippetPreview__TitleUnboundedMobile>
+                        </div>
+                      </SnippetPreview__Title>
+                    </SnippetPreview__TitleBounded>
+                  </div>
+                </SnippetPreview__BaseTitle>
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Url preview"
+                  id="snippetPreview.urlPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Url preview"
+                    id="snippetPreview.urlPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Url preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseUrl>
+                  <div
+                    className="c6"
+                  >
+                    <SnippetPreview__BaseUrlOverflowContainer
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__BaseUrl
+                        className="c7"
+                        onClick={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <div
+                          className="c7 c6"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrl>
+                    </SnippetPreview__BaseUrlOverflowContainer>
+                  </div>
+                </SnippetPreview__BaseUrl>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+            <SnippetPreview__Separator>
+              <hr
+                className="c8"
+              />
+            </SnippetPreview__Separator>
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Meta description preview"
+                  id="snippetPreview.metaDescriptionPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Meta description preview"
+                    id="snippetPreview.metaDescriptionPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Meta description preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__MobileDescription
+                  isDescriptionGenerated={false}
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <SnippetPreview__DesktopDescription
+                    className="c9"
+                    isDescriptionGenerated={false}
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <div
+                      className="c9 c10"
+                      color="#545454"
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c11"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c11 c9"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c11 c9 c10"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
+                    </div>
+                  </SnippetPreview__DesktopDescription>
+                </SnippetPreview__MobileDescription>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+          </div>
+        </SnippetPreview__MobileContainer>
+      </section>
+    </SnippetPreview>
+    <ModeSwitcher
+      active="mobile"
+      onChange={[Function]}
+    >
+      <ModeSwitcher__Switcher>
+        <div
+          className="c12"
+        >
+          <ModeSwitcher__SwitcherButton
+            aria-pressed={true}
+            isActive={true}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={true}
+              className="c13"
+              isActive={true}
+              onClick={[Function]}
+            >
+              <Button
+                aria-pressed={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c13 c14"
+                isActive={true}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={true}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c13 c14 Button-kDSBcD c15"
+                  isActive={true}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={true}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                    isActive={true}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button
+                      aria-pressed={true}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                      isActive={true}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <Button__BaseButton
+                        aria-pressed={true}
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                        isActive={true}
+                        onClick={[Function]}
+                        textColor="#555"
+                        type="button"
+                      >
+                        <button
+                          aria-pressed={true}
+                          className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
+                            size="22px"
+                          >
+                            <SvgIcon__StyledSvg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="22px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c20"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
+                            defaultMessage="Mobile preview"
+                            id="snippetEditor.desktopPreview"
+                          >
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
+                                  }
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
+            aria-pressed={false}
+            isActive={false}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={false}
+              className="c21"
+              isActive={false}
+              onClick={[Function]}
+            >
+              <Button
+                aria-pressed={false}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c21 c14"
+                isActive={false}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={false}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c21 c14 Button-kDSBcD c15"
+                  isActive={false}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={false}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                    isActive={false}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button
+                      aria-pressed={false}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                      isActive={false}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <Button__BaseButton
+                        aria-pressed={false}
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                        isActive={false}
+                        onClick={[Function]}
+                        textColor="#555"
+                        type="button"
+                      >
+                        <button
+                          aria-pressed={false}
+                          className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
+                            size="18px"
+                          >
+                            <SvgIcon__StyledSvg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="18px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c22"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
+                            defaultMessage="Desktop preview"
+                            id="snippetEditor.desktopPreview"
+                          >
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
+                                  }
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </ModeSwitcher__SwitcherButton>
+        </div>
+      </ModeSwitcher__Switcher>
+    </ModeSwitcher>
+    <Button
+      aria-expanded={true}
+      innerRef={[Function]}
+      onClick={[Function]}
+    >
+      <Button
+        aria-expanded={true}
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c23"
+        innerRef={[Function]}
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          aria-expanded={true}
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c23 Button-kDSBcD c15"
+          innerRef={[Function]}
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            aria-expanded={true}
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c23 Button-kDSBcD c15 Button-kDSBcD c16"
+            innerRef={[Function]}
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              aria-expanded={true}
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+              innerRef={[Function]}
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                aria-expanded={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                innerRef={[Function]}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  aria-expanded={true}
+                  className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <SvgIcon
+                    icon="edit"
+                    size="16px"
+                  >
+                    <SvgIcon__StyledSvg
+                      aria-hidden={true}
+                      className="yoast-svg-icon yoast-svg-icon-edit"
+                      focusable="false"
+                      role="img"
+                      size="16px"
+                      viewBox="0 0 1792 1792"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="yoast-svg-icon yoast-svg-icon-edit c24"
+                        focusable="false"
+                        role="img"
+                        size="16px"
+                        viewBox="0 0 1792 1792"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                        />
+                      </svg>
+                    </SvgIcon__StyledSvg>
+                  </SvgIcon>
+                  <FormattedMessage
+                    defaultMessage="Edit snippet"
+                    id="snippetEditor.editSnippet"
+                    values={Object {}}
+                  >
+                    <span>
+                      Edit snippet
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+    <SnippetEditorFields
+      activeField={null}
+      data={
+        Object {
+          "description": "Test description, %%replacement_variable%%",
+          "slug": "test-slug",
+          "title": "Test title",
+        }
+      }
+      descriptionLengthAssessment={
+        Object {
+          "actual": 0,
+          "max": 320,
+          "score": 0,
+        }
+      }
+      hoveredField={null}
+      onChange={[Function]}
+      onFocus={[Function]}
+      replacementVariables={Array []}
+      titleLengthAssessment={
+        Object {
+          "actual": 0,
+          "max": 600,
+          "score": 0,
+        }
+      }
+    >
+      <SnippetEditorFields__StyledEditor>
+        <section
+          className="c25"
+        >
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c26"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-1-title"
+                onClick={[Function]}
+              >
+                <div
+                  className="c27"
+                  id="snippet-editor-field-1-title"
+                  onClick={[Function]}
+                >
+                  SEO title
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c28"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-1-title"
+                    content="Test title"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+              <ProgressBar
+                aria-hidden="true"
+                backgroundColor="#f7f7f7"
+                borderColor="#ddd"
+                max={600}
+                progressColor="#dc3232"
+                value={0}
+              >
+                <progress
+                  aria-hidden="true"
+                  className="c29"
+                  max={600}
+                  value={0}
+                />
+              </ProgressBar>
+            </div>
+          </SnippetEditorFields__FormSection>
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c26"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-1-slug"
+                onClick={[Function]}
+              >
+                <div
+                  className="c27"
+                  id="snippet-editor-field-1-slug"
+                  onClick={[Function]}
+                >
+                  Slug
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c28"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-1-slug"
+                    content="test-slug"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+            </div>
+          </SnippetEditorFields__FormSection>
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c26"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-1-description"
+                onClick={[Function]}
+              >
+                <div
+                  className="c27"
+                  id="snippet-editor-field-1-description"
+                  onClick={[Function]}
+                >
+                  Meta description
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c30"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-1-description"
+                    content="Test description, %%replacement_variable%%"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+              <ProgressBar
+                aria-hidden="true"
+                backgroundColor="#f7f7f7"
+                borderColor="#ddd"
+                max={320}
+                progressColor="#dc3232"
+                value={0}
+              >
+                <progress
+                  aria-hidden="true"
+                  className="c29"
+                  max={320}
+                  value={0}
+                />
+              </ProgressBar>
+            </div>
+          </SnippetEditorFields__FormSection>
+        </section>
+      </SnippetEditorFields__StyledEditor>
+    </SnippetEditorFields>
+    <Button
+      onClick={[Function]}
+    >
+      <Button
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c31"
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c31 Button-kDSBcD c15"
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c31 Button-kDSBcD c15 Button-kDSBcD c16"
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <FormattedMessage
+                    defaultMessage="Close snippet editor"
+                    id="snippet-editor.close-editor"
+                    values={Object {}}
+                  >
+                    <span>
+                      Close snippet editor
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+  </div>
+</SnippetEditor>
+`;
+
+exports[`SnippetEditor passes replacement variables to the title and description editor 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+}
+
+.c6 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+  font-size: 13px;
+}
+
+.c9 {
+  max-height: 4em;
+}
+
+.c11 {
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 20px;
+  max-height: calc( 4em + 3px );
+}
+
+.c1 {
+  padding: 8px 16px;
+}
+
+.c8 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c29::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c28 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+}
+
+.c28::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c30 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  min-height: 60px;
+  padding: 2px 6px;
+  line-height: 19.6px;
+}
+
+.c30::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c26 {
+  margin: 32px 0;
+}
+
+.c25 {
+  padding: 10px 20px 20px 20px;
+}
+
+.c27 {
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c19 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c14 {
+  font-size: 0.8rem;
+}
+
+.c15:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c16:hover {
+  color: #000;
+}
+
+.c17::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c17:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c18 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c18 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c23 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c23 svg {
+  margin-right: 7px;
+}
+
+.c31 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-left: 20px;
+}
+
+.c13 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c13:hover,
+.c13:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c21 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c21:hover,
+.c21:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c12 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c20 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c22 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c24 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c18::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<SnippetEditor
+  baseUrl="https://example.org/"
+  data={
+    Object {
+      "description": "Test description, %%replacement_variable%%",
+      "slug": "test-slug",
+      "title": "Test title",
+    }
+  }
+  date=""
+  descriptionLengthAssessment={
+    Object {
+      "actual": 0,
+      "max": 320,
+      "score": 0,
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "textComponent": "span",
+    }
+  }
+  mapDataToPreview={null}
+  mode="mobile"
+  onChange={[Function]}
+  replacementVariables={
+    Array [
+      Object {
+        "name": "title",
+        "value": "Title!!!",
+      },
+      Object {
+        "name": "excerpt",
+        "value": "Excerpt!!!",
+      },
+    ]
+  }
+  titleLengthAssessment={
+    Object {
+      "actual": 0,
+      "max": 600,
+      "score": 0,
+    }
+  }
+>
+  <div>
+    <SnippetPreview
+      activeField={null}
+      breadcrumbs={null}
+      date=""
+      description="Test description, %%replacement_variable%%"
+      hoveredField={null}
+      isAmp={false}
+      isDescriptionGenerated={false}
+      keyword=""
+      locale="en_US"
+      mode="mobile"
+      onClick={[Function]}
+      onHover={[Function]}
+      onMouseLeave={[Function]}
+      onMouseOver={[Function]}
+      title="Test title"
+      url="example.org/test-slug"
+    >
+      <section>
+        <SnippetPreview__MobileContainer
+          padding={20}
+          width={640}
+        >
+          <div
+            className="c0"
+            width={640}
+          >
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="SEO title preview"
+                  id="snippetPreview.seoTitlePreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="SEO title preview"
+                    id="snippetPreview.seoTitlePreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        SEO title preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseTitle
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <div
+                    className="c2"
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <SnippetPreview__TitleBounded>
+                      <SnippetPreview__Title
+                        className="c3"
+                      >
+                        <div
+                          className="c3 c4"
+                        >
+                          <SnippetPreview__TitleUnboundedMobile
+                            innerRef={[Function]}
+                          >
+                            <span
+                              className="c5"
+                            >
+                              Test title
+                            </span>
+                          </SnippetPreview__TitleUnboundedMobile>
+                        </div>
+                      </SnippetPreview__Title>
+                    </SnippetPreview__TitleBounded>
+                  </div>
+                </SnippetPreview__BaseTitle>
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Url preview"
+                  id="snippetPreview.urlPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Url preview"
+                    id="snippetPreview.urlPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Url preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseUrl>
+                  <div
+                    className="c6"
+                  >
+                    <SnippetPreview__BaseUrlOverflowContainer
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__BaseUrl
+                        className="c7"
+                        onClick={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <div
+                          className="c7 c6"
+                          onClick={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseOver={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrl>
+                    </SnippetPreview__BaseUrlOverflowContainer>
+                  </div>
+                </SnippetPreview__BaseUrl>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+            <SnippetPreview__Separator>
+              <hr
+                className="c8"
+              />
+            </SnippetPreview__Separator>
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Meta description preview"
+                  id="snippetPreview.metaDescriptionPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Meta description preview"
+                    id="snippetPreview.metaDescriptionPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Meta description preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__MobileDescription
+                  isDescriptionGenerated={false}
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <SnippetPreview__DesktopDescription
+                    className="c9"
+                    isDescriptionGenerated={false}
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <div
+                      className="c9 c10"
+                      color="#545454"
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c11"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c11 c9"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c11 c9 c10"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
+                    </div>
+                  </SnippetPreview__DesktopDescription>
+                </SnippetPreview__MobileDescription>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+          </div>
+        </SnippetPreview__MobileContainer>
+      </section>
+    </SnippetPreview>
+    <ModeSwitcher
+      active="mobile"
+      onChange={[Function]}
+    >
+      <ModeSwitcher__Switcher>
+        <div
+          className="c12"
+        >
+          <ModeSwitcher__SwitcherButton
+            aria-pressed={true}
+            isActive={true}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={true}
+              className="c13"
+              isActive={true}
+              onClick={[Function]}
+            >
+              <Button
+                aria-pressed={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c13 c14"
+                isActive={true}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={true}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c13 c14 Button-kDSBcD c15"
+                  isActive={true}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={true}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                    isActive={true}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button
+                      aria-pressed={true}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                      isActive={true}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <Button__BaseButton
+                        aria-pressed={true}
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                        isActive={true}
+                        onClick={[Function]}
+                        textColor="#555"
+                        type="button"
+                      >
+                        <button
+                          aria-pressed={true}
+                          className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <SvgIcon
+                            color="currentColor"
+                            icon="mobile"
+                            size="22px"
+                          >
+                            <SvgIcon__StyledSvg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-mobile"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="22px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-mobile c20"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="22px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
+                            defaultMessage="Mobile preview"
+                            id="snippetEditor.desktopPreview"
+                          >
+                            <FormattedMessage
+                              defaultMessage="Mobile preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
+                                  }
+                                >
+                                  Mobile preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </ModeSwitcher__SwitcherButton>
+          <ModeSwitcher__SwitcherButton
+            aria-pressed={false}
+            isActive={false}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={false}
+              className="c21"
+              isActive={false}
+              onClick={[Function]}
+            >
+              <Button
+                aria-pressed={false}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c21 c14"
+                isActive={false}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={false}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c21 c14 Button-kDSBcD c15"
+                  isActive={false}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={false}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                    isActive={false}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button
+                      aria-pressed={false}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                      isActive={false}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <Button__BaseButton
+                        aria-pressed={false}
+                        backgroundColor="#f7f7f7"
+                        borderColor="#ccc"
+                        boxShadowColor="#ccc"
+                        className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                        isActive={false}
+                        onClick={[Function]}
+                        textColor="#555"
+                        type="button"
+                      >
+                        <button
+                          aria-pressed={false}
+                          className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <SvgIcon
+                            color="currentColor"
+                            icon="desktop"
+                            size="18px"
+                          >
+                            <SvgIcon__StyledSvg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-desktop"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="18px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="yoast-svg-icon yoast-svg-icon-desktop c22"
+                                fill="currentColor"
+                                focusable="false"
+                                role="img"
+                                size="18px"
+                                viewBox="0 0 1792 1792"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                />
+                              </svg>
+                            </SvgIcon__StyledSvg>
+                          </SvgIcon>
+                          <FormattedScreenReaderMessage
+                            defaultMessage="Desktop preview"
+                            id="snippetEditor.desktopPreview"
+                          >
+                            <FormattedMessage
+                              defaultMessage="Desktop preview"
+                              id="snippetEditor.desktopPreview"
+                              values={Object {}}
+                            >
+                              <ScreenReaderText>
+                                <span
+                                  className="screen-reader-text"
+                                  style={
+                                    Object {
+                                      "clip": "rect(1px, 1px, 1px, 1px)",
+                                      "height": "1px",
+                                      "overflow": "hidden",
+                                      "position": "absolute",
+                                      "width": "1px",
+                                    }
+                                  }
+                                >
+                                  Desktop preview
+                                </span>
+                              </ScreenReaderText>
+                            </FormattedMessage>
+                          </FormattedScreenReaderMessage>
+                        </button>
+                      </Button__BaseButton>
+                    </Button>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </ModeSwitcher__SwitcherButton>
+        </div>
+      </ModeSwitcher__Switcher>
+    </ModeSwitcher>
+    <Button
+      aria-expanded={true}
+      innerRef={[Function]}
+      onClick={[Function]}
+    >
+      <Button
+        aria-expanded={true}
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c23"
+        innerRef={[Function]}
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          aria-expanded={true}
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c23 Button-kDSBcD c15"
+          innerRef={[Function]}
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            aria-expanded={true}
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c23 Button-kDSBcD c15 Button-kDSBcD c16"
+            innerRef={[Function]}
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              aria-expanded={true}
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+              innerRef={[Function]}
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                aria-expanded={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                innerRef={[Function]}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  aria-expanded={true}
+                  className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <SvgIcon
+                    icon="edit"
+                    size="16px"
+                  >
+                    <SvgIcon__StyledSvg
+                      aria-hidden={true}
+                      className="yoast-svg-icon yoast-svg-icon-edit"
+                      focusable="false"
+                      role="img"
+                      size="16px"
+                      viewBox="0 0 1792 1792"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="yoast-svg-icon yoast-svg-icon-edit c24"
+                        focusable="false"
+                        role="img"
+                        size="16px"
+                        viewBox="0 0 1792 1792"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                        />
+                      </svg>
+                    </SvgIcon__StyledSvg>
+                  </SvgIcon>
+                  <FormattedMessage
+                    defaultMessage="Edit snippet"
+                    id="snippetEditor.editSnippet"
+                    values={Object {}}
+                  >
+                    <span>
+                      Edit snippet
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+    <SnippetEditorFields
+      activeField={null}
+      data={
+        Object {
+          "description": "Test description, %%replacement_variable%%",
+          "slug": "test-slug",
+          "title": "Test title",
+        }
+      }
+      descriptionLengthAssessment={
+        Object {
+          "actual": 0,
+          "max": 320,
+          "score": 0,
+        }
+      }
+      hoveredField={null}
+      onChange={[Function]}
+      onFocus={[Function]}
+      replacementVariables={
+        Array [
+          Object {
+            "name": "title",
+            "value": "Title!!!",
+          },
+          Object {
+            "name": "excerpt",
+            "value": "Excerpt!!!",
+          },
+        ]
+      }
+      titleLengthAssessment={
+        Object {
+          "actual": 0,
+          "max": 600,
+          "score": 0,
+        }
+      }
+    >
+      <SnippetEditorFields__StyledEditor>
+        <section
+          className="c25"
+        >
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c26"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-6-title"
+                onClick={[Function]}
+              >
+                <div
+                  className="c27"
+                  id="snippet-editor-field-6-title"
+                  onClick={[Function]}
+                >
+                  SEO title
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c28"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-6-title"
+                    content="Test title"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={
+                      Array [
+                        Object {
+                          "name": "title",
+                          "value": "Title!!!",
+                        },
+                        Object {
+                          "name": "excerpt",
+                          "value": "Excerpt!!!",
+                        },
+                      ]
+                    }
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+              <ProgressBar
+                aria-hidden="true"
+                backgroundColor="#f7f7f7"
+                borderColor="#ddd"
+                max={600}
+                progressColor="#dc3232"
+                value={0}
+              >
+                <progress
+                  aria-hidden="true"
+                  className="c29"
+                  max={600}
+                  value={0}
+                />
+              </ProgressBar>
+            </div>
+          </SnippetEditorFields__FormSection>
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c26"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-6-slug"
+                onClick={[Function]}
+              >
+                <div
+                  className="c27"
+                  id="snippet-editor-field-6-slug"
+                  onClick={[Function]}
+                >
+                  Slug
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c28"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-6-slug"
+                    content="test-slug"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={Array []}
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+            </div>
+          </SnippetEditorFields__FormSection>
+          <SnippetEditorFields__FormSection>
+            <div
+              className="c26"
+            >
+              <SnippetEditorFields__SimulatedLabel
+                id="snippet-editor-field-6-description"
+                onClick={[Function]}
+              >
+                <div
+                  className="c27"
+                  id="snippet-editor-field-6-description"
+                  onClick={[Function]}
+                >
+                  Meta description
+                </div>
+              </SnippetEditorFields__SimulatedLabel>
+              <SnippetEditorFields__InputContainer
+                isActive={false}
+                isHovered={false}
+              >
+                <div
+                  className="c30"
+                >
+                  <ReplacementVariableEditor
+                    ariaLabelledBy="snippet-editor-field-6-description"
+                    content="Test description, %%replacement_variable%%"
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    replacementVariables={
+                      Array [
+                        Object {
+                          "name": "title",
+                          "value": "Title!!!",
+                        },
+                        Object {
+                          "name": "excerpt",
+                          "value": "Excerpt!!!",
+                        },
+                      ]
+                    }
+                  >
+                    <div />
+                  </ReplacementVariableEditor>
+                </div>
+              </SnippetEditorFields__InputContainer>
+              <ProgressBar
+                aria-hidden="true"
+                backgroundColor="#f7f7f7"
+                borderColor="#ddd"
+                max={320}
+                progressColor="#dc3232"
+                value={0}
+              >
+                <progress
+                  aria-hidden="true"
+                  className="c29"
+                  max={320}
+                  value={0}
+                />
+              </ProgressBar>
+            </div>
+          </SnippetEditorFields__FormSection>
+        </section>
+      </SnippetEditorFields__StyledEditor>
+    </SnippetEditorFields>
+    <Button
+      onClick={[Function]}
+    >
+      <Button
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c31"
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c31 Button-kDSBcD c15"
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c31 Button-kDSBcD c15 Button-kDSBcD c16"
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  className="c31 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <FormattedMessage
+                    defaultMessage="Close snippet editor"
+                    id="snippet-editor.close-editor"
+                    values={Object {}}
+                  >
+                    <span>
+                      Close snippet editor
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+  </div>
+</SnippetEditor>
+`;
+
+exports[`SnippetEditor passes the date prop 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+}
+
+.c6 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+  font-size: 13px;
+}
+
+.c9 {
+  max-height: 4em;
+}
+
+.c11 {
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 20px;
+  max-height: calc( 4em + 3px );
+}
+
+.c1 {
+  padding: 8px 16px;
+}
+
+.c12 {
+  color: #808080;
+}
+
+.c8 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c20 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c15 {
+  font-size: 0.8rem;
+}
+
+.c16:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c17:hover {
+  color: #000;
+}
+
+.c18::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c18:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c19 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c19 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c24 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c24 svg {
+  margin-right: 7px;
+}
+
+.c14 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c14:hover,
+.c14:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c22 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c22:hover,
+.c22:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c13 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c21 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c23 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c25 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c19::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<div>
+  <section>
+    <div
+      className="c0"
+      onMouseLeave={undefined}
+      width={640}
+    >
+      <div
+        className="c1"
+      >
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          SEO title preview:
+        </span>
+        <div
+          className="c2"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          <div
+            className="c3 c4"
+          >
+            <span
+              className="c5"
+            >
+              Test title
+            </span>
+          </div>
+        </div>
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          Url preview:
+        </span>
+        <div
+          className="c6"
+        >
+          <div
+            className="c7 c6"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            example.org › test-slug
+          </div>
+        </div>
+      </div>
+      <hr
+        className="c8"
+      />
+      <div
+        className="c1"
+      >
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          Meta description preview:
+        </span>
+        <div
+          className="c9 c10"
+          color="#545454"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          <div
+            className="c11 c9 c10"
+            color="#545454"
+          >
+            <span
+              className="c12"
+            >
+              date string
+               - 
+            </span>
+            Test description, %%replacement_variable%%
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <div
+    className="c13"
+  >
+    <button
+      aria-pressed={true}
+      className="c14 c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19 c20"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-mobile c21"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="22px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Mobile preview
+      </span>
+    </button>
+    <button
+      aria-pressed={false}
+      className="c22 c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19 c20"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-desktop c23"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="18px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Desktop preview
+      </span>
+    </button>
+  </div>
+  <button
+    aria-expanded={false}
+    className="c24 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 Button-kDSBcD c19 c20"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      aria-hidden={true}
+      className="yoast-svg-icon yoast-svg-icon-edit c25"
       fill={undefined}
       focusable="false"
       role="img"
@@ -16146,12 +16362,16 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c9 {
+.c8 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -16159,7 +16379,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   font-size: 13px;
 }
 
-.c8 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -16167,462 +16387,6 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   border-right: 4px solid transparent;
   border-left: 4px solid transparent;
   vertical-align: top;
-}
-
-.c17 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c12 {
-  font-size: 0.8rem;
-}
-
-.c13:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c14:hover {
-  color: #000;
-}
-
-.c15::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c15:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c16 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c16 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c21 {
-  font-size: 0.8rem;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 10px 0 0 4px;
-  fill: #555;
-  padding-left: 8px;
-}
-
-.c21 svg {
-  margin-right: 7px;
-}
-
-.c11 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c11:hover,
-.c11:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c19 {
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c19:hover,
-.c19:focus {
-  background-color: #fff;
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-  box-shadow: none;
-}
-
-.c10 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c18 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c20 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c22 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c16::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<div>
-  <section>
-    <div
-      className="c0 c1"
-      width={640}
-    >
-      <div
-        className="c2"
-        width={600}
-      >
-        <div
-          className=""
-        >
-          <span
-            className="screen-reader-text"
-            style={
-              Object {
-                "clip": "rect(1px, 1px, 1px, 1px)",
-                "height": "1px",
-                "overflow": "hidden",
-                "position": "absolute",
-                "width": "1px",
-              }
-            }
-          >
-            SEO title preview:
-          </span>
-          <div
-            className="c3"
-            onClick={[Function]}
-            onMouseLeave={[Function]}
-            onMouseOver={[Function]}
-          >
-            <div
-              className="c4 c5"
-            >
-              <span
-                className="c6"
-              >
-                Test title
-              </span>
-            </div>
-          </div>
-          <span
-            className="screen-reader-text"
-            style={
-              Object {
-                "clip": "rect(1px, 1px, 1px, 1px)",
-                "height": "1px",
-                "overflow": "hidden",
-                "position": "absolute",
-                "width": "1px",
-              }
-            }
-          >
-            Url preview:
-          </span>
-          <div
-            className="c7"
-            onClick={[Function]}
-            onMouseLeave={[Function]}
-            onMouseOver={[Function]}
-          >
-            example.org/test-slug
-          </div>
-          <div
-            className="c8"
-          />
-        </div>
-        <div
-          className=""
-        >
-          <span
-            className="screen-reader-text"
-            style={
-              Object {
-                "clip": "rect(1px, 1px, 1px, 1px)",
-                "height": "1px",
-                "overflow": "hidden",
-                "position": "absolute",
-                "width": "1px",
-              }
-            }
-          >
-            Meta description preview:
-          </span>
-          <div
-            className="c9"
-            color="#545454"
-            onClick={[Function]}
-            onMouseLeave={[Function]}
-            onMouseOver={[Function]}
-          >
-            Test description, %%replacement_variable%%
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-  <div
-    className="c10"
-  >
-    <button
-      aria-pressed={false}
-      className="c11 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
-      onClick={[Function]}
-      type="button"
-    >
-      <svg
-        aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c18"
-        fill="currentColor"
-        focusable="false"
-        role="img"
-        size="22px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-        />
-      </svg>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Mobile preview
-      </span>
-    </button>
-    <button
-      aria-pressed={true}
-      className="c19 c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
-      onClick={[Function]}
-      type="button"
-    >
-      <svg
-        aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c20"
-        fill="currentColor"
-        focusable="false"
-        role="img"
-        size="18px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-        />
-      </svg>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Desktop preview
-      </span>
-    </button>
-  </div>
-  <button
-    aria-expanded={false}
-    className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
-    onClick={[Function]}
-    type="button"
-  >
-    <svg
-      aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c22"
-      fill={undefined}
-      focusable="false"
-      role="img"
-      size="16px"
-      viewBox="0 0 1792 1792"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-      />
-    </svg>
-    <span>
-      Edit snippet
-    </span>
-  </button>
-</div>
-`;
-
-exports[`SnippetEditor shows and editor 1`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-  font-size: 14px;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 16px;
-}
-
-.c6 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-  max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.c9 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-  font-size: 13px;
-}
-
-.c8 {
-  max-height: 4em;
-}
-
-.c10 {
-  overflow: hidden;
-  font-size: 14px;
-  line-height: 20px;
-  max-height: calc( 4em + 3px );
-}
-
-.c1 {
-  padding: 8px 16px;
-}
-
-.c7 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
 }
 
 .c18 {
@@ -16709,7 +16473,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   border-bottom: 4px solid transparent;
   width: 31px;
   height: 31px;
-  border-color: #555;
+  border-color: transparent;
   color: #555;
   -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
   transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
@@ -16733,7 +16497,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   border-bottom: 4px solid transparent;
   width: 31px;
   height: 31px;
-  border-color: transparent;
+  border-color: #555;
   color: #555;
   -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
   transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
@@ -16797,6 +16561,470 @@ exports[`SnippetEditor shows and editor 1`] = `
 <div>
   <section>
     <div
+      className="c0 c1"
+      width={640}
+    >
+      <div
+        className="c2"
+        width={600}
+      >
+        <div
+          className=""
+        >
+          <span
+            className="screen-reader-text"
+            style={
+              Object {
+                "clip": "rect(1px, 1px, 1px, 1px)",
+                "height": "1px",
+                "overflow": "hidden",
+                "position": "absolute",
+                "width": "1px",
+              }
+            }
+          >
+            SEO title preview:
+          </span>
+          <div
+            className="c3"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            <div
+              className="c4 c5"
+            >
+              <span
+                className="c6"
+              >
+                Test title
+              </span>
+            </div>
+          </div>
+          <span
+            className="screen-reader-text"
+            style={
+              Object {
+                "clip": "rect(1px, 1px, 1px, 1px)",
+                "height": "1px",
+                "overflow": "hidden",
+                "position": "absolute",
+                "width": "1px",
+              }
+            }
+          >
+            Url preview:
+          </span>
+          <div
+            className="c7"
+          >
+            <div
+              className="c8 c7"
+              onClick={[Function]}
+              onMouseLeave={[Function]}
+              onMouseOver={[Function]}
+            >
+              example.org/test-slug
+            </div>
+          </div>
+          <div
+            className="c9"
+          />
+        </div>
+        <div
+          className=""
+        >
+          <span
+            className="screen-reader-text"
+            style={
+              Object {
+                "clip": "rect(1px, 1px, 1px, 1px)",
+                "height": "1px",
+                "overflow": "hidden",
+                "position": "absolute",
+                "width": "1px",
+              }
+            }
+          >
+            Meta description preview:
+          </span>
+          <div
+            className="c10"
+            color="#545454"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            Test description, %%replacement_variable%%
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <div
+    className="c11"
+  >
+    <button
+      aria-pressed={false}
+      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-mobile c19"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="22px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Mobile preview
+      </span>
+    </button>
+    <button
+      aria-pressed={true}
+      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-desktop c21"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="18px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Desktop preview
+      </span>
+    </button>
+  </div>
+  <button
+    aria-expanded={false}
+    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      aria-hidden={true}
+      className="yoast-svg-icon yoast-svg-icon-edit c23"
+      fill={undefined}
+      focusable="false"
+      role="img"
+      size="16px"
+      viewBox="0 0 1792 1792"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+      />
+    </svg>
+    <span>
+      Edit snippet
+    </span>
+  </button>
+</div>
+`;
+
+exports[`SnippetEditor shows and editor 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
+}
+
+.c6 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+}
+
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+  font-size: 13px;
+}
+
+.c9 {
+  max-height: 4em;
+}
+
+.c11 {
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 20px;
+  max-height: calc( 4em + 3px );
+}
+
+.c1 {
+  padding: 8px 16px;
+}
+
+.c8 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c19 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c14 {
+  font-size: 0.8rem;
+}
+
+.c15:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c16:hover {
+  color: #000;
+}
+
+.c17::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c17:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c18 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c18 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c23 {
+  font-size: 0.8rem;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 10px 0 0 4px;
+  fill: #555;
+  padding-left: 8px;
+}
+
+.c23 svg {
+  margin-right: 7px;
+}
+
+.c13 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c13:hover,
+.c13:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c21 {
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c21:hover,
+.c21:focus {
+  background-color: #fff;
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+  box-shadow: none;
+}
+
+.c12 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c20 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c22 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c24 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c18::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<div>
+  <section>
+    <div
       className="c0"
       onMouseLeave={undefined}
       width={640}
@@ -16850,15 +17078,19 @@ exports[`SnippetEditor shows and editor 1`] = `
         </span>
         <div
           className="c6"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
         >
-          example.org › test-slug
+          <div
+            className="c7 c6"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            example.org › test-slug
+          </div>
         </div>
       </div>
       <hr
-        className="c7"
+        className="c8"
       />
       <div
         className="c1"
@@ -16878,14 +17110,14 @@ exports[`SnippetEditor shows and editor 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c8 c9"
+          className="c9 c10"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
         >
           <div
-            className="c10 c8 c9"
+            className="c11 c9 c10"
             color="#545454"
           >
             Test description, %%replacement_variable%%
@@ -16895,17 +17127,17 @@ exports[`SnippetEditor shows and editor 1`] = `
     </div>
   </section>
   <div
-    className="c11"
+    className="c12"
   >
     <button
       aria-pressed={true}
-      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+      className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c19"
+        className="yoast-svg-icon yoast-svg-icon-mobile c20"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -16934,13 +17166,13 @@ exports[`SnippetEditor shows and editor 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+      className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c21"
+        className="yoast-svg-icon yoast-svg-icon-desktop c22"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -16970,13 +17202,13 @@ exports[`SnippetEditor shows and editor 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+    className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
     onClick={[Function]}
     type="button"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c23"
+      className="yoast-svg-icon yoast-svg-icon-edit c24"
       fill={undefined}
       focusable="false"
       role="img"

--- a/composites/Plugin/SnippetPreview/components/ProgressBar.js
+++ b/composites/Plugin/SnippetPreview/components/ProgressBar.js
@@ -17,7 +17,7 @@ const ProgressBar = styled.progress`
 	width: 100%;
 	height: 8px;
 	display: block;
-	margin-top: 5px;
+	margin-top: 8px;
 	appearance: none;
 	background-color: ${ props => props.backgroundColor };
 	border: 1px solid ${ props => props.borderColor };

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -121,7 +121,7 @@ export const BaseUrl = styled.div`
 	color: ${ colorUrl };
 	cursor: pointer;
 	position: relative;
-	width: 100%;
+	width: 90%;
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -121,7 +121,7 @@ export const BaseUrl = styled.div`
 	color: ${ colorUrl };
 	cursor: pointer;
 	position: relative;
-	width: 90%;
+	max-width: 90%;
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -128,6 +128,7 @@ export const BaseUrl = styled.div`
 const BaseUrlOverflowContainer = styled( BaseUrl )`
 	overflow: hidden;
 	text-overflow: ellipsis;
+	max-width: 100%;
 `;
 
 export const DesktopDescription = styled.div.attrs( {

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -120,6 +120,10 @@ export const BaseUrl = styled.div`
 	color: ${ colorUrl };
 	cursor: pointer;
 	position: relative;
+	width: 100%;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
 `;
 
 export const DesktopDescription = styled.div.attrs( {

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -594,7 +594,7 @@ export default class SnippetPreview extends PureComponent {
 							after=":"
 						/>
 						{ amp }
-						<slug> { this.renderUrl() } </slug>
+						{ this.renderUrl() }
 						{ downArrow }
 					</PartContainer>
 					{ separator }

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -43,6 +43,7 @@ const MobileContainer = styled.div`
 	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
 	max-width: ${ MAX_WIDTH }px;
 	box-sizing: border-box;
+	font-size: 14px;
 `;
 
 const angleRight = ( color ) => "data:image/svg+xml;charset=utf8," + encodeURI(
@@ -133,17 +134,18 @@ export const DesktopDescription = styled.div.attrs( {
 	cursor: pointer;
 	position: relative;
 	max-width: ${ MAX_WIDTH }px;
+	font-size: 13px;
 `;
 
 const MobileDescription = styled( DesktopDescription )`
-	line-height: 1em;
 	max-height: 4em;
 	overflow: hidden;
 	font-size: 14px;
+	line-height: 20px;
 `;
 
 const MobilePartContainer = styled.div`
-	padding: 16px;
+	padding: 8px 16px;
 `;
 
 const DesktopPartContainer = styled.div`

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -123,6 +123,7 @@ export const BaseUrl = styled.div`
 	position: relative;
 	max-width: 90%;
 	white-space: nowrap;
+	font-size: 14px;
 `;
 
 const BaseUrlOverflowContainer = styled( BaseUrl )`
@@ -143,6 +144,7 @@ export const DesktopDescription = styled.div.attrs( {
 
 const MobileDescription = styled( DesktopDescription )`
 	max-height: 4em;
+	padding-bottom: 3px;
 `;
 
 const MobileDescriptionOverflowContainer = styled( MobileDescription )`

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -122,9 +122,12 @@ export const BaseUrl = styled.div`
 	cursor: pointer;
 	position: relative;
 	max-width: 90%;
-	text-overflow: ellipsis;
-	overflow: hidden;
 	white-space: nowrap;
+`;
+
+const BaseUrlOverflowContainer = styled( BaseUrl )`
+	overflow: hidden;
+	text-overflow: ellipsis;
 `;
 
 export const DesktopDescription = styled.div.attrs( {
@@ -493,10 +496,13 @@ export default class SnippetPreview extends PureComponent {
 		 * However this is not relevant in this case, because the url is not focusable.
 		 */
 		/* eslint-disable jsx-a11y/mouse-events-have-key-events */
-		return <Url onClick={ onClick.bind( null, "url" ) }
-		            onMouseOver={ partial( onMouseOver, "url" ) }
-		            onMouseLeave={ partial( onMouseLeave, "url" ) }>
-			{ urlContent }
+		return <Url>
+			<BaseUrlOverflowContainer
+				onClick={ onClick.bind( null, "url" ) }
+				onMouseOver={ partial( onMouseOver, "url" ) }
+				onMouseLeave={ partial( onMouseLeave, "url" ) }>
+				{ urlContent }
+			</BaseUrlOverflowContainer>
 		</Url>;
 		/* eslint-enable jsx-a11y/mouse-events-have-key-events */
 	}

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -40,7 +40,7 @@ const MobileContainer = styled.div`
 	border-radius: 2px;
 	box-shadow: 0 1px 2px rgba(0,0,0,.2);
 	margin: 0 20px 10px;
-	font-family: Roboto-Regular, HelveticaNeue, Arial, sans-serif;
+	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
 	max-width: ${ MAX_WIDTH }px;
 	box-sizing: border-box;
 `;
@@ -112,6 +112,7 @@ export const TitleUnboundedMobile = styled.span`
 	max-height: 2.4em;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	font-size: 16px;
 `;
 
 export const BaseUrl = styled.div`
@@ -134,6 +135,7 @@ const MobileDescription = styled( DesktopDescription )`
 	line-height: 1em;
 	max-height: 4em;
 	overflow: hidden;
+	font-size: 14px;
 `;
 
 const MobilePartContainer = styled.div`
@@ -588,7 +590,7 @@ export default class SnippetPreview extends PureComponent {
 							after=":"
 						/>
 						{ amp }
-						{ this.renderUrl() }
+						<slug> { this.renderUrl() } </slug>
 						{ downArrow }
 					</PartContainer>
 					{ separator }

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/ProgressBarTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/ProgressBarTest.js.snap
@@ -6,7 +6,7 @@ exports[`the progress bar matches the snapshot 1`] = `
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -47,7 +47,7 @@ exports[`the progress bar with custom color matches the snapshot 1`] = `
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -88,7 +88,7 @@ exports[`the progress bar with progress matches the snapshot 1`] = `
   width: 100%;
   height: 8px;
   display: block;
-  margin-top: 5px;
+  margin-top: 8px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -53,7 +53,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -64,6 +64,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
@@ -229,7 +230,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -240,6 +241,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
@@ -408,7 +410,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -419,6 +421,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
@@ -547,6 +550,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -588,7 +592,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -599,17 +603,18 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c9 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c8 {
@@ -737,6 +742,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -778,7 +784,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -789,17 +795,18 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
@@ -913,6 +920,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 .c2 {
@@ -954,7 +962,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -965,17 +973,18 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
-  line-height: 1em;
   max-height: 4em;
   overflow: hidden;
   font-size: 14px;
+  line-height: 20px;
 }
 
 .c1 {
-  padding: 16px;
+  padding: 8px 16px;
 }
 
 .c7 {
@@ -1133,7 +1142,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -1144,6 +1153,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
@@ -1309,7 +1319,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -1320,6 +1330,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c9 {
@@ -1497,7 +1508,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -1508,6 +1519,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
@@ -1685,7 +1697,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -1696,6 +1708,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c9 {
@@ -1873,7 +1886,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -1884,6 +1897,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c9 {
@@ -2061,7 +2075,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -2072,6 +2086,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {
@@ -2249,7 +2264,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -2260,6 +2275,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c9 {
@@ -2437,7 +2453,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
-  width: 100%;
+  max-width: 90%;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -2448,6 +2464,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  font-size: 13px;
 }
 
 .c8 {

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -56,6 +56,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c8 {
@@ -242,6 +243,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c8 {
@@ -431,6 +433,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c8 {
@@ -622,6 +625,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c8 {
@@ -640,6 +644,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
 
 .c10 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c12 {
@@ -832,6 +837,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -850,6 +856,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -1028,6 +1035,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c7 {
@@ -1046,6 +1054,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
 
 .c9 {
   max-height: 4em;
+  padding-bottom: 3px;
 }
 
 .c11 {
@@ -1226,6 +1235,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c8 {
@@ -1412,6 +1422,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c9 {
@@ -1610,6 +1621,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c8 {
@@ -1808,6 +1820,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c9 {
@@ -2006,6 +2019,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c9 {
@@ -2204,6 +2218,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c8 {
@@ -2402,6 +2417,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c9 {
@@ -2600,6 +2616,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   position: relative;
   max-width: 90%;
   white-space: nowrap;
+  font-size: 14px;
 }
 
 .c8 {

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -53,6 +53,10 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -225,6 +229,10 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -400,6 +408,10 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -532,7 +544,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -568,6 +580,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c7 {
@@ -575,6 +588,10 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c10 {
@@ -588,6 +605,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -716,7 +734,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -752,6 +770,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -759,6 +778,10 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -772,6 +795,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -886,7 +910,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
 }
@@ -922,6 +946,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .c6 {
@@ -929,6 +954,10 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -942,6 +971,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   line-height: 1em;
   max-height: 4em;
   overflow: hidden;
+  font-size: 14px;
 }
 
 .c1 {
@@ -1103,6 +1133,10 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {
@@ -1275,6 +1309,10 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c10 {
@@ -1459,6 +1497,10 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c10 {
@@ -1643,6 +1685,10 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c10 {
@@ -1827,6 +1873,10 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c10 {
@@ -2011,6 +2061,10 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c10 {
@@ -2195,6 +2249,10 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c10 {
@@ -2379,6 +2437,10 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   color: #006621;
   cursor: pointer;
   position: relative;
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c9 {

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -55,12 +55,16 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c9 {
+.c8 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
   color: #777;
   cursor: pointer;
   position: relative;
@@ -68,7 +72,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   font-size: 13px;
 }
 
-.c8 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -136,14 +140,18 @@ exports[`SnippetPreview changes the colors of the description if it was generate
         </span>
         <div
           className="c7"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
         >
-          https://example.org
+          <div
+            className="c8 c7"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            https://example.org
+          </div>
         </div>
         <div
-          className="c8"
+          className="c9"
         />
       </div>
       <div
@@ -164,7 +172,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
           Meta description preview:
         </span>
         <div
-          className="c9"
+          className="c10"
           color="#777"
           onClick={[Function]}
           onMouseLeave={[Function]}
@@ -233,12 +241,16 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c9 {
+.c8 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -246,7 +258,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   font-size: 13px;
 }
 
-.c8 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -314,14 +326,18 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
         </span>
         <div
           className="c7"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
         >
-          https://example.org
+          <div
+            className="c8 c7"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            https://example.org
+          </div>
         </div>
         <div
-          className="c8"
+          className="c9"
         />
       </div>
       <div
@@ -342,7 +358,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
           Meta description preview:
         </span>
         <div
-          className="c9"
+          className="c10"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
@@ -414,12 +430,16 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c9 {
+.c8 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -427,7 +447,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   font-size: 13px;
 }
 
-.c8 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -495,18 +515,22 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
         </span>
         <div
           className="c7"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
         >
-          https://example.org/this
-          <strong>
-            -keyword-
-          </strong>
-          url
+          <div
+            className="c8 c7"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            https://example.org/this
+            <strong>
+              -keyword-
+            </strong>
+            url
+          </div>
         </div>
         <div
-          className="c8"
+          className="c9"
         />
       </div>
       <div
@@ -527,7 +551,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
           Meta description preview:
         </span>
         <div
-          className="c9"
+          className="c10"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
@@ -597,12 +621,16 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c10 {
+.c8 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -610,11 +638,11 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   font-size: 13px;
 }
 
-.c9 {
+.c10 {
   max-height: 4em;
 }
 
-.c11 {
+.c12 {
   overflow: hidden;
   font-size: 14px;
   line-height: 20px;
@@ -625,7 +653,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   padding: 8px 16px;
 }
 
-.c8 {
+.c9 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
@@ -700,15 +728,19 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
       />
       <div
         className="c7"
-        onClick={[Function]}
-        onMouseLeave={[Function]}
-        onMouseOver={[Function]}
       >
-        https://example.org
+        <div
+          className="c8 c7"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          https://example.org
+        </div>
       </div>
     </div>
     <hr
-      className="c8"
+      className="c9"
     />
     <div
       className="c1"
@@ -728,14 +760,14 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
         Meta description preview:
       </span>
       <div
-        className="c9 c10"
+        className="c10 c11"
         color="#545454"
         onClick={[Function]}
         onMouseLeave={[Function]}
         onMouseOver={[Function]}
       >
         <div
-          className="c11 c9 c10"
+          className="c12 c10 c11"
           color="#545454"
         >
           Description
@@ -799,12 +831,16 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c9 {
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -812,11 +848,11 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   font-size: 13px;
 }
 
-.c8 {
+.c9 {
   max-height: 4em;
 }
 
-.c10 {
+.c11 {
   overflow: hidden;
   font-size: 14px;
   line-height: 20px;
@@ -827,7 +863,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   padding: 8px 16px;
 }
 
-.c7 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
@@ -888,15 +924,19 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
       </span>
       <div
         className="c6"
-        onClick={[Function]}
-        onMouseLeave={[Function]}
-        onMouseOver={[Function]}
       >
-        https://example.org
+        <div
+          className="c7 c6"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          https://example.org
+        </div>
       </div>
     </div>
     <hr
-      className="c7"
+      className="c8"
     />
     <div
       className="c1"
@@ -916,14 +956,14 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
         Meta description preview:
       </span>
       <div
-        className="c8 c9"
+        className="c9 c10"
         color="#545454"
         onClick={[Function]}
         onMouseLeave={[Function]}
         onMouseOver={[Function]}
       >
         <div
-          className="c10 c8 c9"
+          className="c11 c9 c10"
           color="#545454"
         >
           Description
@@ -987,12 +1027,16 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c9 {
+.c7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -1000,11 +1044,11 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   font-size: 13px;
 }
 
-.c8 {
+.c9 {
   max-height: 4em;
 }
 
-.c10 {
+.c11 {
   overflow: hidden;
   font-size: 14px;
   line-height: 20px;
@@ -1015,7 +1059,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   padding: 8px 16px;
 }
 
-.c7 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
@@ -1076,15 +1120,19 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
       </span>
       <div
         className="c6"
-        onClick={[Function]}
-        onMouseLeave={[Function]}
-        onMouseOver={[Function]}
       >
-        https://example.org
+        <div
+          className="c7 c6"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          https://example.org
+        </div>
       </div>
     </div>
     <hr
-      className="c7"
+      className="c8"
     />
     <div
       className="c1"
@@ -1104,14 +1152,14 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
         Meta description preview:
       </span>
       <div
-        className="c8 c9"
+        className="c9 c10"
         color="#545454"
         onClick={[Function]}
         onMouseLeave={[Function]}
         onMouseOver={[Function]}
       >
         <div
-          className="c10 c8 c9"
+          className="c11 c9 c10"
           color="#545454"
         >
           Description
@@ -1177,12 +1225,16 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c9 {
+.c8 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -1190,7 +1242,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   font-size: 13px;
 }
 
-.c8 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -1258,14 +1310,18 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
         </span>
         <div
           className="c7"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
         >
-          https://example.org
+          <div
+            className="c8 c7"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            https://example.org
+          </div>
         </div>
         <div
-          className="c8"
+          className="c9"
         />
       </div>
       <div
@@ -1286,7 +1342,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c9"
+          className="c10"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
@@ -1355,12 +1411,16 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c10 {
+.c9 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -1368,7 +1428,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   font-size: 13px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -1448,14 +1508,18 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
         </span>
         <div
           className="c8"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
         >
-          https://example.org
+          <div
+            className="c9 c8"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            https://example.org
+          </div>
         </div>
         <div
-          className="c9"
+          className="c10"
         />
       </div>
       <div
@@ -1476,7 +1540,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c10"
+          className="c11"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
@@ -1545,12 +1609,16 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c10 {
+.c8 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -1558,7 +1626,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   font-size: 13px;
 }
 
-.c8 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -1568,7 +1636,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   vertical-align: top;
 }
 
-.c9::before {
+.c10::before {
   display: block;
   position: absolute;
   top: -3px;
@@ -1638,14 +1706,18 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
         </span>
         <div
           className="c7"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
         >
-          https://example.org
+          <div
+            className="c8 c7"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            https://example.org
+          </div>
         </div>
         <div
-          className="c8"
+          className="c9"
         />
       </div>
       <div
@@ -1666,7 +1738,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
           Meta description preview:
         </span>
         <div
-          className="c9 c10"
+          className="c10 c11"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
@@ -1735,12 +1807,16 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c10 {
+.c9 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -1748,7 +1824,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   font-size: 13px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -1828,14 +1904,18 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
         </span>
         <div
           className="c7 c8"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
         >
-          https://example.org
+          <div
+            className="c9 c8"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            https://example.org
+          </div>
         </div>
         <div
-          className="c9"
+          className="c10"
         />
       </div>
       <div
@@ -1856,7 +1936,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
           Meta description preview:
         </span>
         <div
-          className="c10"
+          className="c11"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
@@ -1925,12 +2005,16 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c10 {
+.c9 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -1938,7 +2022,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   font-size: 13px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -2018,14 +2102,18 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
         </span>
         <div
           className="c8"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
         >
-          https://example.org
+          <div
+            className="c9 c8"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            https://example.org
+          </div>
         </div>
         <div
-          className="c9"
+          className="c10"
         />
       </div>
       <div
@@ -2046,7 +2134,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c10"
+          className="c11"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
@@ -2115,12 +2203,16 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c10 {
+.c8 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -2128,7 +2220,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   font-size: 13px;
 }
 
-.c8 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -2138,7 +2230,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   vertical-align: top;
 }
 
-.c9::before {
+.c10::before {
   display: block;
   position: absolute;
   top: -3px;
@@ -2208,14 +2300,18 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
         </span>
         <div
           className="c7"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
         >
-          https://example.org
+          <div
+            className="c8 c7"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            https://example.org
+          </div>
         </div>
         <div
-          className="c8"
+          className="c9"
         />
       </div>
       <div
@@ -2236,7 +2332,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
           Meta description preview:
         </span>
         <div
-          className="c9 c10"
+          className="c10 c11"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
@@ -2305,12 +2401,16 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c10 {
+.c9 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -2318,7 +2418,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   font-size: 13px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -2398,14 +2498,18 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
         </span>
         <div
           className="c7 c8"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
         >
-          https://example.org
+          <div
+            className="c9 c8"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            https://example.org
+          </div>
         </div>
         <div
-          className="c9"
+          className="c10"
         />
       </div>
       <div
@@ -2426,7 +2530,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
           Meta description preview:
         </span>
         <div
-          className="c10"
+          className="c11"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
@@ -2495,12 +2599,16 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 90%;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
-.c9 {
+.c8 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -2508,7 +2616,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   font-size: 13px;
 }
 
-.c8 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -2518,7 +2626,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   vertical-align: top;
 }
 
-.c10 {
+.c11 {
   color: #808080;
 }
 
@@ -2580,14 +2688,18 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
         </span>
         <div
           className="c7"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
         >
-          https://example.org
+          <div
+            className="c8 c7"
+            onClick={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
+          >
+            https://example.org
+          </div>
         </div>
         <div
-          className="c8"
+          className="c9"
         />
       </div>
       <div
@@ -2608,14 +2720,14 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c9"
+          className="c10"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
         >
           <span
-            className="c10"
+            className="c11"
           >
             Today
              - 


### PR DESCRIPTION
## Summary

Multiple styling changes to make the snippet editor more closely match the original snippet editor.

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Used a prop to allow for different heights, to create a bigger input field for the meta description.
* Changed button.extends to extends(button). This fixes the switcher style, but I am unsure why. 


## Test instructions

This PR can be tested by following these steps:

* Install deps: `yarn install`.
* Link the yoast-components branch:
  * In the yoast-components clone: `yarn link` (skip this step if already done before).
  * In wordpress-seo clone: `yarn link yoast-components`.
* Checkout it's companion branch in wordpress-seo. https://github.com/Yoast/wordpress-seo/pull/9635
* Install and build yoast-components: `yarn install && yarn start`.
* Start the wordpress-seo dev server: `yarn start`.
* In the `wp-config.php` file of your WordPress installation add `define( 'YOAST_FEATURE_SNIPPET_PREVIEW', true );` to enable the React SnippetPreview.
* Check if the new snippet preview is the same as the old snippet preview. Addressed for now is the following:

--

* Change mobile snippet header 16px Arial.
* Change mobile snippet meta description to 14px Arial.
* Change edit snippet button to a height of 33 px, to match size with the mobile/desktop switcher.
* Change edit snippet pencil color to grey dark.
* Change margin and padding around of button to match the original more closely.
* Change Titles of input fields to 16px Arial.
* Change margin on the progress bar to more closely match the original in terms of looks.
* Change top padding on the edit snippet section to more closely match the original.
* Change slug in the snippet preview to not go to newline, and become an ellipsis when too long. It should work that way based on what search results on google look like. 

--
Additionally fixed after CR:
* Changed line height for mobile description and for 
* Switcher white background on hover and focus. And with a think border when hovered, focused, or active.
* Matched the padding on input fields to those of the old editor.
* Gave the description input field a min-height. Anton decided a draggable input field wasn't essential, but that the height of the input field should be larger, to communicate more content was acceptable.
* Increased the space between seperate editor input fields, to more resemble the old snippet editor.
* The height of input fields is off by about two pixels. This is difficult to fix because draft.js creates those input fields. It has been discussed with Anton, and considered an acceptable discrepancy.
* The caret missing in the mobile desc is addressed in another pull: #513

Fixes https://github.com/Yoast/wordpress-seo/issues/9533
