### PR TITLE
Keyword highlighting in the description

### DIFF
--- a/app/SnippetEditorExample.js
+++ b/app/SnippetEditorExample.js
@@ -199,6 +199,7 @@ export default class SnippetEditorExample extends Component {
 				replacementVariables={ replacementVariables }
 				titleLengthAssessment={ titleLengthAssessment }
 				descriptionLengthAssessment={ descriptionLengthAssessment }
+				keyword="keyword"
 			/>
 
 			<h2>Test Sliders</h2>

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -46,6 +46,7 @@ class SnippetEditor extends React.Component {
 	 * @param {Object} props.replacementVariables        The replacement variables
 	 *                                                   for this editor.
 	 * @param {Object} props.data                        The initial editor data.
+	 * @param {string} props.keyword                     The focus keyword.
 	 * @param {string} props.data.title                  The initial title.
 	 * @param {string} props.data.slug                   The initial slug.
 	 * @param {string} props.data.description            The initial description.
@@ -299,6 +300,7 @@ class SnippetEditor extends React.Component {
 			data,
 			mode,
 			date,
+			keyword,
 		} = this.props;
 
 		const {
@@ -324,6 +326,7 @@ class SnippetEditor extends React.Component {
 					onMouseOver={ this.onMouseOver }
 					onMouseLeave={ this.onMouseLeave }
 					onClick={ this.onClick }
+					keyword={ keyword }
 					{ ...mappedData }
 				/>
 
@@ -355,6 +358,7 @@ SnippetEditor.propTypes = {
 	baseUrl: PropTypes.string.isRequired,
 	mode: PropTypes.oneOf( MODES ),
 	date: PropTypes.string,
+	keyword: PropTypes.string,
 	onChange: PropTypes.func.isRequired,
 	titleLengthAssessment: lengthAssessmentShape,
 	descriptionLengthAssessment: lengthAssessmentShape,


### PR DESCRIPTION
Pass along the keyword prop to the snippet preview to allow for keyword highlighting. Also added keyword as the keyword prop for the standalone version, to have it function there.

## Summary

This PR can be summarized in the following changelog entry:

*N/A

## Relevant technical choices:

* Passed it along as a separate prop, could have also made it part of the data shape.

## Test instructions

This PR can be tested by following these steps:

* On the standalone, add the word 'keyword' to the description, and check if it's highlighted.

Fixes #516 
