### PR TITLE
Pass locale prop from snippet editor to snippet preview

### DIFF
--- a/app/SnippetEditorExample.js
+++ b/app/SnippetEditorExample.js
@@ -47,7 +47,7 @@ export default class SnippetEditorExample extends Component {
 			" Title Snippet Title Snippet Title Snippet Title Snippet Title",
 			url: "https://local.wordpress.test/welcome-to-the-gutenberg-editor-2/",
 			slug: "welcome-to-the-gutenberg-editor-2",
-			description: "Of Mountains & Printing Presses The goal of this new editor is to make" +
+			description: "Merci, merçi, Of Mountains & Printing Presses The goal of this new editor is to make" +
 			" adding rich content to WordPress simple and enjoyable. This whole post is composed" +
 			" of. Of Mountains & Printing Presses The goal of this new editor is to make adding" +
 			" rich content to WordPress simple and enjoyable. This whole post is composed of. Of" +
@@ -59,9 +59,9 @@ export default class SnippetEditorExample extends Component {
 			" simple and enjoyable. This whole post is composed of. Of Mountains & Printing Presses" +
 			" The goal of this new editor is to make adding rich content to WordPress simple and" +
 			" enjoyable. This whole post is composed of",
-			keyword: "editor",
+			keyword: "merci",
 			date: "Jan 8, 2018",
-			locale: "en_US",
+			locale: "fr",
 			onClick( type ) {
 				// eslint-disable-next-line no-console
 				console.log( "clicked:", type );

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -62,6 +62,7 @@ class SnippetEditor extends React.Component {
 	 *                                                   assessment.
 	 * @param {Function} props.mapDataToPreview          Function to map the editor
 	 *                                                   data to data for the preview.
+	 * @param {string} props.locale                      The locale of the page.
 	 *
 	 * @returns {void}
 	 */
@@ -299,6 +300,7 @@ class SnippetEditor extends React.Component {
 			data,
 			mode,
 			date,
+			locale,
 		} = this.props;
 
 		const {
@@ -324,6 +326,7 @@ class SnippetEditor extends React.Component {
 					onMouseOver={ this.onMouseOver }
 					onMouseLeave={ this.onMouseLeave }
 					onClick={ this.onClick }
+					locale={ locale }
 					{ ...mappedData }
 				/>
 
@@ -359,6 +362,7 @@ SnippetEditor.propTypes = {
 	titleLengthAssessment: lengthAssessmentShape,
 	descriptionLengthAssessment: lengthAssessmentShape,
 	mapDataToPreview: PropTypes.func,
+	locale: PropTypes.string,
 };
 
 SnippetEditor.defaultProps = {
@@ -376,6 +380,7 @@ SnippetEditor.defaultProps = {
 		score: 0,
 	},
 	mapDataToPreview: null,
+	locale: "en",
 };
 
 export default SnippetEditor;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -301,6 +301,7 @@ class SnippetEditor extends React.Component {
 			mode,
 			date,
 			locale,
+			keyword,
 		} = this.props;
 
 		const {
@@ -319,6 +320,7 @@ class SnippetEditor extends React.Component {
 		return (
 			<div>
 				<SnippetPreview
+					keyword={ keyword }
 					mode={ mode }
 					date={ date }
 					activeField={ this.mapFieldToPreview( activeField ) }
@@ -362,6 +364,7 @@ SnippetEditor.propTypes = {
 	titleLengthAssessment: lengthAssessmentShape,
 	descriptionLengthAssessment: lengthAssessmentShape,
 	mapDataToPreview: PropTypes.func,
+	keyword: PropTypes.string,
 	locale: PropTypes.string,
 };
 

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -476,7 +476,7 @@ exports[`SnippetEditor activates a field on onClick() and opens the editor 1`] =
     isAmp={false}
     isDescriptionGenerated={false}
     keyword=""
-    locale="en_US"
+    locale="en"
     mode="mobile"
     onClick={[Function]}
     onHover={[Function]}
@@ -968,6 +968,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
       "textComponent": "span",
     }
   }
+  locale="en"
   mapDataToPreview={null}
   mode="mobile"
   onChange={[MockFunction]}
@@ -990,7 +991,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
       isAmp={false}
       isDescriptionGenerated={false}
       keyword=""
-      locale="en_US"
+      locale="en"
       mode="mobile"
       onClick={[Function]}
       onHover={[Function]}
@@ -2290,6 +2291,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
       "textComponent": "span",
     }
   }
+  locale="en"
   mapDataToPreview={null}
   mode="mobile"
   onChange={[MockFunction]}
@@ -2312,7 +2314,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
       isAmp={false}
       isDescriptionGenerated={false}
       keyword=""
-      locale="en_US"
+      locale="en"
       mode="mobile"
       onClick={[Function]}
       onHover={[Function]}
@@ -3612,6 +3614,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
       "textComponent": "span",
     }
   }
+  locale="en"
   mapDataToPreview={null}
   mode="mobile"
   onChange={[MockFunction]}
@@ -3634,7 +3637,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
       isAmp={false}
       isDescriptionGenerated={false}
       keyword=""
-      locale="en_US"
+      locale="en"
       mode="mobile"
       onClick={[Function]}
       onHover={[Function]}
@@ -4934,6 +4937,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
       "textComponent": "span",
     }
   }
+  locale="en"
   mapDataToPreview={null}
   mode="mobile"
   onChange={[Function]}
@@ -4956,7 +4960,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
       isAmp={false}
       isDescriptionGenerated={false}
       keyword=""
-      locale="en_US"
+      locale="en"
       mode="mobile"
       onClick={[Function]}
       onHover={[Function]}
@@ -6130,6 +6134,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
       "textComponent": "span",
     }
   }
