### PR TITLE
CSS Solution for fixing the carret by the mobile description

### DIFF
--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -62,7 +62,11 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
 .c8 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c10 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -75,14 +79,14 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   margin: 0;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -97,33 +101,33 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
+.c12:hover,
+.c12:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -152,13 +156,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c19 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -173,26 +177,26 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c20 {
+.c21 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin: 10px 0 0 9px;
 }
 
-.c20 svg {
+.c21 svg {
   margin-right: 7px;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -202,7 +206,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -210,7 +214,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -218,7 +222,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -227,7 +231,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -324,23 +328,28 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
         >
-          Totally different description
+          <div
+            className="c10 c8 c9"
+            color="#545454"
+          >
+            Totally different description
+          </div>
         </div>
       </div>
     </div>
   </section>
   <div
-    className="c10"
+    className="c11"
   >
     <button
       aria-pressed={true}
-      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c17"
+        className="yoast-svg-icon yoast-svg-icon-mobile c18"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -369,13 +378,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c19"
+        className="yoast-svg-icon yoast-svg-icon-desktop c20"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -405,13 +414,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+    className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
     onClick={[Function]}
     type="button"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c21"
+      className="yoast-svg-icon yoast-svg-icon-edit c22"
       fill={undefined}
       focusable="false"
       role="img"
@@ -573,7 +582,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 .c8 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c10 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -586,7 +599,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   margin: 0;
 }
 
-.c26 {
+.c27 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -599,26 +612,26 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border: 1px solid #ddd;
 }
 
-.c26::-webkit-progress-bar {
+.c27::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c26::-webkit-progress-value {
+.c27::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c26::-moz-progress-bar {
+.c27::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c26::-ms-fill {
+.c27::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
 
-.c25 {
+.c26 {
   padding: 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -630,7 +643,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   position: relative;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -642,26 +655,26 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   content: "";
 }
 
-.c23 {
+.c24 {
   margin: 1em 0;
 }
 
-.c22 {
+.c23 {
   padding: 0 20px;
 }
 
-.c24 {
+.c25 {
   cursor: pointer;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -676,33 +689,33 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
+.c12:hover,
+.c12:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -731,13 +744,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c19 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -752,33 +765,33 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c20 {
+.c21 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin: 10px 0 0 9px;
 }
 
-.c20 svg {
+.c21 svg {
   margin-right: 7px;
 }
 
-.c27 {
+.c28 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin-left: 20px;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -788,7 +801,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -796,7 +809,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -804,7 +817,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -813,7 +826,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -1051,7 +1064,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
                 <SnippetPreview__MobileDescription
-                  innerRef={[Function]}
                   isDescriptionGenerated={false}
                   onClick={[Function]}
                   onMouseLeave={[Function]}
@@ -1059,7 +1071,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 >
                   <SnippetPreview__DesktopDescription
                     className="c8"
-                    innerRef={[Function]}
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
@@ -1072,7 +1083,26 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      Test description, %%replacement_variable%%
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c10"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c10 c8"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c10 c8 c9"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
                     </div>
                   </SnippetPreview__DesktopDescription>
                 </SnippetPreview__MobileDescription>
@@ -1088,7 +1118,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c10"
+          className="c11"
         >
           <Button
             aria-pressed={true}
@@ -1100,7 +1130,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c11"
+              className="c12"
               isActive={true}
               onClick={[Function]}
               textColor="#555"
@@ -1111,7 +1141,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c12 Button-kDSBcD c13"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -1122,7 +1152,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c12 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -1133,7 +1163,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -1144,7 +1174,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -1152,7 +1182,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     >
                       <button
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -1173,7 +1203,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile c18"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -1231,7 +1261,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
               textColor="#555"
@@ -1242,7 +1272,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 Button-kDSBcD c13"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -1253,7 +1283,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -1264,7 +1294,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -1275,7 +1305,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -1283,7 +1313,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     >
                       <button
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -1304,7 +1334,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop c20"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -1365,7 +1395,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -1376,7 +1406,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -1387,7 +1417,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -1398,7 +1428,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -1409,7 +1439,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -1417,7 +1447,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -1436,7 +1466,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -1548,18 +1578,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-title"
                     onClick={[Function]}
                   >
@@ -1571,7 +1601,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-title"
@@ -1594,7 +1624,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={600}
                     value={0}
                   />
@@ -1603,14 +1633,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-slug"
                     onClick={[Function]}
                   >
@@ -1622,7 +1652,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-slug"
@@ -1639,14 +1669,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-description"
                     onClick={[Function]}
                   >
@@ -1658,7 +1688,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-description"
@@ -1681,7 +1711,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={320}
                     value={0}
                   />
@@ -1699,7 +1729,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c27"
+        className="c28"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -1708,7 +1738,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c12"
+          className="c28 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -1717,7 +1747,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c28 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -1726,7 +1756,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -1735,13 +1765,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -1827,7 +1857,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 .c8 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c10 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -1840,7 +1874,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   margin: 0;
 }
 
-.c26 {
+.c27 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -1853,26 +1887,26 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border: 1px solid #ddd;
 }
 
-.c26::-webkit-progress-bar {
+.c27::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c26::-webkit-progress-value {
+.c27::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c26::-moz-progress-bar {
+.c27::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c26::-ms-fill {
+.c27::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
 
-.c25 {
+.c26 {
   padding: 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -1884,7 +1918,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   position: relative;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -1896,26 +1930,26 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   content: "";
 }
 
-.c23 {
+.c24 {
   margin: 1em 0;
 }
 
-.c22 {
+.c23 {
   padding: 0 20px;
 }
 
-.c24 {
+.c25 {
   cursor: pointer;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -1930,33 +1964,33 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
+.c12:hover,
+.c12:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1985,13 +2019,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c19 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -2006,33 +2040,33 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c20 {
+.c21 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin: 10px 0 0 9px;
 }
 
-.c20 svg {
+.c21 svg {
   margin-right: 7px;
 }
 
-.c27 {
+.c28 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin-left: 20px;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -2042,7 +2076,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -2050,7 +2084,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -2058,7 +2092,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -2067,7 +2101,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -2305,7 +2339,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
                 <SnippetPreview__MobileDescription
-                  innerRef={[Function]}
                   isDescriptionGenerated={false}
                   onClick={[Function]}
                   onMouseLeave={[Function]}
@@ -2313,7 +2346,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 >
                   <SnippetPreview__DesktopDescription
                     className="c8"
-                    innerRef={[Function]}
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
@@ -2326,7 +2358,26 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      Test description, %%replacement_variable%%
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c10"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c10 c8"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c10 c8 c9"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
                     </div>
                   </SnippetPreview__DesktopDescription>
                 </SnippetPreview__MobileDescription>
@@ -2342,7 +2393,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c10"
+          className="c11"
         >
           <Button
             aria-pressed={true}
@@ -2354,7 +2405,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c11"
+              className="c12"
               isActive={true}
               onClick={[Function]}
               textColor="#555"
@@ -2365,7 +2416,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c12 Button-kDSBcD c13"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -2376,7 +2427,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c12 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -2387,7 +2438,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -2398,7 +2449,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -2406,7 +2457,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     >
                       <button
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -2427,7 +2478,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile c18"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -2485,7 +2536,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
               textColor="#555"
@@ -2496,7 +2547,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 Button-kDSBcD c13"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -2507,7 +2558,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -2518,7 +2569,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -2529,7 +2580,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -2537,7 +2588,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     >
                       <button
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -2558,7 +2609,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop c20"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -2619,7 +2670,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -2630,7 +2681,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -2641,7 +2692,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -2652,7 +2703,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -2663,7 +2714,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -2671,7 +2722,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -2690,7 +2741,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -2802,18 +2853,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-title"
                     onClick={[Function]}
                   >
@@ -2825,7 +2876,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-title"
@@ -2848,7 +2899,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={600}
                     value={0}
                   />
@@ -2857,14 +2908,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-slug"
                     onClick={[Function]}
                   >
@@ -2876,7 +2927,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-slug"
@@ -2893,14 +2944,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-description"
                     onClick={[Function]}
                   >
@@ -2912,7 +2963,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-description"
@@ -2935,7 +2986,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={320}
                     value={0}
                   />
@@ -2953,7 +3004,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c27"
+        className="c28"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -2962,7 +3013,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c12"
+          className="c28 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -2971,7 +3022,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c28 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -2980,7 +3031,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -2989,13 +3040,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -3081,7 +3132,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 .c8 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c10 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -3094,7 +3149,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   margin: 0;
 }
 
-.c26 {
+.c27 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -3107,26 +3162,26 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border: 1px solid #ddd;
 }
 
-.c26::-webkit-progress-bar {
+.c27::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c26::-webkit-progress-value {
+.c27::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c26::-moz-progress-bar {
+.c27::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c26::-ms-fill {
+.c27::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
 
-.c25 {
+.c26 {
   padding: 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -3138,7 +3193,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   position: relative;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -3150,26 +3205,26 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   content: "";
 }
 
-.c23 {
+.c24 {
   margin: 1em 0;
 }
 
-.c22 {
+.c23 {
   padding: 0 20px;
 }
 
-.c24 {
+.c25 {
   cursor: pointer;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -3184,33 +3239,33 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
+.c12:hover,
+.c12:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3239,13 +3294,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c19 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -3260,33 +3315,33 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c20 {
+.c21 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin: 10px 0 0 9px;
 }
 
-.c20 svg {
+.c21 svg {
   margin-right: 7px;
 }
 
-.c27 {
+.c28 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin-left: 20px;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -3296,7 +3351,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -3304,7 +3359,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -3312,7 +3367,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -3321,7 +3376,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -3559,7 +3614,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
                 <SnippetPreview__MobileDescription
-                  innerRef={[Function]}
                   isDescriptionGenerated={false}
                   onClick={[Function]}
                   onMouseLeave={[Function]}
@@ -3567,7 +3621,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 >
                   <SnippetPreview__DesktopDescription
                     className="c8"
-                    innerRef={[Function]}
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
@@ -3580,7 +3633,26 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      Test description, %%replacement_variable%%
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c10"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c10 c8"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c10 c8 c9"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
                     </div>
                   </SnippetPreview__DesktopDescription>
                 </SnippetPreview__MobileDescription>
@@ -3596,7 +3668,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c10"
+          className="c11"
         >
           <Button
             aria-pressed={true}
@@ -3608,7 +3680,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c11"
+              className="c12"
               isActive={true}
               onClick={[Function]}
               textColor="#555"
@@ -3619,7 +3691,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c12 Button-kDSBcD c13"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -3630,7 +3702,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c12 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -3641,7 +3713,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -3652,7 +3724,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -3660,7 +3732,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     >
                       <button
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -3681,7 +3753,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile c18"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -3739,7 +3811,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
               textColor="#555"
@@ -3750,7 +3822,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 Button-kDSBcD c13"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -3761,7 +3833,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -3772,7 +3844,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -3783,7 +3855,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -3791,7 +3863,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     >
                       <button
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -3812,7 +3884,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop c20"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -3873,7 +3945,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -3884,7 +3956,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -3895,7 +3967,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -3906,7 +3978,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -3917,7 +3989,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -3925,7 +3997,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -3944,7 +4016,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -4056,18 +4128,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-title"
                     onClick={[Function]}
                   >
@@ -4079,7 +4151,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-title"
@@ -4102,7 +4174,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={600}
                     value={0}
                   />
@@ -4111,14 +4183,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-slug"
                     onClick={[Function]}
                   >
@@ -4130,7 +4202,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-slug"
@@ -4147,14 +4219,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-5-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-5-description"
                     onClick={[Function]}
                   >
@@ -4166,7 +4238,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-5-description"
@@ -4189,7 +4261,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={320}
                     value={0}
                   />
@@ -4207,7 +4279,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c27"
+        className="c28"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -4216,7 +4288,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c12"
+          className="c28 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -4225,7 +4297,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c28 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -4234,7 +4306,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -4243,13 +4315,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -4335,7 +4407,11 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 .c8 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c10 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -4348,7 +4424,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   margin: 0;
 }
 
-.c26 {
+.c27 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -4361,26 +4437,26 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border: 1px solid #ddd;
 }
 
-.c26::-webkit-progress-bar {
+.c27::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c26::-webkit-progress-value {
+.c27::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c26::-moz-progress-bar {
+.c27::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c26::-ms-fill {
+.c27::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
 
-.c25 {
+.c26 {
   padding: 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -4392,7 +4468,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   position: relative;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -4404,26 +4480,26 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   content: "";
 }
 
-.c23 {
+.c24 {
   margin: 1em 0;
 }
 
-.c22 {
+.c23 {
   padding: 0 20px;
 }
 
-.c24 {
+.c25 {
   cursor: pointer;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -4438,33 +4514,33 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
+.c12:hover,
+.c12:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -4493,13 +4569,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c19 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -4514,33 +4590,33 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c20 {
+.c21 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin: 10px 0 0 9px;
 }
 
-.c20 svg {
+.c21 svg {
   margin-right: 7px;
 }
 
-.c27 {
+.c28 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin-left: 20px;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -4550,7 +4626,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -4558,7 +4634,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -4566,7 +4642,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -4575,7 +4651,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -4813,7 +4889,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
                 <SnippetPreview__MobileDescription
-                  innerRef={[Function]}
                   isDescriptionGenerated={false}
                   onClick={[Function]}
                   onMouseLeave={[Function]}
@@ -4821,7 +4896,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 >
                   <SnippetPreview__DesktopDescription
                     className="c8"
-                    innerRef={[Function]}
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
@@ -4834,7 +4908,26 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      Test description, %%replacement_variable%%
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c10"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c10 c8"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c10 c8 c9"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
                     </div>
                   </SnippetPreview__DesktopDescription>
                 </SnippetPreview__MobileDescription>
@@ -4850,7 +4943,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c10"
+          className="c11"
         >
           <Button
             aria-pressed={true}
@@ -4862,7 +4955,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c11"
+              className="c12"
               isActive={true}
               onClick={[Function]}
               textColor="#555"
@@ -4873,7 +4966,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c12 Button-kDSBcD c13"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -4884,7 +4977,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c12 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -4895,7 +4988,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -4906,7 +4999,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -4914,7 +5007,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     >
                       <button
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -4935,7 +5028,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile c18"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -4993,7 +5086,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
               textColor="#555"
@@ -5004,7 +5097,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 Button-kDSBcD c13"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -5015,7 +5108,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -5026,7 +5119,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -5037,7 +5130,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -5045,7 +5138,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     >
                       <button
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -5066,7 +5159,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop c20"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -5127,7 +5220,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -5138,7 +5231,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -5149,7 +5242,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -5160,7 +5253,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -5171,7 +5264,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -5179,7 +5272,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -5198,7 +5291,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -5310,18 +5403,18 @@ exports[`SnippetEditor closes when calling close() 1`] = `
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-2-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-2-title"
                     onClick={[Function]}
                   >
@@ -5333,7 +5426,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-2-title"
@@ -5356,7 +5449,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={600}
                     value={0}
                   />
@@ -5365,14 +5458,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-2-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-2-slug"
                     onClick={[Function]}
                   >
@@ -5384,7 +5477,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-2-slug"
@@ -5401,14 +5494,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-2-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-2-description"
                     onClick={[Function]}
                   >
@@ -5420,7 +5513,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-2-description"
@@ -5443,7 +5536,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={320}
                     value={0}
                   />
@@ -5461,7 +5554,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c27"
+        className="c28"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -5470,7 +5563,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c12"
+          className="c28 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -5479,7 +5572,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c28 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -5488,7 +5581,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -5497,13 +5590,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -5589,7 +5682,11 @@ exports[`SnippetEditor closes when calling close() 2`] = `
 .c8 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c10 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -5602,14 +5699,14 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   margin: 0;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -5624,33 +5721,33 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
+.c12:hover,
+.c12:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -5679,13 +5776,13 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c19 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -5700,26 +5797,26 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c20 {
+.c21 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin: 10px 0 0 9px;
 }
 
-.c20 svg {
+.c21 svg {
   margin-right: 7px;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -5729,7 +5826,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -5737,7 +5834,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -5745,7 +5842,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -5754,7 +5851,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -5992,7 +6089,6 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
                 <SnippetPreview__MobileDescription
-                  innerRef={[Function]}
                   isDescriptionGenerated={false}
                   onClick={[Function]}
                   onMouseLeave={[Function]}
@@ -6000,7 +6096,6 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                 >
                   <SnippetPreview__DesktopDescription
                     className="c8"
-                    innerRef={[Function]}
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
@@ -6013,7 +6108,26 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      Test description, %%replacement_variable%%
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c10"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c10 c8"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c10 c8 c9"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
                     </div>
                   </SnippetPreview__DesktopDescription>
                 </SnippetPreview__MobileDescription>
@@ -6029,7 +6143,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c10"
+          className="c11"
         >
           <Button
             aria-pressed={true}
@@ -6041,7 +6155,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c11"
+              className="c12"
               isActive={true}
               onClick={[Function]}
               textColor="#555"
@@ -6052,7 +6166,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c12 Button-kDSBcD c13"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -6063,7 +6177,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c12 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -6074,7 +6188,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -6085,7 +6199,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -6093,7 +6207,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     >
                       <button
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -6114,7 +6228,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile c18"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -6172,7 +6286,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
               textColor="#555"
@@ -6183,7 +6297,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 Button-kDSBcD c13"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -6194,7 +6308,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -6205,7 +6319,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -6216,7 +6330,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -6224,7 +6338,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     >
                       <button
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -6245,7 +6359,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop c20"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -6306,7 +6420,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -6317,7 +6431,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -6328,7 +6442,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -6339,7 +6453,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -6350,7 +6464,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -6358,7 +6472,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
               >
                 <button
                   aria-expanded={false}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -6377,7 +6491,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -6472,7 +6586,11 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 .c8 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c10 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -6483,6 +6601,38 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
+}
+
+.c28 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 5px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c28::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c28::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c28::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c28::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
 }
 
 .c27 {
@@ -6503,53 +6653,21 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c27::-webkit-progress-value {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c27::-moz-progress-bar {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
 }
 
 .c27::-ms-fill {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   border: 0;
 }
 
 .c26 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 5px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c26::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c26::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c26::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c26::-ms-fill {
-  background-color: #ee7c1b;
-  border: 0;
-}
-
-.c25 {
   padding: 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -6561,7 +6679,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   position: relative;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -6573,26 +6691,26 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   content: "";
 }
 
-.c23 {
+.c24 {
   margin: 1em 0;
 }
 
-.c22 {
+.c23 {
   padding: 0 20px;
 }
 
-.c24 {
+.c25 {
   cursor: pointer;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -6607,33 +6725,33 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
+.c12:hover,
+.c12:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -6662,13 +6780,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c19 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -6683,33 +6801,33 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c20 {
+.c21 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin: 10px 0 0 9px;
 }
 
-.c20 svg {
+.c21 svg {
   margin-right: 7px;
 }
 
-.c28 {
+.c29 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin-left: 20px;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -6719,7 +6837,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -6727,7 +6845,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -6735,7 +6853,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -6744,7 +6862,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -6982,7 +7100,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
                 <SnippetPreview__MobileDescription
-                  innerRef={[Function]}
                   isDescriptionGenerated={false}
                   onClick={[Function]}
                   onMouseLeave={[Function]}
@@ -6990,7 +7107,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 >
                   <SnippetPreview__DesktopDescription
                     className="c8"
-                    innerRef={[Function]}
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
@@ -7003,7 +7119,26 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      Test description, %%replacement_variable%%
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c10"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c10 c8"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c10 c8 c9"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
                     </div>
                   </SnippetPreview__DesktopDescription>
                 </SnippetPreview__MobileDescription>
@@ -7019,7 +7154,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c10"
+          className="c11"
         >
           <Button
             aria-pressed={true}
@@ -7031,7 +7166,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c11"
+              className="c12"
               isActive={true}
               onClick={[Function]}
               textColor="#555"
@@ -7042,7 +7177,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c12 Button-kDSBcD c13"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -7053,7 +7188,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c12 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -7064,7 +7199,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -7075,7 +7210,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -7083,7 +7218,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     >
                       <button
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -7104,7 +7239,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile c18"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -7162,7 +7297,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
               textColor="#555"
@@ -7173,7 +7308,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 Button-kDSBcD c13"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -7184,7 +7319,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -7195,7 +7330,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -7206,7 +7341,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -7214,7 +7349,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     >
                       <button
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -7235,7 +7370,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop c20"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -7296,7 +7431,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -7307,7 +7442,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -7318,7 +7453,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -7329,7 +7464,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -7340,7 +7475,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -7348,7 +7483,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -7367,7 +7502,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -7479,18 +7614,18 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-8-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-8-title"
                     onClick={[Function]}
                   >
@@ -7502,7 +7637,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-8-title"
@@ -7525,7 +7660,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={550}
                     value={361}
                   />
@@ -7534,14 +7669,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-8-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-8-slug"
                     onClick={[Function]}
                   >
@@ -7553,7 +7688,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-8-slug"
@@ -7570,14 +7705,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-8-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-8-description"
                     onClick={[Function]}
                   >
@@ -7589,7 +7724,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-8-description"
@@ -7612,7 +7747,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c27"
+                    className="c28"
                     max={320}
                     value={0}
                   />
@@ -7630,7 +7765,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c28"
+        className="c29"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -7639,7 +7774,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c28 Button-kDSBcD c12"
+          className="c29 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -7648,7 +7783,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c28 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c29 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -7657,7 +7792,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c28 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -7666,13 +7801,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c28 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c28 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -7758,7 +7893,11 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 .c8 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c10 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -7769,38 +7908,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c26 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 5px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c26::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c26::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c26::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c26::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
 }
 
 .c27 {
@@ -7821,21 +7928,53 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c27::-webkit-progress-value {
-  background-color: #7ad03a;
+  background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c27::-moz-progress-bar {
-  background-color: #7ad03a;
+  background-color: #dc3232;
 }
 
 .c27::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c28 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 5px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c28::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c28::-webkit-progress-value {
+  background-color: #7ad03a;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c28::-moz-progress-bar {
+  background-color: #7ad03a;
+}
+
+.c28::-ms-fill {
   background-color: #7ad03a;
   border: 0;
 }
 
-.c25 {
+.c26 {
   padding: 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -7847,7 +7986,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   position: relative;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -7859,26 +7998,26 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   content: "";
 }
 
-.c23 {
+.c24 {
   margin: 1em 0;
 }
 
-.c22 {
+.c23 {
   padding: 0 20px;
 }
 
-.c24 {
+.c25 {
   cursor: pointer;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -7893,33 +8032,33 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
+.c12:hover,
+.c12:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -7948,13 +8087,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c19 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -7969,33 +8108,33 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c20 {
+.c21 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin: 10px 0 0 9px;
 }
 
-.c20 svg {
+.c21 svg {
   margin-right: 7px;
 }
 
-.c28 {
+.c29 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin-left: 20px;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -8005,7 +8144,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -8013,7 +8152,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -8021,7 +8160,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -8030,7 +8169,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -8268,7 +8407,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
                 <SnippetPreview__MobileDescription
-                  innerRef={[Function]}
                   isDescriptionGenerated={false}
                   onClick={[Function]}
                   onMouseLeave={[Function]}
@@ -8276,7 +8414,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 >
                   <SnippetPreview__DesktopDescription
                     className="c8"
-                    innerRef={[Function]}
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
@@ -8289,7 +8426,26 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      Test description, %%replacement_variable%%
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c10"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c10 c8"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c10 c8 c9"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
                     </div>
                   </SnippetPreview__DesktopDescription>
                 </SnippetPreview__MobileDescription>
@@ -8305,7 +8461,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c10"
+          className="c11"
         >
           <Button
             aria-pressed={true}
@@ -8317,7 +8473,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c11"
+              className="c12"
               isActive={true}
               onClick={[Function]}
               textColor="#555"
@@ -8328,7 +8484,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c12 Button-kDSBcD c13"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -8339,7 +8495,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c12 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -8350,7 +8506,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -8361,7 +8517,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -8369,7 +8525,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     >
                       <button
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -8390,7 +8546,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile c18"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -8448,7 +8604,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
               textColor="#555"
@@ -8459,7 +8615,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 Button-kDSBcD c13"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -8470,7 +8626,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -8481,7 +8637,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -8492,7 +8648,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -8500,7 +8656,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     >
                       <button
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -8521,7 +8677,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop c20"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -8582,7 +8738,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -8593,7 +8749,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -8604,7 +8760,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -8615,7 +8771,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -8626,7 +8782,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -8634,7 +8790,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -8653,7 +8809,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -8765,18 +8921,18 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-7-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-7-title"
                     onClick={[Function]}
                   >
@@ -8788,7 +8944,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-7-title"
@@ -8811,7 +8967,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={550}
                     value={100}
                   />
@@ -8820,14 +8976,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-7-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-7-slug"
                     onClick={[Function]}
                   >
@@ -8839,7 +8995,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-7-slug"
@@ -8856,14 +9012,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-7-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-7-description"
                     onClick={[Function]}
                   >
@@ -8875,7 +9031,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-7-description"
@@ -8898,7 +9054,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 >
                   <progress
                     aria-hidden="true"
-                    className="c27"
+                    className="c28"
                     max={650}
                     value={330}
                   />
@@ -8916,7 +9072,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c28"
+        className="c29"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -8925,7 +9081,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c28 Button-kDSBcD c12"
+          className="c29 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -8934,7 +9090,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c28 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c29 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -8943,7 +9099,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c28 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -8952,13 +9108,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c28 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c28 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -9125,7 +9281,11 @@ exports[`SnippetEditor highlights a focused field 1`] = `
 .c8 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c10 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -9136,958 +9296,6 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c16 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c11 {
-  font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c13:hover {
-  color: #000;
-}
-
-.c14::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c14:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c15 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c15 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c18 {
-  font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c18:hover,
-.c18:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  margin: 10px 0 0 9px;
-}
-
-.c20 svg {
-  margin-right: 7px;
-}
-
-.c10 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c17 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c19 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<div>
-  <section>
-    <div
-      className="c0"
-      onMouseLeave={undefined}
-      width={640}
-    >
-      <div
-        className="c1"
-      >
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          SEO title preview:
-        </span>
-        <div
-          className="c2"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          <div
-            className="c3 c4"
-          >
-            <span
-              className="c5"
-            >
-              Test title
-            </span>
-          </div>
-        </div>
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Url preview:
-        </span>
-        <div
-          className="c6"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          example.org › test-slug
-        </div>
-      </div>
-      <hr
-        className="c7"
-      />
-      <div
-        className="c1"
-      >
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Meta description preview:
-        </span>
-        <div
-          className="c8 c9"
-          color="#545454"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          Test description, %%replacement_variable%%
-        </div>
-      </div>
-    </div>
-  </section>
-  <div
-    className="c10"
-  >
-    <button
-      aria-pressed={true}
-      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-      onClick={[Function]}
-      type="button"
-    >
-      <svg
-        aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c17"
-        fill="currentColor"
-        focusable="false"
-        role="img"
-        size="22px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-        />
-      </svg>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Mobile preview
-      </span>
-    </button>
-    <button
-      aria-pressed={false}
-      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-      onClick={[Function]}
-      type="button"
-    >
-      <svg
-        aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c19"
-        fill="currentColor"
-        focusable="false"
-        role="img"
-        size="18px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-        />
-      </svg>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Desktop preview
-      </span>
-    </button>
-  </div>
-  <button
-    aria-expanded={false}
-    className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-    onClick={[Function]}
-    type="button"
-  >
-    <svg
-      aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c21"
-      fill={undefined}
-      focusable="false"
-      role="img"
-      size="16px"
-      viewBox="0 0 1792 1792"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-      />
-    </svg>
-    <span>
-      Edit snippet
-    </span>
-  </button>
-</div>
-`;
-
-exports[`SnippetEditor highlights a hovered field 1`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.c6 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-}
-
-.c9 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-}
-
-.c8 {
-  line-height: 1em;
-  max-height: 4em;
-  overflow: hidden;
-}
-
-.c1 {
-  padding: 16px;
-}
-
-.c7 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
-}
-
-.c16 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c11 {
-  font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c13:hover {
-  color: #000;
-}
-
-.c14::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c14:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c15 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c15 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c18 {
-  font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c18:hover,
-.c18:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  margin: 10px 0 0 9px;
-}
-
-.c20 svg {
-  margin-right: 7px;
-}
-
-.c10 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c17 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c19 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<div>
-  <section>
-    <div
-      className="c0"
-      onMouseLeave={undefined}
-      width={640}
-    >
-      <div
-        className="c1"
-      >
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          SEO title preview:
-        </span>
-        <div
-          className="c2"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          <div
-            className="c3 c4"
-          >
-            <span
-              className="c5"
-            >
-              Test title
-            </span>
-          </div>
-        </div>
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Url preview:
-        </span>
-        <div
-          className="c6"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          example.org › test-slug
-        </div>
-      </div>
-      <hr
-        className="c7"
-      />
-      <div
-        className="c1"
-      >
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Meta description preview:
-        </span>
-        <div
-          className="c8 c9"
-          color="#545454"
-          onClick={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-        >
-          Test description, %%replacement_variable%%
-        </div>
-      </div>
-    </div>
-  </section>
-  <div
-    className="c10"
-  >
-    <button
-      aria-pressed={true}
-      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-      onClick={[Function]}
-      type="button"
-    >
-      <svg
-        aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c17"
-        fill="currentColor"
-        focusable="false"
-        role="img"
-        size="22px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-        />
-      </svg>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Mobile preview
-      </span>
-    </button>
-    <button
-      aria-pressed={false}
-      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-      onClick={[Function]}
-      type="button"
-    >
-      <svg
-        aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c19"
-        fill="currentColor"
-        focusable="false"
-        role="img"
-        size="18px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-        />
-      </svg>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Desktop preview
-      </span>
-    </button>
-  </div>
-  <button
-    aria-expanded={false}
-    className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-    onClick={[Function]}
-    type="button"
-  >
-    <svg
-      aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c21"
-      fill={undefined}
-      focusable="false"
-      role="img"
-      size="16px"
-      viewBox="0 0 1792 1792"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-      />
-    </svg>
-    <span>
-      Edit snippet
-    </span>
-  </button>
-</div>
-`;
-
-exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.c7 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-}
-
-.c10 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-}
-
-.c9 {
-  line-height: 1em;
-  max-height: 4em;
-  overflow: hidden;
-}
-
-.c1 {
-  padding: 16px;
-}
-
-.c8 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
-}
-
-.c27 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 5px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c27::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c27::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c27::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c27::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c26 {
-  padding: 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-}
-
-.c26::before {
-  display: block;
-  position: absolute;
-  top: 4px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c28 {
-  padding: 5px;
-  border: 1px solid #5b9dd9;
-  box-shadow: 0 0 2px rgba(30,140,190,.8);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-}
-
-.c28::before {
-  display: block;
-  position: absolute;
-  top: 4px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#1e8cbe%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c24 {
-  margin: 1em 0;
-}
-
-.c23 {
-  padding: 0 20px;
-}
-
-.c25 {
-  cursor: pointer;
 }
 
 .c17 {
@@ -10207,11 +9415,443 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   margin-right: 7px;
 }
 
-.c29 {
+.c11 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c18 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c20 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c22 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c16::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<div>
+  <section>
+    <div
+      className="c0"
+      onMouseLeave={undefined}
+      width={640}
+    >
+      <div
+        className="c1"
+      >
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          SEO title preview:
+        </span>
+        <div
+          className="c2"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          <div
+            className="c3 c4"
+          >
+            <span
+              className="c5"
+            >
+              Test title
+            </span>
+          </div>
+        </div>
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          Url preview:
+        </span>
+        <div
+          className="c6"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          example.org › test-slug
+        </div>
+      </div>
+      <hr
+        className="c7"
+      />
+      <div
+        className="c1"
+      >
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          Meta description preview:
+        </span>
+        <div
+          className="c8 c9"
+          color="#545454"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          <div
+            className="c10 c8 c9"
+            color="#545454"
+          >
+            Test description, %%replacement_variable%%
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <div
+    className="c11"
+  >
+    <button
+      aria-pressed={true}
+      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-mobile c18"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="22px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Mobile preview
+      </span>
+    </button>
+    <button
+      aria-pressed={false}
+      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-desktop c20"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="18px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Desktop preview
+      </span>
+    </button>
+  </div>
+  <button
+    aria-expanded={false}
+    className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      aria-hidden={true}
+      className="yoast-svg-icon yoast-svg-icon-edit c22"
+      fill={undefined}
+      focusable="false"
+      role="img"
+      size="16px"
+      viewBox="0 0 1792 1792"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+      />
+    </svg>
+    <span>
+      Edit snippet
+    </span>
+  </button>
+</div>
+`;
+
+exports[`SnippetEditor highlights a hovered field 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+}
+
+.c9 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+}
+
+.c8 {
+  line-height: 1em;
+  max-height: 4em;
+}
+
+.c10 {
+  overflow: hidden;
+  max-height: calc( 4em + 3px );
+}
+
+.c1 {
+  padding: 16px;
+}
+
+.c7 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c17 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c12 {
+  font-size: 0.8rem;
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c12:hover,
+.c12:focus {
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c13:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c14:hover {
+  color: #000;
+}
+
+.c15::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c15:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c16 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c16 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c19 {
+  font-size: 0.8rem;
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c19:hover,
+.c19:focus {
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c21 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
-  margin-left: 20px;
+  margin: 10px 0 0 9px;
+}
+
+.c21 svg {
+  margin-right: 7px;
 }
 
 .c11 {
@@ -10248,6 +9888,544 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   flex: none;
 }
 
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c16::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<div>
+  <section>
+    <div
+      className="c0"
+      onMouseLeave={undefined}
+      width={640}
+    >
+      <div
+        className="c1"
+      >
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          SEO title preview:
+        </span>
+        <div
+          className="c2"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          <div
+            className="c3 c4"
+          >
+            <span
+              className="c5"
+            >
+              Test title
+            </span>
+          </div>
+        </div>
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          Url preview:
+        </span>
+        <div
+          className="c6"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          example.org › test-slug
+        </div>
+      </div>
+      <hr
+        className="c7"
+      />
+      <div
+        className="c1"
+      >
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          Meta description preview:
+        </span>
+        <div
+          className="c8 c9"
+          color="#545454"
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+        >
+          <div
+            className="c10 c8 c9"
+            color="#545454"
+          >
+            Test description, %%replacement_variable%%
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <div
+    className="c11"
+  >
+    <button
+      aria-pressed={true}
+      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-mobile c18"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="22px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Mobile preview
+      </span>
+    </button>
+    <button
+      aria-pressed={false}
+      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="yoast-svg-icon yoast-svg-icon-desktop c20"
+        fill="currentColor"
+        focusable="false"
+        role="img"
+        size="18px"
+        viewBox="0 0 1792 1792"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+        />
+      </svg>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        Desktop preview
+      </span>
+    </button>
+  </div>
+  <button
+    aria-expanded={false}
+    className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      aria-hidden={true}
+      className="yoast-svg-icon yoast-svg-icon-edit c22"
+      fill={undefined}
+      focusable="false"
+      role="img"
+      size="16px"
+      viewBox="0 0 1792 1792"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+      />
+    </svg>
+    <span>
+      Edit snippet
+    </span>
+  </button>
+</div>
+`;
+
+exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+}
+
+.c10 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+}
+
+.c9 {
+  line-height: 1em;
+  max-height: 4em;
+}
+
+.c11 {
+  overflow: hidden;
+  max-height: calc( 4em + 3px );
+}
+
+.c1 {
+  padding: 16px;
+}
+
+.c8 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c28 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 5px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c28::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c28::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c28::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c28::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c27 {
+  padding: 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+}
+
+.c27::before {
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c29 {
+  padding: 5px;
+  border: 1px solid #5b9dd9;
+  box-shadow: 0 0 2px rgba(30,140,190,.8);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+}
+
+.c29::before {
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#1e8cbe%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c25 {
+  margin: 1em 0;
+}
+
+.c24 {
+  padding: 0 20px;
+}
+
+.c26 {
+  cursor: pointer;
+}
+
+.c18 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c13 {
+  font-size: 0.8rem;
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c13:hover,
+.c13:focus {
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c14:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c15:hover {
+  color: #000;
+}
+
+.c16::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c16:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c17 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c17 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c20 {
+  font-size: 0.8rem;
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c20:hover,
+.c20:focus {
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c22 {
+  font-size: 0.8rem;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  margin: 10px 0 0 9px;
+}
+
+.c22 svg {
+  margin-right: 7px;
+}
+
+.c30 {
+  font-size: 0.8rem;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  margin-left: 20px;
+}
+
+.c12 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c19 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c21 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 .c6::before {
   display: block;
   position: absolute;
@@ -10255,13 +10433,13 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
   left: -40px;
   width: 24px;
   height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#555%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#555%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E );
   background-size: 25px;
   content: "";
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c16::after {
+  .c17::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -10506,7 +10684,6 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
                 <SnippetPreview__MobileDescription
-                  innerRef={[Function]}
                   isDescriptionGenerated={false}
                   onClick={[Function]}
                   onMouseLeave={[Function]}
@@ -10514,7 +10691,6 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                 >
                   <SnippetPreview__DesktopDescription
                     className="c9"
-                    innerRef={[Function]}
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
@@ -10527,7 +10703,26 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      Test description, %%replacement_variable%%
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c11"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c11 c9"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c11 c9 c10"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
                     </div>
                   </SnippetPreview__DesktopDescription>
                 </SnippetPreview__MobileDescription>
@@ -10543,7 +10738,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c11"
+          className="c12"
         >
           <Button
             aria-pressed={true}
@@ -10555,7 +10750,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c12"
+              className="c13"
               isActive={true}
               onClick={[Function]}
               textColor="#555"
@@ -10566,7 +10761,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c12 Button-kDSBcD c13"
+                className="c13 Button-kDSBcD c14"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -10577,7 +10772,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                  className="c13 Button-kDSBcD c14 Button-kDSBcD c15"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -10588,7 +10783,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                    className="c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -10599,7 +10794,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                      className="c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -10607,7 +10802,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                     >
                       <button
                         aria-pressed={true}
-                        className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                        className="c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                         onClick={[Function]}
                         type="button"
                       >
@@ -10628,7 +10823,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c18"
+                              className="yoast-svg-icon yoast-svg-icon-mobile c19"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -10686,7 +10881,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c19"
+              className="c20"
               isActive={false}
               onClick={[Function]}
               textColor="#555"
@@ -10697,7 +10892,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c19 Button-kDSBcD c13"
+                className="c20 Button-kDSBcD c14"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -10708,7 +10903,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c19 Button-kDSBcD c13 Button-kDSBcD c14"
+                  className="c20 Button-kDSBcD c14 Button-kDSBcD c15"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -10719,7 +10914,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                    className="c20 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -10730,7 +10925,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                      className="c20 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -10738,7 +10933,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                     >
                       <button
                         aria-pressed={false}
-                        className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                        className="c20 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                         onClick={[Function]}
                         type="button"
                       >
@@ -10759,7 +10954,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c20"
+                              className="yoast-svg-icon yoast-svg-icon-desktop c21"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -10820,7 +11015,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c21"
+        className="c22"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -10831,7 +11026,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c21 Button-kDSBcD c13"
+          className="c22 Button-kDSBcD c14"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -10842,7 +11037,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
+            className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -10853,7 +11048,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+              className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -10864,7 +11059,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -10872,7 +11067,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
               >
                 <button
                   aria-expanded={true}
-                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                   onClick={[Function]}
                   type="button"
                 >
@@ -10891,7 +11086,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c22"
+                        className="yoast-svg-icon yoast-svg-icon-edit c23"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -11003,18 +11198,18 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c23"
+            className="c24"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c24"
+                className="c25"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-4-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                     id="snippet-editor-field-4-title"
                     onClick={[Function]}
                   >
@@ -11026,7 +11221,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                   isHovered={false}
                 >
                   <div
-                    className="c26"
+                    className="c27"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-4-title"
@@ -11049,7 +11244,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                 >
                   <progress
                     aria-hidden="true"
-                    className="c27"
+                    className="c28"
                     max={600}
                     value={0}
                   />
@@ -11058,14 +11253,14 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c24"
+                className="c25"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-4-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                     id="snippet-editor-field-4-slug"
                     onClick={[Function]}
                   >
@@ -11077,7 +11272,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                   isHovered={false}
                 >
                   <div
-                    className="c28"
+                    className="c29"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-4-slug"
@@ -11094,14 +11289,14 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c24"
+                className="c25"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-4-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                     id="snippet-editor-field-4-description"
                     onClick={[Function]}
                   >
@@ -11113,7 +11308,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                   isHovered={false}
                 >
                   <div
-                    className="c26"
+                    className="c27"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-4-description"
@@ -11136,7 +11331,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                 >
                   <progress
                     aria-hidden="true"
-                    className="c27"
+                    className="c28"
                     max={320}
                     value={0}
                   />
@@ -11154,7 +11349,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c29"
+        className="c30"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -11163,7 +11358,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c29 Button-kDSBcD c13"
+          className="c30 Button-kDSBcD c14"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -11172,7 +11367,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c29 Button-kDSBcD c13 Button-kDSBcD c14"
+            className="c30 Button-kDSBcD c14 Button-kDSBcD c15"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -11181,7 +11376,7 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+              className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -11190,13 +11385,13 @@ exports[`SnippetEditor highlights the active field when calling setFieldFocus 1`
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+                  className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                   onClick={[Function]}
                   type="button"
                 >
@@ -11282,7 +11477,11 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 .c9 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c11 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -11295,7 +11494,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   margin: 0;
 }
 
-.c27 {
+.c28 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -11308,26 +11507,26 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   border: 1px solid #ddd;
 }
 
-.c27::-webkit-progress-bar {
+.c28::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c27::-webkit-progress-value {
+.c28::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c27::-moz-progress-bar {
+.c28::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c27::-ms-fill {
+.c28::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
 
-.c26 {
+.c27 {
   padding: 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -11339,7 +11538,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   position: relative;
 }
 
-.c26::before {
+.c27::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -11351,7 +11550,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   content: "";
 }
 
-.c28 {
+.c29 {
   padding: 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -11363,7 +11562,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   position: relative;
 }
 
-.c28::before {
+.c29::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -11375,26 +11574,26 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   content: "";
 }
 
-.c24 {
+.c25 {
   margin: 1em 0;
 }
 
-.c23 {
+.c24 {
   padding: 0 20px;
 }
 
-.c25 {
+.c26 {
   cursor: pointer;
 }
 
-.c17 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c12 {
+.c13 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -11409,33 +11608,33 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   border-radius: 3px 0 0 3px;
 }
 
-.c12:hover,
-.c12:focus {
+.c13:hover,
+.c13:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c13:active {
+.c14:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c14:hover {
+.c15:hover {
   color: #000;
 }
 
-.c15::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c15:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c16 {
+.c17 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -11464,13 +11663,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   min-height: 32px;
 }
 
-.c16 svg {
+.c17 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c19 {
+.c20 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -11485,33 +11684,33 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   border-radius: 0 3px 3px 0;
 }
 
-.c19:hover,
-.c19:focus {
+.c20:hover,
+.c20:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c21 {
+.c22 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin: 10px 0 0 9px;
 }
 
-.c21 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c29 {
+.c30 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin-left: 20px;
 }
 
-.c11 {
+.c12 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -11521,7 +11720,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   vertical-align: top;
 }
 
-.c18 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -11529,7 +11728,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   flex: none;
 }
 
-.c20 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -11537,7 +11736,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   flex: none;
 }
 
-.c22 {
+.c23 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -11552,13 +11751,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   left: -40px;
   width: 24px;
   height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#ccc%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#ccc%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E );
   background-size: 25px;
   content: "";
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c16::after {
+  .c17::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -11796,7 +11995,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
                 <SnippetPreview
-                  innerRef={[Function]}
                   isDescriptionGenerated={false}
                   onClick={[Function]}
                   onMouseLeave={[Function]}
@@ -11804,7 +12002,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 >
                   <SnippetPreview__MobileDescription
                     className="c8"
-                    innerRef={[Function]}
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
@@ -11812,7 +12009,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                   >
                     <SnippetPreview__DesktopDescription
                       className="c8 c9"
-                      innerRef={[Function]}
                       isDescriptionGenerated={false}
                       onClick={[Function]}
                       onMouseLeave={[Function]}
@@ -11825,11 +12021,1305 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                         onMouseLeave={[Function]}
                         onMouseOver={[Function]}
                       >
-                        Test description, %%replacement_variable%%
+                        <SnippetPreview__MobileDescriptionOverflowContainer
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__MobileDescription
+                            className="c11"
+                            innerRef={[Function]}
+                          >
+                            <SnippetPreview__DesktopDescription
+                              className="c11 c9"
+                              innerRef={[Function]}
+                            >
+                              <div
+                                className="c11 c9 c10"
+                                color="#545454"
+                              >
+                                Test description, %%replacement_variable%%
+                              </div>
+                            </SnippetPreview__DesktopDescription>
+                          </SnippetPreview__MobileDescription>
+                        </SnippetPreview__MobileDescriptionOverflowContainer>
                       </div>
                     </SnippetPreview__DesktopDescription>
                   </SnippetPreview__MobileDescription>
                 </SnippetPreview>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+          </div>
+        </SnippetPreview__MobileContainer>
+      </section>
+    </SnippetPreview>
+    <ModeSwitcher
+      active="mobile"
+      onChange={[Function]}
+    >
+      <ModeSwitcher__Switcher>
+        <div
+          className="c12"
+        >
+          <Button
+            aria-pressed={true}
+            isActive={true}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={true}
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c13"
+              isActive={true}
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button
+                aria-pressed={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c13 Button-kDSBcD c14"
+                isActive={true}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={true}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                  isActive={true}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={true}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                    isActive={true}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button__BaseButton
+                      aria-pressed={true}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                      isActive={true}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <button
+                        aria-pressed={true}
+                        className="c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <SvgIcon
+                          color="currentColor"
+                          icon="mobile"
+                          size="22px"
+                        >
+                          <SvgIcon__StyledSvg
+                            aria-hidden={true}
+                            className="yoast-svg-icon yoast-svg-icon-mobile"
+                            fill="currentColor"
+                            focusable="false"
+                            role="img"
+                            size="22px"
+                            viewBox="0 0 1792 1792"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-mobile c19"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="22px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                              />
+                            </svg>
+                          </SvgIcon__StyledSvg>
+                        </SvgIcon>
+                        <FormattedScreenReaderMessage
+                          defaultMessage="Mobile preview"
+                          id="snippetEditor.desktopPreview"
+                        >
+                          <FormattedMessage
+                            defaultMessage="Mobile preview"
+                            id="snippetEditor.desktopPreview"
+                            values={Object {}}
+                          >
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
+                                }
+                              >
+                                Mobile preview
+                              </span>
+                            </ScreenReaderText>
+                          </FormattedMessage>
+                        </FormattedScreenReaderMessage>
+                      </button>
+                    </Button__BaseButton>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </Button>
+          <Button
+            aria-pressed={false}
+            isActive={false}
+            onClick={[Function]}
+          >
+            <Button
+              aria-pressed={false}
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c20"
+              isActive={false}
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button
+                aria-pressed={false}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c20 Button-kDSBcD c14"
+                isActive={false}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <Button
+                  aria-pressed={false}
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c20 Button-kDSBcD c14 Button-kDSBcD c15"
+                  isActive={false}
+                  onClick={[Function]}
+                  textColor="#555"
+                  type="button"
+                >
+                  <Button
+                    aria-pressed={false}
+                    backgroundColor="#f7f7f7"
+                    borderColor="#ccc"
+                    boxShadowColor="#ccc"
+                    className="c20 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+                    isActive={false}
+                    onClick={[Function]}
+                    textColor="#555"
+                    type="button"
+                  >
+                    <Button__BaseButton
+                      aria-pressed={false}
+                      backgroundColor="#f7f7f7"
+                      borderColor="#ccc"
+                      boxShadowColor="#ccc"
+                      className="c20 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                      isActive={false}
+                      onClick={[Function]}
+                      textColor="#555"
+                      type="button"
+                    >
+                      <button
+                        aria-pressed={false}
+                        className="c20 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <SvgIcon
+                          color="currentColor"
+                          icon="desktop"
+                          size="18px"
+                        >
+                          <SvgIcon__StyledSvg
+                            aria-hidden={true}
+                            className="yoast-svg-icon yoast-svg-icon-desktop"
+                            fill="currentColor"
+                            focusable="false"
+                            role="img"
+                            size="18px"
+                            viewBox="0 0 1792 1792"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="yoast-svg-icon yoast-svg-icon-desktop c21"
+                              fill="currentColor"
+                              focusable="false"
+                              role="img"
+                              size="18px"
+                              viewBox="0 0 1792 1792"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                              />
+                            </svg>
+                          </SvgIcon__StyledSvg>
+                        </SvgIcon>
+                        <FormattedScreenReaderMessage
+                          defaultMessage="Desktop preview"
+                          id="snippetEditor.desktopPreview"
+                        >
+                          <FormattedMessage
+                            defaultMessage="Desktop preview"
+                            id="snippetEditor.desktopPreview"
+                            values={Object {}}
+                          >
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
+                                }
+                              >
+                                Desktop preview
+                              </span>
+                            </ScreenReaderText>
+                          </FormattedMessage>
+                        </FormattedScreenReaderMessage>
+                      </button>
+                    </Button__BaseButton>
+                  </Button>
+                </Button>
+              </Button>
+            </Button>
+          </Button>
+        </div>
+      </ModeSwitcher__Switcher>
+    </ModeSwitcher>
+    <Button
+      aria-expanded={true}
+      innerRef={[Function]}
+      onClick={[Function]}
+    >
+      <Button
+        aria-expanded={true}
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c22"
+        innerRef={[Function]}
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          aria-expanded={true}
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c22 Button-kDSBcD c14"
+          innerRef={[Function]}
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            aria-expanded={true}
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
+            innerRef={[Function]}
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              aria-expanded={true}
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+              innerRef={[Function]}
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                aria-expanded={true}
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                innerRef={[Function]}
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  aria-expanded={true}
+                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <SvgIcon
+                    icon="edit"
+                    size="16px"
+                  >
+                    <SvgIcon__StyledSvg
+                      aria-hidden={true}
+                      className="yoast-svg-icon yoast-svg-icon-edit"
+                      focusable="false"
+                      role="img"
+                      size="16px"
+                      viewBox="0 0 1792 1792"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="yoast-svg-icon yoast-svg-icon-edit c23"
+                        focusable="false"
+                        role="img"
+                        size="16px"
+                        viewBox="0 0 1792 1792"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                        />
+                      </svg>
+                    </SvgIcon__StyledSvg>
+                  </SvgIcon>
+                  <FormattedMessage
+                    defaultMessage="Edit snippet"
+                    id="snippetEditor.editSnippet"
+                    values={Object {}}
+                  >
+                    <span>
+                      Edit snippet
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+    <InjectIntl(SnippetEditorFields)
+      activeField={null}
+      data={
+        Object {
+          "description": "Test description, %%replacement_variable%%",
+          "slug": "test-slug",
+          "title": "Test title",
+        }
+      }
+      descriptionLengthAssessment={
+        Object {
+          "actual": 0,
+          "max": 320,
+          "score": 0,
+        }
+      }
+      hoveredField="description"
+      onChange={[Function]}
+      onFocus={[Function]}
+      replacementVariables={Array []}
+      titleLengthAssessment={
+        Object {
+          "actual": 0,
+          "max": 600,
+          "score": 0,
+        }
+      }
+    >
+      <SnippetEditorFields
+        activeField={null}
+        data={
+          Object {
+            "description": "Test description, %%replacement_variable%%",
+            "slug": "test-slug",
+            "title": "Test title",
+          }
+        }
+        descriptionLengthAssessment={
+          Object {
+            "actual": 0,
+            "max": 320,
+            "score": 0,
+          }
+        }
+        hoveredField="description"
+        intl={
+          Object {
+            "defaultFormats": Object {},
+            "defaultLocale": "en",
+            "formatDate": [Function],
+            "formatHTMLMessage": [Function],
+            "formatMessage": [Function],
+            "formatNumber": [Function],
+            "formatPlural": [Function],
+            "formatRelative": [Function],
+            "formatTime": [Function],
+            "formats": Object {},
+            "formatters": Object {
+              "getDateTimeFormat": [Function],
+              "getMessageFormat": [Function],
+              "getNumberFormat": [Function],
+              "getPluralFormat": [Function],
+              "getRelativeFormat": [Function],
+            },
+            "locale": "en",
+            "messages": Object {},
+            "now": [Function],
+            "textComponent": "span",
+          }
+        }
+        onChange={[Function]}
+        onFocus={[Function]}
+        replacementVariables={Array []}
+        titleLengthAssessment={
+          Object {
+            "actual": 0,
+            "max": 600,
+            "score": 0,
+          }
+        }
+      >
+        <SnippetEditorFields__StyledEditor>
+          <section
+            className="c24"
+          >
+            <SnippetEditorFields__FormSection>
+              <div
+                className="c25"
+              >
+                <SnippetEditorFields__SimulatedLabel
+                  id="snippet-editor-field-3-title"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="c26"
+                    id="snippet-editor-field-3-title"
+                    onClick={[Function]}
+                  >
+                    SEO title
+                  </div>
+                </SnippetEditorFields__SimulatedLabel>
+                <SnippetEditorFields__InputContainer
+                  isActive={false}
+                  isHovered={false}
+                >
+                  <div
+                    className="c27"
+                  >
+                    <ReplacementVariableEditor
+                      ariaLabelledBy="snippet-editor-field-3-title"
+                      content="Test title"
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      replacementVariables={Array []}
+                    >
+                      <div />
+                    </ReplacementVariableEditor>
+                  </div>
+                </SnippetEditorFields__InputContainer>
+                <ProgressBar
+                  aria-hidden="true"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
+                  max={600}
+                  progressColor="#dc3232"
+                  value={0}
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c28"
+                    max={600}
+                    value={0}
+                  />
+                </ProgressBar>
+              </div>
+            </SnippetEditorFields__FormSection>
+            <SnippetEditorFields__FormSection>
+              <div
+                className="c25"
+              >
+                <SnippetEditorFields__SimulatedLabel
+                  id="snippet-editor-field-3-slug"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="c26"
+                    id="snippet-editor-field-3-slug"
+                    onClick={[Function]}
+                  >
+                    Slug
+                  </div>
+                </SnippetEditorFields__SimulatedLabel>
+                <SnippetEditorFields__InputContainer
+                  isActive={false}
+                  isHovered={false}
+                >
+                  <div
+                    className="c27"
+                  >
+                    <ReplacementVariableEditor
+                      ariaLabelledBy="snippet-editor-field-3-slug"
+                      content="test-slug"
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      replacementVariables={Array []}
+                    >
+                      <div />
+                    </ReplacementVariableEditor>
+                  </div>
+                </SnippetEditorFields__InputContainer>
+              </div>
+            </SnippetEditorFields__FormSection>
+            <SnippetEditorFields__FormSection>
+              <div
+                className="c25"
+              >
+                <SnippetEditorFields__SimulatedLabel
+                  id="snippet-editor-field-3-description"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="c26"
+                    id="snippet-editor-field-3-description"
+                    onClick={[Function]}
+                  >
+                    Meta description
+                  </div>
+                </SnippetEditorFields__SimulatedLabel>
+                <SnippetEditorFields__InputContainer
+                  isActive={false}
+                  isHovered={true}
+                >
+                  <div
+                    className="c29"
+                  >
+                    <ReplacementVariableEditor
+                      ariaLabelledBy="snippet-editor-field-3-description"
+                      content="Test description, %%replacement_variable%%"
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      replacementVariables={Array []}
+                    >
+                      <div />
+                    </ReplacementVariableEditor>
+                  </div>
+                </SnippetEditorFields__InputContainer>
+                <ProgressBar
+                  aria-hidden="true"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
+                  max={320}
+                  progressColor="#dc3232"
+                  value={0}
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c28"
+                    max={320}
+                    value={0}
+                  />
+                </ProgressBar>
+              </div>
+            </SnippetEditorFields__FormSection>
+          </section>
+        </SnippetEditorFields__StyledEditor>
+      </SnippetEditorFields>
+    </InjectIntl(SnippetEditorFields)>
+    <Button
+      onClick={[Function]}
+    >
+      <Button
+        backgroundColor="#f7f7f7"
+        borderColor="#ccc"
+        boxShadowColor="#ccc"
+        className="c30"
+        onClick={[Function]}
+        textColor="#555"
+        type="button"
+      >
+        <Button
+          backgroundColor="#f7f7f7"
+          borderColor="#ccc"
+          boxShadowColor="#ccc"
+          className="c30 Button-kDSBcD c14"
+          onClick={[Function]}
+          textColor="#555"
+          type="button"
+        >
+          <Button
+            backgroundColor="#f7f7f7"
+            borderColor="#ccc"
+            boxShadowColor="#ccc"
+            className="c30 Button-kDSBcD c14 Button-kDSBcD c15"
+            onClick={[Function]}
+            textColor="#555"
+            type="button"
+          >
+            <Button
+              backgroundColor="#f7f7f7"
+              borderColor="#ccc"
+              boxShadowColor="#ccc"
+              className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
+              onClick={[Function]}
+              textColor="#555"
+              type="button"
+            >
+              <Button__BaseButton
+                backgroundColor="#f7f7f7"
+                borderColor="#ccc"
+                boxShadowColor="#ccc"
+                className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
+                onClick={[Function]}
+                textColor="#555"
+                type="button"
+              >
+                <button
+                  className="c30 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <FormattedMessage
+                    defaultMessage="Close snippet editor"
+                    id="snippet-editor.close-editor"
+                    values={Object {}}
+                  >
+                    <span>
+                      Close snippet editor
+                    </span>
+                  </FormattedMessage>
+                </button>
+              </Button__BaseButton>
+            </Button>
+          </Button>
+        </Button>
+      </Button>
+    </Button>
+  </div>
+</SnippetEditor>
+`;
+
+exports[`SnippetEditor opens when calling open() 1`] = `
+.c0 {
+  border-bottom: 1px hidden #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin: 0 20px 10px;
+  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
+  max-width: 600px;
+  box-sizing: border-box;
+}
+
+.c2 {
+  cursor: pointer;
+  position: relative;
+}
+
+.c4 {
+  color: #1e0fbe;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: normal;
+  margin: 0;
+  display: inline-block;
+  overflow: hidden;
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c3 {
+  max-width: 600px;
+  vertical-align: top;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c6 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+}
+
+.c9 {
+  color: #545454;
+  cursor: pointer;
+  position: relative;
+  max-width: 600px;
+}
+
+.c8 {
+  line-height: 1em;
+  max-height: 4em;
+}
+
+.c10 {
+  overflow: hidden;
+  max-height: calc( 4em + 3px );
+}
+
+.c1 {
+  padding: 16px;
+}
+
+.c7 {
+  border: 0;
+  border-bottom: 1px solid #DFE1E5;
+  margin: 0;
+}
+
+.c27 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 5px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c27::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c27::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c27::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c27::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c26 {
+  padding: 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+}
+
+.c26::before {
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c24 {
+  margin: 1em 0;
+}
+
+.c23 {
+  padding: 0 20px;
+}
+
+.c25 {
+  cursor: pointer;
+}
+
+.c17 {
+  color: #555;
+  border-color: #ccc;
+  background: #f7f7f7;
+  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
+}
+
+.c12 {
+  font-size: 0.8rem;
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: #555;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 3px 0 0 3px;
+}
+
+.c12:hover,
+.c12:focus {
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c13:active {
+  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
+}
+
+.c14:hover {
+  color: #000;
+}
+
+.c15::-moz-focus-inner {
+  border-width: 0;
+}
+
+.c15:focus {
+  outline: none;
+  border-color: #0066cd;
+  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
+}
+
+.c16 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  vertical-align: middle;
+  border-width: 1px;
+  border-style: solid;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+  overflow: visible;
+  min-height: 32px;
+}
+
+.c16 svg {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c19 {
+  font-size: 0.8rem;
+  border: none;
+  border-bottom: 4px solid transparent;
+  width: 31px;
+  height: 31px;
+  border-color: transparent;
+  color: #555;
+  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
+  -webkit-transition-property: border-color;
+  transition-property: border-color;
+  border-radius: 0 3px 3px 0;
+}
+
+.c19:hover,
+.c19:focus {
+  border: none;
+  border-bottom: 4px solid transparent;
+  border-color: #1e8cbe;
+  color: #1e8cbe;
+}
+
+.c21 {
+  font-size: 0.8rem;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  margin: 10px 0 0 9px;
+}
+
+.c21 svg {
+  margin-right: 7px;
+}
+
+.c28 {
+  font-size: 0.8rem;
+  border: 1px solid #dbdbdb;
+  box-shadow: none;
+  margin-left: 20px;
+}
+
+.c11 {
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 20px;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  vertical-align: top;
+}
+
+.c18 {
+  width: 22px;
+  height: 22px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c20 {
+  width: 18px;
+  height: 18px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c22 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+  .c16::after {
+    display: inline-block;
+    content: "";
+    min-height: 22px;
+  }
+}
+
+<SnippetEditor
+  baseUrl="https://example.org/"
+  data={
+    Object {
+      "description": "Test description, %%replacement_variable%%",
+      "slug": "test-slug",
+      "title": "Test title",
+    }
+  }
+  date=""
+  descriptionLengthAssessment={
+    Object {
+      "actual": 0,
+      "max": 320,
+      "score": 0,
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "textComponent": "span",
+    }
+  }
+  mapDataToPreview={null}
+  mode="mobile"
+  onChange={[Function]}
+  replacementVariables={Array []}
+  titleLengthAssessment={
+    Object {
+      "actual": 0,
+      "max": 600,
+      "score": 0,
+    }
+  }
+>
+  <div>
+    <SnippetPreview
+      activeField={null}
+      breadcrumbs={null}
+      date=""
+      description="Test description, %%replacement_variable%%"
+      hoveredField={null}
+      isAmp={false}
+      isDescriptionGenerated={false}
+      keyword=""
+      locale="en_US"
+      mode="mobile"
+      onClick={[Function]}
+      onHover={[Function]}
+      onMouseLeave={[Function]}
+      onMouseOver={[Function]}
+      title="Test title"
+      url="example.org/test-slug"
+    >
+      <section>
+        <SnippetPreview__MobileContainer
+          padding={20}
+          width={640}
+        >
+          <div
+            className="c0"
+            width={640}
+          >
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="SEO title preview"
+                  id="snippetPreview.seoTitlePreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="SEO title preview"
+                    id="snippetPreview.seoTitlePreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        SEO title preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseTitle
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <div
+                    className="c2"
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <SnippetPreview__TitleBounded>
+                      <SnippetPreview__Title
+                        className="c3"
+                      >
+                        <div
+                          className="c3 c4"
+                        >
+                          <SnippetPreview__TitleUnboundedMobile
+                            innerRef={[Function]}
+                          >
+                            <span
+                              className="c5"
+                            >
+                              Test title
+                            </span>
+                          </SnippetPreview__TitleUnboundedMobile>
+                        </div>
+                      </SnippetPreview__Title>
+                    </SnippetPreview__TitleBounded>
+                  </div>
+                </SnippetPreview__BaseTitle>
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Url preview"
+                  id="snippetPreview.urlPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Url preview"
+                    id="snippetPreview.urlPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Url preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__BaseUrl
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <div
+                    className="c6"
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    example.org › test-slug
+                  </div>
+                </SnippetPreview__BaseUrl>
+              </div>
+            </SnippetPreview__MobilePartContainer>
+            <SnippetPreview__Separator>
+              <hr
+                className="c7"
+              />
+            </SnippetPreview__Separator>
+            <SnippetPreview__MobilePartContainer>
+              <div
+                className="c1"
+              >
+                <FormattedScreenReaderMessage
+                  after=":"
+                  defaultMessage="Meta description preview"
+                  id="snippetPreview.metaDescriptionPreview"
+                >
+                  <FormattedMessage
+                    after=":"
+                    defaultMessage="Meta description preview"
+                    id="snippetPreview.metaDescriptionPreview"
+                    values={Object {}}
+                  >
+                    <ScreenReaderText>
+                      <span
+                        className="screen-reader-text"
+                        style={
+                          Object {
+                            "clip": "rect(1px, 1px, 1px, 1px)",
+                            "height": "1px",
+                            "overflow": "hidden",
+                            "position": "absolute",
+                            "width": "1px",
+                          }
+                        }
+                      >
+                        Meta description preview:
+                      </span>
+                    </ScreenReaderText>
+                  </FormattedMessage>
+                </FormattedScreenReaderMessage>
+                <SnippetPreview__MobileDescription
+                  isDescriptionGenerated={false}
+                  onClick={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <SnippetPreview__DesktopDescription
+                    className="c8"
+                    isDescriptionGenerated={false}
+                    onClick={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    <div
+                      className="c8 c9"
+                      color="#545454"
+                      onClick={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                    >
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c10"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c10 c8"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c10 c8 c9"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
+                    </div>
+                  </SnippetPreview__DesktopDescription>
+                </SnippetPreview__MobileDescription>
               </div>
             </SnippetPreview__MobilePartContainer>
           </div>
@@ -12235,1260 +13725,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
           "score": 0,
         }
       }
-      hoveredField="description"
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthAssessment={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 0,
-        }
-      }
-    >
-      <SnippetEditorFields
-        activeField={null}
-        data={
-          Object {
-            "description": "Test description, %%replacement_variable%%",
-            "slug": "test-slug",
-            "title": "Test title",
-          }
-        }
-        descriptionLengthAssessment={
-          Object {
-            "actual": 0,
-            "max": 320,
-            "score": 0,
-          }
-        }
-        hoveredField="description"
-        intl={
-          Object {
-            "defaultFormats": Object {},
-            "defaultLocale": "en",
-            "formatDate": [Function],
-            "formatHTMLMessage": [Function],
-            "formatMessage": [Function],
-            "formatNumber": [Function],
-            "formatPlural": [Function],
-            "formatRelative": [Function],
-            "formatTime": [Function],
-            "formats": Object {},
-            "formatters": Object {
-              "getDateTimeFormat": [Function],
-              "getMessageFormat": [Function],
-              "getNumberFormat": [Function],
-              "getPluralFormat": [Function],
-              "getRelativeFormat": [Function],
-            },
-            "locale": "en",
-            "messages": Object {},
-            "now": [Function],
-            "textComponent": "span",
-          }
-        }
-        onChange={[Function]}
-        onFocus={[Function]}
-        replacementVariables={Array []}
-        titleLengthAssessment={
-          Object {
-            "actual": 0,
-            "max": 600,
-            "score": 0,
-          }
-        }
-      >
-        <SnippetEditorFields__StyledEditor>
-          <section
-            className="c23"
-          >
-            <SnippetEditorFields__FormSection>
-              <div
-                className="c24"
-              >
-                <SnippetEditorFields__SimulatedLabel
-                  id="snippet-editor-field-3-title"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="c25"
-                    id="snippet-editor-field-3-title"
-                    onClick={[Function]}
-                  >
-                    SEO title
-                  </div>
-                </SnippetEditorFields__SimulatedLabel>
-                <SnippetEditorFields__InputContainer
-                  isActive={false}
-                  isHovered={false}
-                >
-                  <div
-                    className="c26"
-                  >
-                    <ReplacementVariableEditor
-                      ariaLabelledBy="snippet-editor-field-3-title"
-                      content="Test title"
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      replacementVariables={Array []}
-                    >
-                      <div />
-                    </ReplacementVariableEditor>
-                  </div>
-                </SnippetEditorFields__InputContainer>
-                <ProgressBar
-                  aria-hidden="true"
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ddd"
-                  max={600}
-                  progressColor="#dc3232"
-                  value={0}
-                >
-                  <progress
-                    aria-hidden="true"
-                    className="c27"
-                    max={600}
-                    value={0}
-                  />
-                </ProgressBar>
-              </div>
-            </SnippetEditorFields__FormSection>
-            <SnippetEditorFields__FormSection>
-              <div
-                className="c24"
-              >
-                <SnippetEditorFields__SimulatedLabel
-                  id="snippet-editor-field-3-slug"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="c25"
-                    id="snippet-editor-field-3-slug"
-                    onClick={[Function]}
-                  >
-                    Slug
-                  </div>
-                </SnippetEditorFields__SimulatedLabel>
-                <SnippetEditorFields__InputContainer
-                  isActive={false}
-                  isHovered={false}
-                >
-                  <div
-                    className="c26"
-                  >
-                    <ReplacementVariableEditor
-                      ariaLabelledBy="snippet-editor-field-3-slug"
-                      content="test-slug"
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      replacementVariables={Array []}
-                    >
-                      <div />
-                    </ReplacementVariableEditor>
-                  </div>
-                </SnippetEditorFields__InputContainer>
-              </div>
-            </SnippetEditorFields__FormSection>
-            <SnippetEditorFields__FormSection>
-              <div
-                className="c24"
-              >
-                <SnippetEditorFields__SimulatedLabel
-                  id="snippet-editor-field-3-description"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="c25"
-                    id="snippet-editor-field-3-description"
-                    onClick={[Function]}
-                  >
-                    Meta description
-                  </div>
-                </SnippetEditorFields__SimulatedLabel>
-                <SnippetEditorFields__InputContainer
-                  isActive={false}
-                  isHovered={true}
-                >
-                  <div
-                    className="c28"
-                  >
-                    <ReplacementVariableEditor
-                      ariaLabelledBy="snippet-editor-field-3-description"
-                      content="Test description, %%replacement_variable%%"
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      replacementVariables={Array []}
-                    >
-                      <div />
-                    </ReplacementVariableEditor>
-                  </div>
-                </SnippetEditorFields__InputContainer>
-                <ProgressBar
-                  aria-hidden="true"
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ddd"
-                  max={320}
-                  progressColor="#dc3232"
-                  value={0}
-                >
-                  <progress
-                    aria-hidden="true"
-                    className="c27"
-                    max={320}
-                    value={0}
-                  />
-                </ProgressBar>
-              </div>
-            </SnippetEditorFields__FormSection>
-          </section>
-        </SnippetEditorFields__StyledEditor>
-      </SnippetEditorFields>
-    </InjectIntl(SnippetEditorFields)>
-    <Button
-      onClick={[Function]}
-    >
-      <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c29"
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c29 Button-kDSBcD c13"
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c29 Button-kDSBcD c13 Button-kDSBcD c14"
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  className="c29 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <FormattedMessage
-                    defaultMessage="Close snippet editor"
-                    id="snippet-editor.close-editor"
-                    values={Object {}}
-                  >
-                    <span>
-                      Close snippet editor
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-  </div>
-</SnippetEditor>
-`;
-
-exports[`SnippetEditor opens when calling open() 1`] = `
-.c0 {
-  border-bottom: 1px hidden #fff;
-  border-radius: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
-  font-family: Roboto-Regular,HelveticaNeue,Arial,sans-serif;
-  max-width: 600px;
-  box-sizing: border-box;
-}
-
-.c2 {
-  cursor: pointer;
-  position: relative;
-}
-
-.c4 {
-  color: #1e0fbe;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: normal;
-  margin: 0;
-  display: inline-block;
-  overflow: hidden;
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c3 {
-  max-width: 600px;
-  vertical-align: top;
-  text-overflow: ellipsis;
-}
-
-.c5 {
-  display: inline-block;
-  line-height: 1.2em;
-  max-height: 2.4em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.c6 {
-  display: inline-block;
-  color: #006621;
-  cursor: pointer;
-  position: relative;
-}
-
-.c9 {
-  color: #545454;
-  cursor: pointer;
-  position: relative;
-  max-width: 600px;
-}
-
-.c8 {
-  line-height: 1em;
-  max-height: 4em;
-  overflow: hidden;
-}
-
-.c1 {
-  padding: 16px;
-}
-
-.c7 {
-  border: 0;
-  border-bottom: 1px solid #DFE1E5;
-  margin: 0;
-}
-
-.c26 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 5px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c26::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c26::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c26::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c26::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c25 {
-  padding: 5px;
-  border: 1px solid #ddd;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-}
-
-.c25::before {
-  display: block;
-  position: absolute;
-  top: 4px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22transparent%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c23 {
-  margin: 1em 0;
-}
-
-.c22 {
-  padding: 0 20px;
-}
-
-.c24 {
-  cursor: pointer;
-}
-
-.c16 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c11 {
-  font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: #555;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 3px 0 0 3px;
-}
-
-.c11:hover,
-.c11:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c12:active {
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c13:hover {
-  color: #000;
-}
-
-.c14::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c14:focus {
-  outline: none;
-  border-color: #0066cd;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c15 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c15 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c18 {
-  font-size: 0.8rem;
-  border: none;
-  border-bottom: 4px solid transparent;
-  width: 31px;
-  height: 31px;
-  border-color: transparent;
-  color: #555;
-  -webkit-transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  transition: 0.15s color ease-in-out,0.15s background-color ease-in-out,0.15s border-color ease-in-out;
-  -webkit-transition-property: border-color;
-  transition-property: border-color;
-  border-radius: 0 3px 3px 0;
-}
-
-.c18:hover,
-.c18:focus {
-  border: none;
-  border-bottom: 4px solid transparent;
-  border-color: #1e8cbe;
-  color: #1e8cbe;
-}
-
-.c20 {
-  font-size: 0.8rem;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  margin: 10px 0 0 9px;
-}
-
-.c20 svg {
-  margin-right: 7px;
-}
-
-.c27 {
-  font-size: 0.8rem;
-  border: 1px solid #dbdbdb;
-  box-shadow: none;
-  margin-left: 20px;
-}
-
-.c10 {
-  display: inline-block;
-  margin-top: 10px;
-  margin-left: 20px;
-  border: 1px solid #dbdbdb;
-  border-radius: 4px;
-  background-color: #f7f7f7;
-  vertical-align: top;
-}
-
-.c17 {
-  width: 22px;
-  height: 22px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c19 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
-<SnippetEditor
-  baseUrl="https://example.org/"
-  data={
-    Object {
-      "description": "Test description, %%replacement_variable%%",
-      "slug": "test-slug",
-      "title": "Test title",
-    }
-  }
-  date=""
-  descriptionLengthAssessment={
-    Object {
-      "actual": 0,
-      "max": 320,
-      "score": 0,
-    }
-  }
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "textComponent": "span",
-    }
-  }
-  mapDataToPreview={null}
-  mode="mobile"
-  onChange={[Function]}
-  replacementVariables={Array []}
-  titleLengthAssessment={
-    Object {
-      "actual": 0,
-      "max": 600,
-      "score": 0,
-    }
-  }
->
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      isDescriptionGenerated={false}
-      keyword=""
-      locale="en_US"
-      mode="mobile"
-      onClick={[Function]}
-      onHover={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c0"
-            width={640}
-          >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="SEO title preview"
-                  id="snippetPreview.seoTitlePreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="SEO title preview"
-                    id="snippetPreview.seoTitlePreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        SEO title preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseTitle
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c2"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c3"
-                      >
-                        <div
-                          className="c3 c4"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c5"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Url preview"
-                  id="snippetPreview.urlPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Url preview"
-                    id="snippetPreview.urlPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Url preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__BaseUrl
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <div
-                    className="c6"
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    example.org › test-slug
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c7"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c1"
-              >
-                <FormattedScreenReaderMessage
-                  after=":"
-                  defaultMessage="Meta description preview"
-                  id="snippetPreview.metaDescriptionPreview"
-                >
-                  <FormattedMessage
-                    after=":"
-                    defaultMessage="Meta description preview"
-                    id="snippetPreview.metaDescriptionPreview"
-                    values={Object {}}
-                  >
-                    <ScreenReaderText>
-                      <span
-                        className="screen-reader-text"
-                        style={
-                          Object {
-                            "clip": "rect(1px, 1px, 1px, 1px)",
-                            "height": "1px",
-                            "overflow": "hidden",
-                            "position": "absolute",
-                            "width": "1px",
-                          }
-                        }
-                      >
-                        Meta description preview:
-                      </span>
-                    </ScreenReaderText>
-                  </FormattedMessage>
-                </FormattedScreenReaderMessage>
-                <SnippetPreview__MobileDescription
-                  innerRef={[Function]}
-                  isDescriptionGenerated={false}
-                  onClick={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseOver={[Function]}
-                >
-                  <SnippetPreview__DesktopDescription
-                    className="c8"
-                    innerRef={[Function]}
-                    isDescriptionGenerated={false}
-                    onClick={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <div
-                      className="c8 c9"
-                      color="#545454"
-                      onClick={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseOver={[Function]}
-                    >
-                      Test description, %%replacement_variable%%
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c10"
-        >
-          <Button
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c11"
-              isActive={true}
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button
-                aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
-                isActive={true}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={true}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
-                  isActive={true}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={true}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
-                    isActive={true}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button__BaseButton
-                      aria-pressed={true}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                      isActive={true}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <button
-                        aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="mobile"
-                          size="22px"
-                        >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-mobile"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
-                            size="22px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Mobile preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
-                            defaultMessage="Mobile preview"
-                            id="snippetEditor.desktopPreview"
-                            values={Object {}}
-                          >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
-                                  }
-                                }
-                              >
-                                Mobile preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </Button>
-          <Button
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
-              aria-pressed={false}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c18"
-              isActive={false}
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button
-                aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
-                isActive={false}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <Button
-                  aria-pressed={false}
-                  backgroundColor="#f7f7f7"
-                  borderColor="#ccc"
-                  boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
-                  isActive={false}
-                  onClick={[Function]}
-                  textColor="#555"
-                  type="button"
-                >
-                  <Button
-                    aria-pressed={false}
-                    backgroundColor="#f7f7f7"
-                    borderColor="#ccc"
-                    boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
-                    isActive={false}
-                    onClick={[Function]}
-                    textColor="#555"
-                    type="button"
-                  >
-                    <Button__BaseButton
-                      aria-pressed={false}
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                      isActive={false}
-                      onClick={[Function]}
-                      textColor="#555"
-                      type="button"
-                    >
-                      <button
-                        aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <SvgIcon
-                          color="currentColor"
-                          icon="desktop"
-                          size="18px"
-                        >
-                          <SvgIcon__StyledSvg
-                            aria-hidden={true}
-                            className="yoast-svg-icon yoast-svg-icon-desktop"
-                            fill="currentColor"
-                            focusable="false"
-                            role="img"
-                            size="18px"
-                            viewBox="0 0 1792 1792"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
-                              size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                              />
-                            </svg>
-                          </SvgIcon__StyledSvg>
-                        </SvgIcon>
-                        <FormattedScreenReaderMessage
-                          defaultMessage="Desktop preview"
-                          id="snippetEditor.desktopPreview"
-                        >
-                          <FormattedMessage
-                            defaultMessage="Desktop preview"
-                            id="snippetEditor.desktopPreview"
-                            values={Object {}}
-                          >
-                            <ScreenReaderText>
-                              <span
-                                className="screen-reader-text"
-                                style={
-                                  Object {
-                                    "clip": "rect(1px, 1px, 1px, 1px)",
-                                    "height": "1px",
-                                    "overflow": "hidden",
-                                    "position": "absolute",
-                                    "width": "1px",
-                                  }
-                                }
-                              >
-                                Desktop preview
-                              </span>
-                            </ScreenReaderText>
-                          </FormattedMessage>
-                        </FormattedScreenReaderMessage>
-                      </button>
-                    </Button__BaseButton>
-                  </Button>
-                </Button>
-              </Button>
-            </Button>
-          </Button>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
-      <Button
-        aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c20"
-        innerRef={[Function]}
-        onClick={[Function]}
-        textColor="#555"
-        type="button"
-      >
-        <Button
-          aria-expanded={true}
-          backgroundColor="#f7f7f7"
-          borderColor="#ccc"
-          boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
-          innerRef={[Function]}
-          onClick={[Function]}
-          textColor="#555"
-          type="button"
-        >
-          <Button
-            aria-expanded={true}
-            backgroundColor="#f7f7f7"
-            borderColor="#ccc"
-            boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
-            innerRef={[Function]}
-            onClick={[Function]}
-            textColor="#555"
-            type="button"
-          >
-            <Button
-              aria-expanded={true}
-              backgroundColor="#f7f7f7"
-              borderColor="#ccc"
-              boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
-              innerRef={[Function]}
-              onClick={[Function]}
-              textColor="#555"
-              type="button"
-            >
-              <Button__BaseButton
-                aria-expanded={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
-                innerRef={[Function]}
-                onClick={[Function]}
-                textColor="#555"
-                type="button"
-              >
-                <button
-                  aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
-                  >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
-                      size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
-                        focusable="false"
-                        role="img"
-                        size="16px"
-                        viewBox="0 0 1792 1792"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  <FormattedMessage
-                    defaultMessage="Edit snippet"
-                    id="snippetEditor.editSnippet"
-                    values={Object {}}
-                  >
-                    <span>
-                      Edit snippet
-                    </span>
-                  </FormattedMessage>
-                </button>
-              </Button__BaseButton>
-            </Button>
-          </Button>
-        </Button>
-      </Button>
-    </Button>
-    <InjectIntl(SnippetEditorFields)
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
-        }
-      }
-      descriptionLengthAssessment={
-        Object {
-          "actual": 0,
-          "max": 320,
-          "score": 0,
-        }
-      }
       hoveredField={null}
       onChange={[Function]}
       onFocus={[Function]}
@@ -13556,18 +13792,18 @@ exports[`SnippetEditor opens when calling open() 1`] = `
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-1-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-1-title"
                     onClick={[Function]}
                   >
@@ -13579,7 +13815,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-1-title"
@@ -13602,7 +13838,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={600}
                     value={0}
                   />
@@ -13611,14 +13847,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-1-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-1-slug"
                     onClick={[Function]}
                   >
@@ -13630,7 +13866,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-1-slug"
@@ -13647,14 +13883,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-1-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-1-description"
                     onClick={[Function]}
                   >
@@ -13666,7 +13902,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-1-description"
@@ -13689,7 +13925,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={320}
                     value={0}
                   />
@@ -13707,7 +13943,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c27"
+        className="c28"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -13716,7 +13952,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c12"
+          className="c28 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -13725,7 +13961,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c28 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -13734,7 +13970,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -13743,13 +13979,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -13835,7 +14071,11 @@ exports[`SnippetEditor passes replacement variables to the title and description
 .c8 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c10 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -13848,7 +14088,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   margin: 0;
 }
 
-.c26 {
+.c27 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -13861,26 +14101,26 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border: 1px solid #ddd;
 }
 
-.c26::-webkit-progress-bar {
+.c27::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c26::-webkit-progress-value {
+.c27::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c26::-moz-progress-bar {
+.c27::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c26::-ms-fill {
+.c27::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
 
-.c25 {
+.c26 {
   padding: 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -13892,7 +14132,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   position: relative;
 }
 
-.c25::before {
+.c26::before {
   display: block;
   position: absolute;
   top: 4px;
@@ -13904,26 +14144,26 @@ exports[`SnippetEditor passes replacement variables to the title and description
   content: "";
 }
 
-.c23 {
+.c24 {
   margin: 1em 0;
 }
 
-.c22 {
+.c23 {
   padding: 0 20px;
 }
 
-.c24 {
+.c25 {
   cursor: pointer;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -13938,33 +14178,33 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
+.c12:hover,
+.c12:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -13993,13 +14233,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c19 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -14014,33 +14254,33 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c20 {
+.c21 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin: 10px 0 0 9px;
 }
 
-.c20 svg {
+.c21 svg {
   margin-right: 7px;
 }
 
-.c27 {
+.c28 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin-left: 20px;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -14050,7 +14290,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -14058,7 +14298,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -14066,7 +14306,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -14075,7 +14315,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -14324,7 +14564,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   </FormattedMessage>
                 </FormattedScreenReaderMessage>
                 <SnippetPreview__MobileDescription
-                  innerRef={[Function]}
                   isDescriptionGenerated={false}
                   onClick={[Function]}
                   onMouseLeave={[Function]}
@@ -14332,7 +14571,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 >
                   <SnippetPreview__DesktopDescription
                     className="c8"
-                    innerRef={[Function]}
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
@@ -14345,7 +14583,26 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      Test description, %%replacement_variable%%
+                      <SnippetPreview__MobileDescriptionOverflowContainer
+                        innerRef={[Function]}
+                      >
+                        <SnippetPreview__MobileDescription
+                          className="c10"
+                          innerRef={[Function]}
+                        >
+                          <SnippetPreview__DesktopDescription
+                            className="c10 c8"
+                            innerRef={[Function]}
+                          >
+                            <div
+                              className="c10 c8 c9"
+                              color="#545454"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </SnippetPreview__MobileDescriptionOverflowContainer>
                     </div>
                   </SnippetPreview__DesktopDescription>
                 </SnippetPreview__MobileDescription>
@@ -14361,7 +14618,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c10"
+          className="c11"
         >
           <Button
             aria-pressed={true}
@@ -14373,7 +14630,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c11"
+              className="c12"
               isActive={true}
               onClick={[Function]}
               textColor="#555"
@@ -14384,7 +14641,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c11 Button-kDSBcD c12"
+                className="c12 Button-kDSBcD c13"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -14395,7 +14652,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c11 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c12 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -14406,7 +14663,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -14417,7 +14674,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -14425,7 +14682,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     >
                       <button
                         aria-pressed={true}
-                        className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -14446,7 +14703,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile c17"
+                              className="yoast-svg-icon yoast-svg-icon-mobile c18"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -14504,7 +14761,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c18"
+              className="c19"
               isActive={false}
               onClick={[Function]}
               textColor="#555"
@@ -14515,7 +14772,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c18 Button-kDSBcD c12"
+                className="c19 Button-kDSBcD c13"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -14526,7 +14783,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c18 Button-kDSBcD c12 Button-kDSBcD c13"
+                  className="c19 Button-kDSBcD c13 Button-kDSBcD c14"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -14537,7 +14794,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+                    className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -14548,7 +14805,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -14556,7 +14813,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     >
                       <button
                         aria-pressed={false}
-                        className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                        className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                         onClick={[Function]}
                         type="button"
                       >
@@ -14577,7 +14834,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           >
                             <svg
                               aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop c19"
+                              className="yoast-svg-icon yoast-svg-icon-desktop c20"
                               fill="currentColor"
                               focusable="false"
                               role="img"
@@ -14638,7 +14895,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c20"
+        className="c21"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -14649,7 +14906,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c20 Button-kDSBcD c12"
+          className="c21 Button-kDSBcD c13"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -14660,7 +14917,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c20 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c21 Button-kDSBcD c13 Button-kDSBcD c14"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -14671,7 +14928,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -14682,7 +14939,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -14690,7 +14947,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               >
                 <button
                   aria-expanded={true}
-                  className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -14709,7 +14966,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     >
                       <svg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c21"
+                        className="yoast-svg-icon yoast-svg-icon-edit c22"
                         focusable="false"
                         role="img"
                         size="16px"
@@ -14843,18 +15100,18 @@ exports[`SnippetEditor passes replacement variables to the title and description
       >
         <SnippetEditorFields__StyledEditor>
           <section
-            className="c22"
+            className="c23"
           >
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-6-title"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-6-title"
                     onClick={[Function]}
                   >
@@ -14866,7 +15123,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-6-title"
@@ -14900,7 +15157,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={600}
                     value={0}
                   />
@@ -14909,14 +15166,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-6-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-6-slug"
                     onClick={[Function]}
                   >
@@ -14928,7 +15185,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-6-slug"
@@ -14945,14 +15202,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
             </SnippetEditorFields__FormSection>
             <SnippetEditorFields__FormSection>
               <div
-                className="c23"
+                className="c24"
               >
                 <SnippetEditorFields__SimulatedLabel
                   id="snippet-editor-field-6-description"
                   onClick={[Function]}
                 >
                   <div
-                    className="c24"
+                    className="c25"
                     id="snippet-editor-field-6-description"
                     onClick={[Function]}
                   >
@@ -14964,7 +15221,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   isHovered={false}
                 >
                   <div
-                    className="c25"
+                    className="c26"
                   >
                     <ReplacementVariableEditor
                       ariaLabelledBy="snippet-editor-field-6-description"
@@ -14998,7 +15255,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 >
                   <progress
                     aria-hidden="true"
-                    className="c26"
+                    className="c27"
                     max={320}
                     value={0}
                   />
@@ -15016,7 +15273,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c27"
+        className="c28"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -15025,7 +15282,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c12"
+          className="c28 Button-kDSBcD c13"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -15034,7 +15291,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c12 Button-kDSBcD c13"
+            className="c28 Button-kDSBcD c13 Button-kDSBcD c14"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -15043,7 +15300,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14"
+              className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -15052,13 +15309,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15"
+                className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c27 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+                  className="c28 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
                   onClick={[Function]}
                   type="button"
                 >
@@ -15144,14 +15401,18 @@ exports[`SnippetEditor passes the date prop 1`] = `
 .c8 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c10 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
   padding: 16px;
 }
 
-.c10 {
+.c11 {
   color: #808080;
 }
 
@@ -15161,14 +15422,14 @@ exports[`SnippetEditor passes the date prop 1`] = `
   margin: 0;
 }
 
-.c17 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c12 {
+.c13 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -15183,33 +15444,33 @@ exports[`SnippetEditor passes the date prop 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c12:hover,
-.c12:focus {
+.c13:hover,
+.c13:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c13:active {
+.c14:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c14:hover {
+.c15:hover {
   color: #000;
 }
 
-.c15::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c15:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c16 {
+.c17 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -15238,13 +15499,13 @@ exports[`SnippetEditor passes the date prop 1`] = `
   min-height: 32px;
 }
 
-.c16 svg {
+.c17 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c19 {
+.c20 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -15259,26 +15520,26 @@ exports[`SnippetEditor passes the date prop 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c19:hover,
-.c19:focus {
+.c20:hover,
+.c20:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c21 {
+.c22 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin: 10px 0 0 9px;
 }
 
-.c21 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c11 {
+.c12 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -15288,7 +15549,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   vertical-align: top;
 }
 
-.c18 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -15296,7 +15557,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   flex: none;
 }
 
-.c20 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -15304,7 +15565,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   flex: none;
 }
 
-.c22 {
+.c23 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -15313,7 +15574,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c16::after {
+  .c17::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -15410,29 +15671,34 @@ exports[`SnippetEditor passes the date prop 1`] = `
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
         >
-          <span
-            className="c10"
+          <div
+            className="c10 c8 c9"
+            color="#545454"
           >
-            date string
-             - 
-          </span>
-          Test description, %%replacement_variable%%
+            <span
+              className="c11"
+            >
+              date string
+               - 
+            </span>
+            Test description, %%replacement_variable%%
+          </div>
         </div>
       </div>
     </div>
   </section>
   <div
-    className="c11"
+    className="c12"
   >
     <button
       aria-pressed={true}
-      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+      className="c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c18"
+        className="yoast-svg-icon yoast-svg-icon-mobile c19"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -15461,13 +15727,13 @@ exports[`SnippetEditor passes the date prop 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+      className="c20 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c20"
+        className="yoast-svg-icon yoast-svg-icon-desktop c21"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -15497,13 +15763,13 @@ exports[`SnippetEditor passes the date prop 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
+    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
     onClick={[Function]}
     type="button"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c22"
+      className="yoast-svg-icon yoast-svg-icon-edit c23"
       fill={undefined}
       focusable="false"
       role="img"
@@ -16097,7 +16363,11 @@ exports[`SnippetEditor shows and editor 1`] = `
 .c8 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c10 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -16110,14 +16380,14 @@ exports[`SnippetEditor shows and editor 1`] = `
   margin: 0;
 }
 
-.c16 {
+.c17 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c11 {
+.c12 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -16132,33 +16402,33 @@ exports[`SnippetEditor shows and editor 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c11:hover,
-.c11:focus {
+.c12:hover,
+.c12:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c12:active {
+.c13:active {
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c13:hover {
+.c14:hover {
   color: #000;
 }
 
-.c14::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border-width: 0;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   border-color: #0066cd;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -16187,13 +16457,13 @@ exports[`SnippetEditor shows and editor 1`] = `
   min-height: 32px;
 }
 
-.c15 svg {
+.c16 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c18 {
+.c19 {
   font-size: 0.8rem;
   border: none;
   border-bottom: 4px solid transparent;
@@ -16208,26 +16478,26 @@ exports[`SnippetEditor shows and editor 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c18:hover,
-.c18:focus {
+.c19:hover,
+.c19:focus {
   border: none;
   border-bottom: 4px solid transparent;
   border-color: #1e8cbe;
   color: #1e8cbe;
 }
 
-.c20 {
+.c21 {
   font-size: 0.8rem;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   margin: 10px 0 0 9px;
 }
 
-.c20 svg {
+.c21 svg {
   margin-right: 7px;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -16237,7 +16507,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   vertical-align: top;
 }
 
-.c17 {
+.c18 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -16245,7 +16515,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   flex: none;
 }
 
-.c19 {
+.c20 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -16253,7 +16523,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   flex: none;
 }
 
-.c21 {
+.c22 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -16262,7 +16532,7 @@ exports[`SnippetEditor shows and editor 1`] = `
 }
 
 @media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
-  .c15::after {
+  .c16::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -16359,23 +16629,28 @@ exports[`SnippetEditor shows and editor 1`] = `
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
         >
-          Test description, %%replacement_variable%%
+          <div
+            className="c10 c8 c9"
+            color="#545454"
+          >
+            Test description, %%replacement_variable%%
+          </div>
         </div>
       </div>
     </div>
   </section>
   <div
-    className="c10"
+    className="c11"
   >
     <button
       aria-pressed={true}
-      className="c11 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+      className="c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c17"
+        className="yoast-svg-icon yoast-svg-icon-mobile c18"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -16404,13 +16679,13 @@ exports[`SnippetEditor shows and editor 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c18 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+      className="c19 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c19"
+        className="yoast-svg-icon yoast-svg-icon-desktop c20"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -16440,13 +16715,13 @@ exports[`SnippetEditor shows and editor 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c20 Button-kDSBcD c12 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 c16"
+    className="c21 Button-kDSBcD c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 c17"
     onClick={[Function]}
     type="button"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c21"
+      className="yoast-svg-icon yoast-svg-icon-edit c22"
       fill={undefined}
       focusable="false"
       role="img"

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -532,6 +532,11 @@ export default class SnippetPreview extends PureComponent {
 		}
 	}
 
+	/**
+	 * Renders the snippet preview description, based on the mode.
+	 *
+	 * @returns {ReactElement} The rendered description.
+	 */
 	renderDescription() {
 		const {
 			keyword,

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -558,25 +558,25 @@ export default class SnippetPreview extends PureComponent {
 		};
 
 		if ( mode === MODE_DESKTOP ) {
-			const DesktopDescriptionWithCarret = this.addCaretStyles( "description", DesktopDescription );
+			const DesktopDescriptionWithCaret = this.addCaretStyles( "description", DesktopDescription );
 			return (
-				<DesktopDescriptionWithCarret { ...outerContainerProps }
+				<DesktopDescriptionWithCaret { ...outerContainerProps }
 											  innerRef={ this.setDescriptionRef }>
 					{ renderedDate }
 					{ highlightKeyword( locale, keyword, this.getDescription() ) }
-				</DesktopDescriptionWithCarret>
+				</DesktopDescriptionWithCaret>
 			);
 		} else if ( mode === MODE_MOBILE ) {
-			const MobileDescriptionWithCarret = this.addCaretStyles( "description", MobileDescription );
+			const MobileDescriptionWithCaret = this.addCaretStyles( "description", MobileDescription );
 			return (
-				<MobileDescriptionWithCarret
+				<MobileDescriptionWithCaret
 					{ ...outerContainerProps } >
 					<MobileDescriptionOverflowContainer
 						innerRef={ this.setDescriptionRef } >
 						{ renderedDate }
 						{ highlightKeyword( locale, keyword, this.getDescription() ) }
 					</MobileDescriptionOverflowContainer>
-				</MobileDescriptionWithCarret>
+				</MobileDescriptionWithCaret>
 			);
 		}
 		return null;

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -74,7 +74,7 @@ function addCaretStyle( WithoutCaret, color, mode ) {
 			left: ${ () => mode === MODE_DESKTOP ? "-22px" : "-40px" };
 			width: 24px;
 			height: 24px;
-			background-image: url( ${ () => angleRight( color ) });
+			background-image: url( ${ () => angleRight( color ) } );
 			background-size: 25px;
 			content: "";
 		}
@@ -133,7 +133,11 @@ export const DesktopDescription = styled.div.attrs( {
 const MobileDescription = styled( DesktopDescription )`
 	line-height: 1em;
 	max-height: 4em;
+`;
+
+const MobileDescriptionOverflowContainer = styled( MobileDescription )`
 	overflow: hidden;
+	max-height: calc( 4em + 3px );
 `;
 
 const MobilePartContainer = styled.div`
@@ -528,6 +532,51 @@ export default class SnippetPreview extends PureComponent {
 		}
 	}
 
+	renderDescription() {
+		const {
+			keyword,
+			isDescriptionGenerated,
+			locale,
+			onClick,
+			onMouseLeave,
+			onMouseOver,
+			mode,
+		} = this.props;
+
+		const renderedDate = this.renderDate();
+
+		const outerContainerProps = {
+			isDescriptionGenerated: isDescriptionGenerated,
+			onClick: onClick.bind( null, "description" ),
+			onMouseOver: partial( onMouseOver, "description" ),
+			onMouseLeave: partial( onMouseLeave, "description" ),
+		};
+
+		if ( mode === MODE_DESKTOP ) {
+			const DesktopDescriptionWithCarret = this.addCaretStyles( "description", DesktopDescription );
+			return (
+				<DesktopDescriptionWithCarret { ...outerContainerProps }
+											  innerRef={ this.setDescriptionRef }>
+					{ renderedDate }
+					{ highlightKeyword( locale, keyword, this.getDescription() ) }
+				</DesktopDescriptionWithCarret>
+			);
+		} else if ( mode === MODE_MOBILE ) {
+			const MobileDescriptionWithCarret = this.addCaretStyles( "description", MobileDescription );
+			return (
+				<MobileDescriptionWithCarret
+					{ ...outerContainerProps } >
+					<MobileDescriptionOverflowContainer
+						innerRef={ this.setDescriptionRef } >
+						{ renderedDate }
+						{ highlightKeyword( locale, keyword, this.getDescription() ) }
+					</MobileDescriptionOverflowContainer>
+				</MobileDescriptionWithCarret>
+			);
+		}
+		return null;
+	}
+
 	/**
 	 * Renders the snippet preview.
 	 *
@@ -535,9 +584,6 @@ export default class SnippetPreview extends PureComponent {
 	 */
 	render() {
 		const {
-			keyword,
-			isDescriptionGenerated,
-			locale,
 			onClick,
 			onMouseLeave,
 			onMouseOver,
@@ -550,14 +596,11 @@ export default class SnippetPreview extends PureComponent {
 			Container,
 			TitleUnbounded,
 			Title,
-			Description,
 		} = this.getPreparedComponents( mode );
 
 		const separator = mode === MODE_DESKTOP ? null : <Separator/>;
 		const downArrow = mode === MODE_DESKTOP ? <UrlDownArrow/> : null;
 		const amp       = mode === MODE_DESKTOP || ! isAmp ? null : <Amp/>;
-
-		const renderedDate = this.renderDate();
 
 		/*
 		 * The jsx-a11y eslint plugin is asking for an onFocus accompanying the onMouseOver.
@@ -601,14 +644,7 @@ export default class SnippetPreview extends PureComponent {
 							defaultMessage="Meta description preview"
 							after=":"
 						/>
-						<Description isDescriptionGenerated={ isDescriptionGenerated }
-						             onClick={ onClick.bind( null, "description" ) }
-						             onMouseOver={ partial( onMouseOver, "description" ) }
-						             onMouseLeave={ partial( onMouseLeave, "description" ) }
-						             innerRef={ this.setDescriptionRef } >
-							{ renderedDate }
-							{ highlightKeyword( locale, keyword, this.getDescription() ) }
-						</Description>
+						{ this.renderDescription() }
 					</PartContainer>
 				</Container>
 			</section>
@@ -625,24 +661,20 @@ export default class SnippetPreview extends PureComponent {
 	 *     Container: ReactComponent,
 	 *     TitleUnbounded: ReactComponent,
 	 *     Title: ReactComponent,
-	 *     Description: ReactComponent
 	 * }} The prepared components.
 	 */
 	getPreparedComponents( mode ) {
-		const BaseDescription = mode === MODE_DESKTOP ? DesktopDescription : MobileDescription;
 		const PartContainer = mode === MODE_DESKTOP ? DesktopPartContainer : MobilePartContainer;
 		const Container = mode === MODE_DESKTOP ? DesktopContainer : MobileContainer;
 		const TitleUnbounded = mode === MODE_DESKTOP ? TitleUnboundedDesktop : TitleUnboundedMobile;
 
 		const Title = this.addCaretStyles( "title", BaseTitle );
-		const Description = this.addCaretStyles( "description", BaseDescription );
 
 		return {
 			PartContainer,
 			Container,
 			TitleUnbounded,
 			Title,
-			Description,
 		};
 	}
 }

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -591,7 +591,11 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
 .c9 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c11 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -707,7 +711,12 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
         onMouseLeave={[Function]}
         onMouseOver={[Function]}
       >
-        Description
+        <div
+          className="c11 c9 c10"
+          color="#545454"
+        >
+          Description
+        </div>
       </div>
     </div>
   </div>
@@ -776,7 +785,11 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
 .c8 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c10 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -878,7 +891,12 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
         onMouseLeave={[Function]}
         onMouseOver={[Function]}
       >
-        Description
+        <div
+          className="c10 c8 c9"
+          color="#545454"
+        >
+          Description
+        </div>
       </div>
     </div>
   </div>
@@ -947,7 +965,11 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
 .c8 {
   line-height: 1em;
   max-height: 4em;
+}
+
+.c10 {
   overflow: hidden;
+  max-height: calc( 4em + 3px );
 }
 
 .c1 {
@@ -1049,7 +1071,12 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
         onMouseLeave={[Function]}
         onMouseOver={[Function]}
       >
-        Description
+        <div
+          className="c10 c8 c9"
+          color="#545454"
+        >
+          Description
+        </div>
       </div>
     </div>
   </div>
@@ -1309,7 +1336,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   left: -22px;
   width: 24px;
   height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#555%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#555%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E );
   background-size: 25px;
   content: "";
 }
@@ -1494,7 +1521,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   left: -22px;
   width: 24px;
   height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#555%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#555%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E );
   background-size: 25px;
   content: "";
 }
@@ -1679,7 +1706,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   left: -22px;
   width: 24px;
   height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#555%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#555%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E );
   background-size: 25px;
   content: "";
 }
@@ -1864,7 +1891,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   left: -22px;
   width: 24px;
   height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#ccc%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#ccc%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E );
   background-size: 25px;
   content: "";
 }
@@ -2049,7 +2076,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   left: -22px;
   width: 24px;
   height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#ccc%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#ccc%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E );
   background-size: 25px;
   content: "";
 }
@@ -2234,7 +2261,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   left: -22px;
   width: 24px;
   height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#ccc%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E);
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width=%221792%22%20height=%221792%22%20viewBox=%220%200%201792%201792%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill=%22#ccc%22%20d=%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20/%3E%3C/svg%3E );
   background-size: 25px;
   content: "";
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes arrow not showing up next to mobile description on hover and selection.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

*

Fixes #504 
