### PR TITLE
Don't encode percent characters that are encoded by node's url.parse

### DIFF
--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -58,6 +58,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -320,7 +327,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
           className="c6"
         >
           <div
-            className="c7 c6"
+            className="c7"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
@@ -596,6 +603,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -1111,21 +1125,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      <SnippetPreview__BaseUrl
+                      <div
                         className="c7"
                         onClick={[Function]}
                         onMouseLeave={[Function]}
                         onMouseOver={[Function]}
                       >
-                        <div
-                          className="c7 c6"
-                          onClick={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseOver={[Function]}
-                        >
-                          example.org › test-slug
-                        </div>
-                      </SnippetPreview__BaseUrl>
+                        example.org › test-slug
+                      </div>
                     </SnippetPreview__BaseUrlOverflowContainer>
                   </div>
                 </SnippetPreview__BaseUrl>
@@ -1918,6 +1925,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -2433,21 +2447,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      <SnippetPreview__BaseUrl
+                      <div
                         className="c7"
                         onClick={[Function]}
                         onMouseLeave={[Function]}
                         onMouseOver={[Function]}
                       >
-                        <div
-                          className="c7 c6"
-                          onClick={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseOver={[Function]}
-                        >
-                          example.org › test-slug
-                        </div>
-                      </SnippetPreview__BaseUrl>
+                        example.org › test-slug
+                      </div>
                     </SnippetPreview__BaseUrlOverflowContainer>
                   </div>
                 </SnippetPreview__BaseUrl>
@@ -3240,6 +3247,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -3755,21 +3769,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      <SnippetPreview__BaseUrl
+                      <div
                         className="c7"
                         onClick={[Function]}
                         onMouseLeave={[Function]}
                         onMouseOver={[Function]}
                       >
-                        <div
-                          className="c7 c6"
-                          onClick={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseOver={[Function]}
-                        >
-                          example.org › test-slug
-                        </div>
-                      </SnippetPreview__BaseUrl>
+                        example.org › test-slug
+                      </div>
                     </SnippetPreview__BaseUrlOverflowContainer>
                   </div>
                 </SnippetPreview__BaseUrl>
@@ -4562,6 +4569,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -5077,21 +5091,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      <SnippetPreview__BaseUrl
+                      <div
                         className="c7"
                         onClick={[Function]}
                         onMouseLeave={[Function]}
                         onMouseOver={[Function]}
                       >
-                        <div
-                          className="c7 c6"
-                          onClick={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseOver={[Function]}
-                        >
-                          example.org › test-slug
-                        </div>
-                      </SnippetPreview__BaseUrl>
+                        example.org › test-slug
+                      </div>
                     </SnippetPreview__BaseUrlOverflowContainer>
                   </div>
                 </SnippetPreview__BaseUrl>
@@ -5884,6 +5891,13 @@ exports[`SnippetEditor closes when calling close() 2`] = `
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -6273,21 +6287,14 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      <SnippetPreview__BaseUrl
+                      <div
                         className="c7"
                         onClick={[Function]}
                         onMouseLeave={[Function]}
                         onMouseOver={[Function]}
                       >
-                        <div
-                          className="c7 c6"
-                          onClick={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseOver={[Function]}
-                        >
-                          example.org › test-slug
-                        </div>
-                      </SnippetPreview__BaseUrl>
+                        example.org › test-slug
+                      </div>
                     </SnippetPreview__BaseUrlOverflowContainer>
                   </div>
                 </SnippetPreview__BaseUrl>
@@ -6831,6 +6838,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -7378,21 +7392,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      <SnippetPreview__BaseUrl
+                      <div
                         className="c7"
                         onClick={[Function]}
                         onMouseLeave={[Function]}
                         onMouseOver={[Function]}
                       >
-                        <div
-                          className="c7 c6"
-                          onClick={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseOver={[Function]}
-                        >
-                          example.org › test-slug
-                        </div>
-                      </SnippetPreview__BaseUrl>
+                        example.org › test-slug
+                      </div>
                     </SnippetPreview__BaseUrlOverflowContainer>
                   </div>
                 </SnippetPreview__BaseUrl>
@@ -8185,6 +8192,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -8732,21 +8746,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      <SnippetPreview__BaseUrl
+                      <div
                         className="c7"
                         onClick={[Function]}
                         onMouseLeave={[Function]}
                         onMouseOver={[Function]}
                       >
-                        <div
-                          className="c7 c6"
-                          onClick={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseOver={[Function]}
-                        >
-                          example.org › test-slug
-                        </div>
-                      </SnippetPreview__BaseUrl>
+                        example.org › test-slug
+                      </div>
                     </SnippetPreview__BaseUrlOverflowContainer>
                   </div>
                 </SnippetPreview__BaseUrl>
@@ -9612,6 +9619,13 @@ exports[`SnippetEditor highlights a focused field 1`] = `
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -9874,7 +9888,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
           className="c6"
         >
           <div
-            className="c7 c6"
+            className="c7"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
@@ -10077,6 +10091,13 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -10339,7 +10360,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
           className="c6"
         >
           <div
-            className="c7 c6"
+            className="c7"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
@@ -10542,6 +10563,13 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -11069,21 +11097,14 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      <SnippetPreview__BaseUrl
+                      <div
                         className="c7"
                         onClick={[Function]}
                         onMouseLeave={[Function]}
                         onMouseOver={[Function]}
                       >
-                        <div
-                          className="c7 c6"
-                          onClick={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseOver={[Function]}
-                        >
-                          example.org › test-slug
-                        </div>
-                      </SnippetPreview__BaseUrl>
+                        example.org › test-slug
+                      </div>
                     </SnippetPreview__BaseUrlOverflowContainer>
                   </div>
                 </SnippetPreview__BaseUrl>
@@ -11884,6 +11905,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -12411,21 +12439,14 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      <SnippetPreview__BaseUrl
+                      <div
                         className="c7"
                         onClick={[Function]}
                         onMouseLeave={[Function]}
                         onMouseOver={[Function]}
                       >
-                        <div
-                          className="c7 c6"
-                          onClick={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseOver={[Function]}
-                        >
-                          example.org › test-slug
-                        </div>
-                      </SnippetPreview__BaseUrl>
+                        example.org › test-slug
+                      </div>
                     </SnippetPreview__BaseUrlOverflowContainer>
                   </div>
                 </SnippetPreview__BaseUrl>
@@ -13226,6 +13247,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -13741,21 +13769,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      <SnippetPreview__BaseUrl
+                      <div
                         className="c7"
                         onClick={[Function]}
                         onMouseLeave={[Function]}
                         onMouseOver={[Function]}
                       >
-                        <div
-                          className="c7 c6"
-                          onClick={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseOver={[Function]}
-                        >
-                          example.org › test-slug
-                        </div>
-                      </SnippetPreview__BaseUrl>
+                        example.org › test-slug
+                      </div>
                     </SnippetPreview__BaseUrlOverflowContainer>
                   </div>
                 </SnippetPreview__BaseUrl>
@@ -14548,6 +14569,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -15074,21 +15102,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
-                      <SnippetPreview__BaseUrl
+                      <div
                         className="c7"
                         onClick={[Function]}
                         onMouseLeave={[Function]}
                         onMouseOver={[Function]}
                       >
-                        <div
-                          className="c7 c6"
-                          onClick={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseOver={[Function]}
-                        >
-                          example.org › test-slug
-                        </div>
-                      </SnippetPreview__BaseUrl>
+                        example.org › test-slug
+                      </div>
                     </SnippetPreview__BaseUrlOverflowContainer>
                   </div>
                 </SnippetPreview__BaseUrl>
@@ -15914,6 +15935,13 @@ exports[`SnippetEditor passes the date prop 1`] = `
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -16180,7 +16208,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
           className="c6"
         >
           <div
-            className="c7 c6"
+            className="c7"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
@@ -16464,6 +16492,13 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
 }
 
 .c8 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -16717,7 +16752,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
             className="c7"
           >
             <div
-              className="c8 c7"
+              className="c8"
               onClick={[Function]}
               onMouseLeave={[Function]}
               onMouseOver={[Function]}
@@ -16916,6 +16951,13 @@ exports[`SnippetEditor shows and editor 1`] = `
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -17178,7 +17220,7 @@ exports[`SnippetEditor shows and editor 1`] = `
           className="c6"
         >
           <div
-            className="c7 c6"
+            className="c7"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -127,11 +127,13 @@ export const BaseUrl = styled.div`
 	font-size: 14px;
 `;
 
-const BaseUrlOverflowContainer = styled( BaseUrl )`
+const BaseUrlOverflowContainer = BaseUrl.extend`
 	overflow: hidden;
 	text-overflow: ellipsis;
 	max-width: 100%;
 `;
+
+BaseUrlOverflowContainer.displayName = "SnippetPreview__BaseUrlOverflowContainer";
 
 export const DesktopDescription = styled.div.attrs( {
 	color: ( props ) => props.isDescriptionGenerated ? colorGeneratedDescription : colorDescription,

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -458,7 +458,7 @@ export default class SnippetPreview extends PureComponent {
 
 		const breadCrumbs = [ hostPart, ...urlParts ].filter( part => !! part ).join( " › " );
 
-		return decodeURI( breadCrumbs.replace( /%20/g, " " ) );
+		return decodeURI( breadCrumbs );
 	}
 
 	/**

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -444,15 +444,21 @@ export default class SnippetPreview extends PureComponent {
 	 */
 	getBreadcrumbs() {
 		const { url, breadcrumbs } = this.props;
-		// Strip out question mark and hash characters from the raw URL.
-		const cleanUrl = url.replace( /\?|#/g, "" );
-		const { protocol, hostname, pathname } = parse( cleanUrl );
+		/*
+		 * Strip out question mark and hash characters from the raw URL and percent-encode
+		 * characters that are not allowed in a URI.
+		 */
+		const cleanEncodedUrl = encodeURI( url ).replace( /\?|#/g, "" );
+
+		const { protocol, hostname, pathname } = parse( cleanEncodedUrl );
 
 		const hostPart = protocol === "https:" ? protocol + "//" + hostname : hostname;
 
 		const urlParts = breadcrumbs || pathname.split( "/" );
 
-		return [ hostPart, ...urlParts ].filter( part => !! part ).join( " › " );
+		const breadCrumbs = [ hostPart, ...urlParts ].filter( part => !! part ).join( " › " );
+
+		return decodeURI( breadCrumbs.replace( /%20/g, " " ) );
 	}
 
 	/**

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -448,7 +448,7 @@ export default class SnippetPreview extends PureComponent {
 		 * Strip out question mark and hash characters from the raw URL and percent-encode
 		 * characters that are not allowed in a URI.
 		 */
-		const cleanEncodedUrl = encodeURI( url ).replace( /\?|#/g, "" );
+		const cleanEncodedUrl = encodeURI( url.replace( /\?|#/g, "" ) );
 
 		const { protocol, hostname, pathname } = parse( cleanEncodedUrl );
 

--- a/composites/Plugin/SnippetPreview/tests/SnippetPreviewTest.js
+++ b/composites/Plugin/SnippetPreview/tests/SnippetPreviewTest.js
@@ -92,13 +92,13 @@ describe( "SnippetPreview", () => {
 		it( "properly renders multiple breadcrumbs in mobile view", () => {
 			const wrapper = mountWithArgs( { mode: MODE_MOBILE, url: "http://www.google.nl/about" } );
 
-			expect( wrapper.find( "SnippetPreview__BaseUrl" ).text() ).toBe( "www.google.nl › about" );
+			expect( wrapper.find( "SnippetPreview__BaseUrlOverflowContainer" ).text() ).toBe( "www.google.nl › about" );
 		} );
 
 		it( "doesn't percent encode characters that are percent encoded by node's url.parse", () => {
 			const wrapper = mountWithArgs( { mode: MODE_MOBILE, url: "http://www.google.nl/`^ {}" } );
 
-			expect( wrapper.find( "SnippetPreview__BaseUrl" ).text() ).toBe( "www.google.nl › `^ {}" );
+			expect( wrapper.find( "SnippetPreview__BaseUrlOverflowContainer" ).text() ).toBe( "www.google.nl › `^ {}" );
 		} );
 	} );
 } );

--- a/composites/Plugin/SnippetPreview/tests/SnippetPreviewTest.js
+++ b/composites/Plugin/SnippetPreview/tests/SnippetPreviewTest.js
@@ -2,6 +2,9 @@ import SnippetPreview from "../components/SnippetPreview";
 import { MODE_DESKTOP, MODE_MOBILE } from "../constants";
 import React from "react";
 import { createComponentWithIntl } from "../../../../utils/intlProvider";
+import {
+	mountWithIntl,
+} from "../../../../utils/helpers/intl-enzyme-test-helper";
 
 const defaultArgs = {
 	description: "Description",
@@ -17,6 +20,14 @@ const renderSnapshotWithArgs = ( changedArgs ) => {
 		.toJSON();
 
 	expect( tree ).toMatchSnapshot();
+};
+
+const mountWithArgs = ( props ) => {
+	return mountWithIntl(
+		<SnippetPreview
+			{ ...defaultArgs }
+			{ ...props } />
+	);
 };
 
 describe( "SnippetPreview", () => {
@@ -74,6 +85,20 @@ describe( "SnippetPreview", () => {
 
 		it( "renders an AMP logo when isAmp is true", () => {
 			renderSnapshotWithArgs( { mode: MODE_MOBILE, isAmp: true } );
+		} );
+	} );
+
+	describe( "breadcrumbs", () => {
+		it( "properly renders multiple breadcrumbs in mobile view", () => {
+			const wrapper = mountWithArgs( { mode: MODE_MOBILE, url: "http://www.google.nl/about" } );
+
+			expect( wrapper.find( "SnippetPreview__BaseUrl" ).text() ).toBe( "www.google.nl › about" );
+		} );
+
+		it( "doesn't percent encode characters that are percent encoded by node's url.parse", () => {
+			const wrapper = mountWithArgs( { mode: MODE_MOBILE, url: "http://www.google.nl/percent:%" } );
+
+			expect( wrapper.find( "SnippetPreview__BaseUrl" ).text() ).toBe( "www.google.nl › percent:%" );
 		} );
 	} );
 } );

--- a/composites/Plugin/SnippetPreview/tests/SnippetPreviewTest.js
+++ b/composites/Plugin/SnippetPreview/tests/SnippetPreviewTest.js
@@ -96,9 +96,9 @@ describe( "SnippetPreview", () => {
 		} );
 
 		it( "doesn't percent encode characters that are percent encoded by node's url.parse", () => {
-			const wrapper = mountWithArgs( { mode: MODE_MOBILE, url: "http://www.google.nl/percent:%" } );
+			const wrapper = mountWithArgs( { mode: MODE_MOBILE, url: "http://www.google.nl/`^ {}" } );
 
-			expect( wrapper.find( "SnippetPreview__BaseUrl" ).text() ).toBe( "www.google.nl › percent:%" );
+			expect( wrapper.find( "SnippetPreview__BaseUrl" ).text() ).toBe( "www.google.nl › `^ {}" );
 		} );
 	} );
 } );

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -60,6 +60,13 @@ exports[`SnippetPreview changes the colors of the description if it was generate
 }
 
 .c8 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -143,7 +150,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
           className="c7"
         >
           <div
-            className="c8 c7"
+            className="c8"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
@@ -247,6 +254,13 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
 }
 
 .c8 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -330,7 +344,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
           className="c7"
         >
           <div
-            className="c8 c7"
+            className="c8"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
@@ -437,6 +451,13 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
 }
 
 .c8 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -520,7 +541,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
           className="c7"
         >
           <div
-            className="c8 c7"
+            className="c8"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
@@ -629,6 +650,13 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
 }
 
 .c8 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -735,7 +763,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
         className="c7"
       >
         <div
-          className="c8 c7"
+          className="c8"
           onClick={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
@@ -841,6 +869,13 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -933,7 +968,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
         className="c6"
       >
         <div
-          className="c7 c6"
+          className="c7"
           onClick={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
@@ -1039,6 +1074,13 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
 }
 
 .c7 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -1131,7 +1173,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
         className="c6"
       >
         <div
-          className="c7 c6"
+          className="c7"
           onClick={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
@@ -1239,6 +1281,13 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
 }
 
 .c8 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -1322,7 +1371,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
           className="c7"
         >
           <div
-            className="c8 c7"
+            className="c8"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
@@ -1426,6 +1475,13 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
 }
 
 .c9 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -1521,7 +1577,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
           className="c8"
         >
           <div
-            className="c9 c8"
+            className="c9"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
@@ -1625,6 +1681,13 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
 }
 
 .c8 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -1720,7 +1783,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
           className="c7"
         >
           <div
-            className="c8 c7"
+            className="c8"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
@@ -1824,6 +1887,13 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
 }
 
 .c9 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -1919,7 +1989,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
           className="c7 c8"
         >
           <div
-            className="c9 c8"
+            className="c9"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
@@ -2023,6 +2093,13 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
 }
 
 .c9 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -2118,7 +2195,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
           className="c8"
         >
           <div
-            className="c9 c8"
+            className="c9"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
@@ -2222,6 +2299,13 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
 }
 
 .c8 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -2317,7 +2401,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
           className="c7"
         >
           <div
-            className="c8 c7"
+            className="c8"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
@@ -2421,6 +2505,13 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
 }
 
 .c9 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -2516,7 +2607,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
           className="c7 c8"
         >
           <div
-            className="c9 c8"
+            className="c9"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
@@ -2620,6 +2711,13 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
 }
 
 .c8 {
+  display: inline-block;
+  color: #006621;
+  cursor: pointer;
+  position: relative;
+  max-width: 90%;
+  white-space: nowrap;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -2707,7 +2805,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
           className="c7"
         >
           <div
-            className="c8 c7"
+            className="c8"
             onClick={[Function]}
             onMouseLeave={[Function]}
             onMouseOver={[Function]}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Not applicable

## Relevant technical choices:

* Characters that were previously encoded by `node`'s `url.parse` are now no longer url encoded in the mobile preview's breadcrumbs.

## Test instructions

This PR can be tested by following these steps:

* Create a slug containing some of the following characters (` `^{`(including space)).
* Make sure the characters are not percent encoded in the breadcrumbs preview in mobile mode.

Fixes #514
