### PR TITLE
Quick fix warning custom_field replacevars

### DIFF
--- a/composites/Plugin/SnippetEditor/constants.js
+++ b/composites/Plugin/SnippetEditor/constants.js
@@ -8,5 +8,9 @@ export const lengthAssessmentShape = PropTypes.shape( {
 
 export const replacementVariablesShape = PropTypes.arrayOf( PropTypes.shape( {
 	name: PropTypes.string,
-	value: PropTypes.string,
+	value: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.object,
+		PropTypes.array,
+	] ),
 } ) );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* There was an error (see image) in a different PR related to the Snippet Editor replacevars.
<img width="1087" alt="gut_post___ _local_wordpress_test_ _wordpress" src="https://user-images.githubusercontent.com/11849359/39918842-08f67ecc-5512-11e8-9cde-ee6fa25ef812.png">

## Test instructions

This PR can be tested by following these steps:

* Navigate to pages with this branch and the PR on Wordpress-SEO checked out https://github.com/Yoast/wordpress-seo/pull/9678
* There should be no warning (compared to the old version of yoast-components).

**NOTE**: When this PR has been merged, yoast-components should be released and updated in wordpress-seo's (free and premium) package.json.
