### PR TITLE
Strip out question mark and hash characters from the snippet preview …

### DIFF
--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -440,7 +440,9 @@ export default class SnippetPreview extends PureComponent {
 	 */
 	getBreadcrumbs() {
 		const { url, breadcrumbs } = this.props;
-		const { protocol, hostname, pathname } = parse( url );
+		// Strip out question mark and hash characters from the raw URL.
+		const cleanUrl = url.replace( /\?|#/g, "" );
+		const { protocol, hostname, pathname } = parse( cleanUrl );
 
 		const hostPart = protocol === "https:" ? protocol + "//" + hostname : hostname;
 


### PR DESCRIPTION
Strips out any `?` and `#` from the snippet preview URL before passing it to node-url `parse()`.

To test:
- in the standalone example or yarn-link to wpseo:
- if testing on WordPress, make sure your `wp-config.php` sets the constant `define( 'YOAST_FEATURE_SNIPPET_PREVIEW', true );`
- if testing on WordPress, build the wpseo plugin js
- edit the snippet preview
- in the slug field, enter a slug that contains `?` and `#` characters
- check the slug in the snippet preview is rendered correctly, without `?` and `#` and with no missing parts

Fixes https://github.com/Yoast/yoast-components/issues/485