### PR TITLE
Stories/9590 add trailing slashes to react snippet editor

### DIFF
--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -16768,7 +16768,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
               onMouseLeave={[Function]}
               onMouseOver={[Function]}
             >
-              example.org/test-slug
+              example.org/test-slug/
             </div>
           </div>
           <div

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -253,6 +253,16 @@ function highlightKeyword( locale, keyword, text, cleanText ) {
 	} );
 }
 
+/**
+ * Returns if a url has a trailing slash or not.
+ *
+ * @param {string} url The url to check for a trailing slash.
+ * @returns {boolean} Whether or not the url contains a trailing slash.
+ */
+function hasTrailingSlash( url ) {
+	return url.indexOf( "/" ) === ( url.length - 1 );
+}
+
 export default class SnippetPreview extends PureComponent {
 	/**
 	 * Renders the SnippetPreview component.
@@ -511,7 +521,10 @@ export default class SnippetPreview extends PureComponent {
 		 * returns an array of strings plus a strong React element, and replace()
 		 * can't run on an array.
 		 */
+		console.log( "Raw url: " + url );
 		let cleanUrl = replaceSpecialCharactersAndDiacritics( url );
+		console.log( "cleanUrl: " + cleanUrl );
+		console.log( "this.props.mode: " + this.props.mode );
 
 		if ( this.props.mode === MODE_MOBILE ) {
 			urlContent = this.getBreadcrumbs( cleanUrl );
@@ -520,6 +533,12 @@ export default class SnippetPreview extends PureComponent {
 		}
 
 		const Url = this.addCaretStyles( "url", BaseUrl );
+
+		console.log( "First: " + urlContent );
+		if ( ! hasTrailingSlash( urlContent ) ) {
+			urlContent = urlContent + "/";
+		}
+		console.log( "Then: " + urlContent );
 
 		/*
 		 * The jsx-a11y eslint plugin is asking for an onFocus accompanying the onMouseOver.
@@ -716,7 +735,6 @@ export default class SnippetPreview extends PureComponent {
 		const PartContainer = mode === MODE_DESKTOP ? DesktopPartContainer : MobilePartContainer;
 		const Container = mode === MODE_DESKTOP ? DesktopContainer : MobileContainer;
 		const TitleUnbounded = mode === MODE_DESKTOP ? TitleUnboundedDesktop : TitleUnboundedMobile;
-
 		const Title = this.addCaretStyles( "title", BaseTitle );
 
 		return {

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -515,6 +515,7 @@ export default class SnippetPreview extends PureComponent {
 		} = this.props;
 
 		let urlContent;
+		let defaultUrl = url;
 		/*
 		 * We need to replace special characters and diacritics only on the url
 		 * string because when highlightKeyword kicks in, interpolateComponents
@@ -528,12 +529,14 @@ export default class SnippetPreview extends PureComponent {
 		} else {
 			/*
 			* Check if the url in desktop mode has a trailing slash before
-			* highlighting any keywords in it.
+			* highlighting any keywords in it. Adds it for both the clean
+			* and the default url in case no keyword is defined.
 			*/
 			if ( ! hasTrailingSlash( cleanUrl ) ) {
 				cleanUrl = cleanUrl + "/";
+				defaultUrl = defaultUrl + "/";
 			}
-			urlContent = highlightKeyword( locale, keyword, url, cleanUrl );
+			urlContent = highlightKeyword( locale, keyword, defaultUrl, cleanUrl );
 		}
 
 		const Url = this.addCaretStyles( "url", BaseUrl );

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -526,10 +526,14 @@ export default class SnippetPreview extends PureComponent {
 		if ( this.props.mode === MODE_MOBILE ) {
 			urlContent = this.getBreadcrumbs( cleanUrl );
 		} else {
-			urlContent = highlightKeyword( locale, keyword, url, cleanUrl );
-			if ( ! hasTrailingSlash( urlContent ) ) {
-				urlContent = urlContent + "/";
+			/*
+			* Check if the url in desktop mode has a trailing slash before
+			* highlighting any keywords in it.
+			*/
+			if ( ! hasTrailingSlash( cleanUrl ) ) {
+				cleanUrl = cleanUrl + "/";
 			}
+			urlContent = highlightKeyword( locale, keyword, url, cleanUrl );
 		}
 
 		const Url = this.addCaretStyles( "url", BaseUrl );

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -528,10 +528,10 @@ export default class SnippetPreview extends PureComponent {
 			urlContent = this.getBreadcrumbs( cleanUrl );
 		} else {
 			/*
-			* Check if the url in desktop mode has a trailing slash before
-			* highlighting any keywords in it. Adds it for both the clean
-			* and the default url in case no keyword is defined.
-			*/
+			 * Check if the url in desktop mode has a trailing slash before
+			 * highlighting any keywords in it. Adds it for both the clean
+			 * and the default url in case no keyword is defined.
+			 */
 			if ( ! hasTrailingSlash( cleanUrl ) ) {
 				cleanUrl = cleanUrl + "/";
 				defaultUrl = defaultUrl + "/";

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -260,7 +260,7 @@ function highlightKeyword( locale, keyword, text, cleanText ) {
  * @returns {boolean} Whether or not the url contains a trailing slash.
  */
 function hasTrailingSlash( url ) {
-	return url.indexOf( "/" ) === ( url.length - 1 );
+	return url.lastIndexOf( "/" ) === ( url.length - 1 );
 }
 
 export default class SnippetPreview extends PureComponent {
@@ -521,25 +521,18 @@ export default class SnippetPreview extends PureComponent {
 		 * returns an array of strings plus a strong React element, and replace()
 		 * can't run on an array.
 		 */
-		console.log( "Raw url: " + url );
 		let cleanUrl = replaceSpecialCharactersAndDiacritics( url );
-		console.log( "cleanUrl: " + cleanUrl );
-		console.log( "this.props.mode: " + this.props.mode );
 
 		if ( this.props.mode === MODE_MOBILE ) {
 			urlContent = this.getBreadcrumbs( cleanUrl );
 		} else {
 			urlContent = highlightKeyword( locale, keyword, url, cleanUrl );
+			if ( ! hasTrailingSlash( urlContent ) ) {
+				urlContent = urlContent + "/";
+			}
 		}
 
 		const Url = this.addCaretStyles( "url", BaseUrl );
-
-		console.log( "First: " + urlContent );
-		if ( ! hasTrailingSlash( urlContent ) ) {
-			urlContent = urlContent + "/";
-		}
-		console.log( "Then: " + urlContent );
-
 		/*
 		 * The jsx-a11y eslint plugin is asking for an onFocus accompanying the onMouseOver.
 		 * However this is not relevant in this case, because the url is not focusable.

--- a/composites/Plugin/SnippetPreview/tests/SnippetPreviewTest.js
+++ b/composites/Plugin/SnippetPreview/tests/SnippetPreviewTest.js
@@ -78,6 +78,19 @@ describe( "SnippetPreview", () => {
 		} );
 	} );
 
+	it( "adds a trailing slash to the url", () => {
+		const wrapper = mountWithArgs( { mode: MODE_DESKTOP, url: "https://example.org/this-url" } );
+
+		expect( wrapper.find( "SnippetPreview__BaseUrlOverflowContainer" ).text() ).toBe( "https://example.org/this-url/" );
+	} );
+
+	it( "does not add a trailing slash to the url", () => {
+		const wrapper = mountWithArgs( { mode: MODE_DESKTOP, url: "https://example.org/this-url/" } );
+
+		expect( wrapper.find( "SnippetPreview__BaseUrlOverflowContainer" ).text() ).toBe( "https://example.org/this-url/" );
+
+	} );
+
 	describe( "mobile mode", () => {
 		it( "renders differently than desktop", () => {
 			renderSnapshotWithArgs( { mode: MODE_MOBILE } );

--- a/composites/Plugin/SnippetPreview/tests/SnippetPreviewTest.js
+++ b/composites/Plugin/SnippetPreview/tests/SnippetPreviewTest.js
@@ -88,7 +88,6 @@ describe( "SnippetPreview", () => {
 		const wrapper = mountWithArgs( { mode: MODE_DESKTOP, url: "https://example.org/this-url/" } );
 
 		expect( wrapper.find( "SnippetPreview__BaseUrlOverflowContainer" ).text() ).toBe( "https://example.org/this-url/" );
-
 	} );
 
 	describe( "mobile mode", () => {

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -546,7 +546,11 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
           >
-            https://example.org/this,[object Object],url/
+            https://example.org/this
+            <strong>
+              -keyword-
+            </strong>
+            url/
           </div>
         </div>
         <div

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -155,7 +155,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
           >
-            https://example.org
+            https://example.org/
           </div>
         </div>
         <div
@@ -349,7 +349,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
           >
-            https://example.org
+            https://example.org/
           </div>
         </div>
         <div
@@ -546,11 +546,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
           >
-            https://example.org/this
-            <strong>
-              -keyword-
-            </strong>
-            url
+            https://example.org/this,[object Object],url/
           </div>
         </div>
         <div
@@ -1376,7 +1372,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
           >
-            https://example.org
+            https://example.org/
           </div>
         </div>
         <div
@@ -1582,7 +1578,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
           >
-            https://example.org
+            https://example.org/
           </div>
         </div>
         <div
@@ -1788,7 +1784,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
           >
-            https://example.org
+            https://example.org/
           </div>
         </div>
         <div
@@ -1994,7 +1990,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
           >
-            https://example.org
+            https://example.org/
           </div>
         </div>
         <div
@@ -2200,7 +2196,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
           >
-            https://example.org
+            https://example.org/
           </div>
         </div>
         <div
@@ -2406,7 +2402,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
           >
-            https://example.org
+            https://example.org/
           </div>
         </div>
         <div
@@ -2612,7 +2608,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
           >
-            https://example.org
+            https://example.org/
           </div>
         </div>
         <div
@@ -2810,7 +2806,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
           >
-            https://example.org
+            https://example.org/
           </div>
         </div>
         <div


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds trailing slashes to the url in the desktop mode

## Relevant technical choices:

* Checks the slug for trailing slashes and adds one in case it is missing. Fixes the bug in the old snippet editor that added additional slashes when already present.

## Test instructions

This PR can be tested by following these steps:

* Run `yarn start` and go the stand-alone snippet preview on localhost:3333
* Edit snippet and type something in the slug field
* There should be a trailing slash in the url, even if you did not end the slug text with one
* There should be no extra slashes if you have one or more slashes at the end of the slug text (i.e. if you have two slashes in the slug text, two should be present in the url).

Fixes https://github.com/Yoast/wordpress-seo/issues/9590