### PR TITLE
Remove keyword highlighting from desktop url

### DIFF
--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -510,33 +510,27 @@ export default class SnippetPreview extends PureComponent {
 			onClick,
 			onMouseOver,
 			onMouseLeave,
-			locale,
-			keyword,
 		} = this.props;
 
-		let urlContent;
-		let defaultUrl = url;
 		/*
 		 * We need to replace special characters and diacritics only on the url
 		 * string because when highlightKeyword kicks in, interpolateComponents
 		 * returns an array of strings plus a strong React element, and replace()
 		 * can't run on an array.
 		 */
-		let cleanUrl = replaceSpecialCharactersAndDiacritics( url );
+		let urlContent = replaceSpecialCharactersAndDiacritics( url );
 
 		if ( this.props.mode === MODE_MOBILE ) {
-			urlContent = this.getBreadcrumbs( cleanUrl );
+			urlContent = this.getBreadcrumbs( urlContent );
 		} else {
 			/*
 			 * Check if the url in desktop mode has a trailing slash before
 			 * highlighting any keywords in it. Adds it for both the clean
 			 * and the default url in case no keyword is defined.
 			 */
-			if ( ! hasTrailingSlash( cleanUrl ) ) {
-				cleanUrl = cleanUrl + "/";
-				defaultUrl = defaultUrl + "/";
+			if ( ! hasTrailingSlash( urlContent ) ) {
+				urlContent = urlContent + "/";
 			}
-			urlContent = highlightKeyword( locale, keyword, defaultUrl, cleanUrl );
 		}
 
 		const Url = this.addCaretStyles( "url", BaseUrl );

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -546,11 +546,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
             onMouseLeave={[Function]}
             onMouseOver={[Function]}
           >
-            https://example.org/this
-            <strong>
-              -keyword-
-            </strong>
-            url/
+            https://example.org/this-keyword-url/
           </div>
         </div>
         <div


### PR DESCRIPTION
## Summary

Removes the keyword highlighting from the desktop url in the snippet preview.

This PR can be summarized in the following changelog entry:

* Not applicable

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* In the old change the props in `SnippetEditorExample` so that the `keyword` appears in the `url` as a separate word (eg. `keyword: "welcome"` and `url: "https://local.wordpress.test/welcome-to-the-gutenberg-editor-2/"`). Make sure the keyword is highlighted in the snippet editor.
* Switch to this branch and make sure the keyword is no longer highlighted.

Fixes #524 