+  locale="en"
   mapDataToPreview={null}
   mode="mobile"
   onChange={[Function]}
@@ -6152,7 +6157,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
       isAmp={false}
       isDescriptionGenerated={false}
       keyword=""
-      locale="en_US"
+      locale="en"
       mode="mobile"
       onClick={[Function]}
       onHover={[Function]}
@@ -7235,6 +7240,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
       "textComponent": "span",
     }
   }
+  locale="en"
   mapDataToPreview={null}
   mode="mobile"
   onChange={[Function]}
@@ -7257,7 +7263,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
       isAmp={false}
       isDescriptionGenerated={false}
       keyword=""
-      locale="en_US"
+      locale="en"
       mode="mobile"
       onClick={[Function]}
       onHover={[Function]}
@@ -8589,6 +8595,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
       "textComponent": "span",
     }
   }
+  locale="en"
   mapDataToPreview={null}
   mode="mobile"
   onChange={[Function]}
@@ -8611,7 +8618,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
       isAmp={false}
       isDescriptionGenerated={false}
       keyword=""
-      locale="en_US"
+      locale="en"
       mode="mobile"
       onClick={[Function]}
       onHover={[Function]}
@@ -9492,7 +9499,7 @@ exports[`SnippetEditor doesn't remove the highlight if the wrong field is left 1
     isAmp={false}
     isDescriptionGenerated={false}
     keyword=""
-    locale="en_US"
+    locale="en"
     mode="mobile"
     onClick={[Function]}
     onHover={[Function]}
@@ -10926,6 +10933,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
       "textComponent": "span",
     }
   }
+  locale="en"
   mapDataToPreview={null}
   mode="mobile"
   onChange={[Function]}
@@ -10948,7 +10956,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
       isAmp={false}
       isDescriptionGenerated={false}
       keyword=""
-      locale="en_US"
+      locale="en"
       mode="mobile"
       onClick={[Function]}
       onHover={[Function]}
@@ -12268,6 +12276,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
       "textComponent": "span",
     }
   }
+  locale="en"
   mapDataToPreview={null}
   mode="mobile"
   onChange={[Function]}
@@ -12290,7 +12299,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
       isAmp={false}
       isDescriptionGenerated={false}
       keyword=""
-      locale="en_US"
+      locale="en"
       mode="mobile"
       onClick={[Function]}
       onHover={[Function]}
@@ -13598,6 +13607,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
       "textComponent": "span",
     }
   }
+  locale="en"
   mapDataToPreview={null}
   mode="mobile"
   onChange={[Function]}
@@ -13620,7 +13630,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
       isAmp={false}
       isDescriptionGenerated={false}
       keyword=""
-      locale="en_US"
+      locale="en"
       mode="mobile"
       onClick={[Function]}
       onHover={[Function]}
@@ -14920,6 +14930,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
       "textComponent": "span",
     }
   }
+  locale="en"
   mapDataToPreview={null}
   mode="mobile"
   onChange={[Function]}
@@ -14953,7 +14964,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
       isAmp={false}
       isDescriptionGenerated={false}
       keyword=""
-      locale="en_US"
+      locale="en"
       mode="mobile"
       onClick={[Function]}
       onHover={[Function]}
@@ -16342,7 +16353,7 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
     isAmp={false}
     isDescriptionGenerated={false}
     keyword=""
-    locale="en_US"
+    locale="en"
     mode="mobile"
     onClick={[Function]}
     onHover={[Function]}

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -207,7 +207,7 @@ const Amp = styled.div`
 /**
  * Highlights a keyword with strong React elements.
  *
- * @param {string} locale Two character locale.
+ * @param {string} locale ISO 639 (2/3 characters) locale.
  * @param {string} keyword The keyword.
  * @param {string} text The text in which to highlight a keyword.
  *

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -207,7 +207,7 @@ const Amp = styled.div`
 /**
  * Highlights a keyword with strong React elements.
  *
- * @param {string} locale The locale.
+ * @param {string} locale Two character locale.
  * @param {string} keyword The keyword.
  * @param {string} text The text in which to highlight a keyword.
  *
@@ -727,7 +727,7 @@ SnippetPreview.defaultProps = {
 	keyword: "",
 	breadcrumbs: null,
 	isDescriptionGenerated: false,
-	locale: "en_US",
+	locale: "en",
 	hoveredField: "",
 	activeField: "",
 	mode: DEFAULT_MODE,


### PR DESCRIPTION
## Summary
Makes the `SnippetEditor` accept a locale prop that is passed down to the `SnippetPreview`.
Also changed the default locale from `en_US` to `en`.

This PR can be summarized in the following changelog entry:

* Not applicable

## Relevant technical choices:

* 

## Test instructions

This PR can be tested by following these steps:

* 

Fixes #518 
