### PR TITLE
Change translation method in makeOutboundLink

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@wordpress/a11y": "^1.0.7",
+    "@wordpress/i18n": "^1.1.0",
     "algoliasearch": "^3.22.3",
     "debug": "^3.0.0",
     "draft-js": "^0.10.5",

--- a/utils/makeOutboundLink.js
+++ b/utils/makeOutboundLink.js
@@ -1,15 +1,10 @@
+/* External dependencies */
 import React from "react";
 import PropTypes from "prop-types";
-import { defineMessages, injectIntl, intlShape } from "react-intl";
+import { __ } from "@wordpress/i18n";
 
+/* Internal dependencies */
 import { A11yNotice } from "../composites/Plugin/Shared/components/A11yNotice";
-
-const messages = defineMessages( {
-	opensInNewTab: {
-		id: "a11yNotice.opensInNewTab",
-		defaultMessage: "(Opens in a new browser tab)",
-	},
-} );
 
 /**
  * Makes an anchor component into an outbound link that opens in a new tab.
@@ -36,16 +31,17 @@ export const makeOutboundLink = ( Component = "a" ) => {
 				React.createElement(
 					A11yNotice,
 					null,
-					this.props.intl.formatMessage( messages.opensInNewTab )
+					__( "(Opens in a new browser tab)", "yoast-components" ),
 				)
 			);
 		}
 	}
+
 	OutboundLink.propTypes = {
 		children: PropTypes.oneOfType( [
 			PropTypes.node,
 		] ),
-		intl: intlShape.isRequired,
 	};
-	return injectIntl( OutboundLink );
+
+	return OutboundLink;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,6 +113,15 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@wordpress/dom-ready/-/dom-ready-1.0.4.tgz#626648e83529de2243009ff04c12aeb9a949e333"
 
+"@wordpress/i18n@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-1.1.0.tgz#05ccae6eb220197a759fbbe4e94b010aa69f19fe"
+  dependencies:
+    gettext-parser "^1.3.1"
+    jed "^1.1.1"
+    lodash "^4.17.5"
+    memize "^1.0.5"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -2149,7 +2158,7 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
-encoding@^0.1.11:
+encoding@^0.1.11, encoding@^0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
@@ -2194,12 +2203,6 @@ enzyme-adapter-utils@^1.3.0:
     lodash "^4.17.4"
     object.assign "^4.0.4"
     prop-types "^15.6.0"
-
-enzyme-react-intl@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/enzyme-react-intl/-/enzyme-react-intl-2.0.0.tgz#1000400c0ab2ec6e7393f3f09cf8435cd3c884bf"
-  dependencies:
-    jsonfile "^4.0.0"
 
 enzyme-to-json@^3.3.3:
   version "3.3.3"
@@ -2959,6 +2962,13 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+gettext-parser@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/gettext-parser/-/gettext-parser-1.3.1.tgz#74b7a99e4b5fa8daab11fa515e8a582480448a12"
+  dependencies:
+    encoding "^0.1.12"
+    safe-buffer "^5.1.1"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -3069,7 +3079,7 @@ globule@^1.0.0:
     lodash "~4.17.4"
     minimatch "~3.0.2"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -4371,12 +4381,6 @@ json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -4682,6 +4686,10 @@ mem@^1.1.0:
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
   dependencies:
     mimic-fn "^1.0.0"
+
+memize@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/memize/-/memize-1.0.5.tgz#51d89e8407643dbc8cab98c6d56b889f9a3954e3"
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _not applicable_

## Relevant technical choices:

We will switch from react-intl to @wordpress/i18n. I will make small PRs that do this. This is the first PR that is required for all the others.

## Test instructions

This PR can be tested by following these steps:

* Make sure the outbound link still works, I've tested this by looking in the source of the content analysis switch language message.