### PR TITLE
Update DraftJS Mention Plugin.

### DIFF
--- a/app/SnippetEditorExample.js
+++ b/app/SnippetEditorExample.js
@@ -43,8 +43,8 @@ export default class SnippetEditorExample extends Component {
 
 		this.state = {
 			title: "Welcome to the Gutenberg Editor - Local WordPress Dev. Snippet Title Snippet" +
-			" Title Snippet Title Snippet Title Snippet Title Snippet Title Snippet Title Snippet" +
-			" Title Snippet Title Snippet Title Snippet Title Snippet Title",
+			" Snippet: %%snippet%% Title: %%title%% Manual: %%snippet_manual%% Type: %%post_type%%" +
+			" %%these%% %%are%% %%not%% %%tags%% and throw in some % here %%%%%%% and %%there too%%",
 			url: "https://local.wordpress.test/welcome-to-the-gutenberg-editor-2/",
 			slug: "welcome-to-the-gutenberg-editor-2",
 			description: "Merci, merçi, Of Mountains & Printing Presses The goal of this new editor is to make" +

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -18,7 +18,6 @@ import { serializeEditor, unserializeEditor } from "../serialization";
  * @returns {EditorState} The editor state.
  */
 const createEditorState = flow( [
-	unserializeEditor,
 	convertFromRaw,
 	EditorState.createWithContent,
 ] );
@@ -64,11 +63,12 @@ class ReplacementVariableEditor extends React.Component {
 	constructor( props ) {
 		super( props );
 
-		const { content: rawContent } = this.props;
+		const { content: rawContent, replacementVariables } = this.props;
+		const unserialized = unserializeEditor( rawContent, replacementVariables );
 
 		this.state = {
-			editorState: createEditorState( rawContent ),
-			replacementVariables: props.replacementVariables,
+			editorState: createEditorState( unserialized ),
+			replacementVariables,
 		};
 
 		/*

--- a/composites/Plugin/SnippetEditor/serialization.js
+++ b/composites/Plugin/SnippetEditor/serialization.js
@@ -2,7 +2,7 @@ import forEach from "lodash/forEach";
 import sortedIndexBy from "lodash/sortedIndexBy";
 import trim from "lodash/trim";
 
-const AFFIX = "%%";
+const CIRCUMFIX = "%%";
 
 /**
  * Serializes a tag into a string.
@@ -12,7 +12,7 @@ const AFFIX = "%%";
  * @returns {string} Serialized tag.
  */
 export function serializeTag( name ) {
-	return AFFIX + name + AFFIX;
+	return CIRCUMFIX + name + CIRCUMFIX;
 }
 
 /**
@@ -68,7 +68,7 @@ export function serializeEditor( rawContent ) {
  * @returns {string} Unserialized tag.
  */
 export function unserializeTag( serializedTag ) {
-	return trim( serializedTag, AFFIX );
+	return trim( serializedTag, CIRCUMFIX );
 }
 
 /**
@@ -167,7 +167,7 @@ export function unserializeEditor( content, tags ) {
 		content = before + between + after;
 
 		// Decrease the offset by twice the length of the affix for every index we replace.
-		const offset = index - i * AFFIX.length * 2;
+		const offset = index - i * CIRCUMFIX.length * 2;
 		const key = entityRanges.length;
 
 		// Create the DraftJS data.

--- a/composites/Plugin/SnippetEditor/serialization.js
+++ b/composites/Plugin/SnippetEditor/serialization.js
@@ -28,7 +28,7 @@ export function serializeBlock( entityMap, block ) {
 		const beforeEntityLength = offset - previousEntityEnd;
 
 		const beforeEntity = text.substr( previousEntityEnd, beforeEntityLength );
-		const serializedEntity = serializeEntity( entityMap[ key ].data.mention.get( "name" ) );
+		const serializedEntity = serializeEntity( entityMap[ key ].data.mention.name );
 
 		previousEntityEnd = offset + length;
 		return serialized + beforeEntity + serializedEntity;
@@ -74,13 +74,12 @@ export function unserializeEntity( key, name, offset ) {
 
 	const mappedEntity = {
 		data: {
-			mention: new Map( [
-				[ "name", name ],
-				[ "description", "%%" + name + "%%" ],
-			] ),
+			mention: {
+				name,
+			},
 		},
 		mutability: "IMMUTABLE",
-		type: "%%mention",
+		type: "%mention",
 	};
 
 	return { entityRange, mappedEntity };

--- a/composites/Plugin/SnippetEditor/serialization.js
+++ b/composites/Plugin/SnippetEditor/serialization.js
@@ -176,14 +176,12 @@ export function unserializeEditor( content, tags ) {
 		// Create the DraftJS data.
 		const { entityRange, mappedEntity } = unserializeEntity( key, tag.name, offset );
 		entityRanges.push( entityRange );
-
 		entityMap[ key ] = mappedEntity;
 	}
 
 	const blocks = [ {
 		entityRanges,
 		text: content,
-
 	} ];
 
 	return {

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
@@ -161,7 +161,7 @@ exports[`ReplacementVariableEditor wraps a DraftJS editor instance 1`] = `
     }
     stripPastedStyles={true}
   />
-  <Decorated(Component)
+  <Decorated(MentionSuggestions)
     onSearchChange={[Function]}
   />
 </React.Fragment>

--- a/composites/Plugin/SnippetEditor/tests/serializationTest.js
+++ b/composites/Plugin/SnippetEditor/tests/serializationTest.js
@@ -1,5 +1,11 @@
 import { serializeEditor, unserializeEditor } from "../serialization";
 
+const TAGS = [
+	{ name: "title", value: "Title" },
+	{ name: "post_type", value: "Gallery" },
+];
+
+
 describe( "editor serialization", () => {
 	it( "transforms the deep structure to a plain string", () => {
 		const structure = {
@@ -10,22 +16,26 @@ describe( "editor serialization", () => {
 				depth: 0,
 				inlineStyleRanges: [],
 				entityRanges: [ {
+					offset: 6,
+					length: 9,
+					key: 0,
+				}, {
 					offset: 0,
 					length: 5,
-					key: 0,
-				}, { offset: 6, length: 9, key: 1 } ],
+					key: 1,
+				} ],
 				data: {},
 			} ],
 			entityMap: {
 				0: {
-					type: "%%mention",
+					type: "%mention",
 					mutability: "IMMUTABLE",
-					data: { mention: new Map( [ [ "name", "title" ], [ "description", "%%title%%" ] ] ) },
+					data: { mention: { name: "post_type" } },
 				},
 				1: {
-					type: "%%mention",
+					type: "%mention",
 					mutability: "IMMUTABLE",
-					data: { mention: new Map( [ [ "name", "post_type" ], [ "description", "%%post_type%%" ] ] ) },
+					data: { mention: { name: "title" } },
 				},
 			},
 		};
@@ -44,26 +54,30 @@ describe( "editor unserialization", () => {
 			blocks: [ {
 				text: "title post_type test test123",
 				entityRanges: [ {
+					offset: 6,
+					length: 9,
+					key: 0,
+				}, {
 					offset: 0,
 					length: 5,
-					key: 0,
-				}, { offset: 6, length: 9, key: 1 } ],
+					key: 1,
+				} ],
 			} ],
 			entityMap: {
 				0: {
-					type: "%%mention",
+					type: "%mention",
 					mutability: "IMMUTABLE",
-					data: { mention: new Map( [ [ "name", "title" ], [ "description", "%%title%%" ] ] ) },
+					data: { mention: { name: "post_type" } },
 				},
 				1: {
-					type: "%%mention",
+					type: "%mention",
 					mutability: "IMMUTABLE",
-					data: { mention: new Map( [ [ "name", "post_type" ], [ "description", "%%post_type%%" ] ] ) },
+					data: { mention: { name: "title" } },
 				},
 			},
 		};
 
-		const actual = unserializeEditor( input );
+		const actual = unserializeEditor( input, TAGS );
 
 		expect( actual ).toEqual( expected );
 	} );
@@ -72,7 +86,7 @@ describe( "editor unserialization", () => {
 		const input = "The first thing, %%title%%, %%post_type%% type.";
 		const expected = input;
 
-		const actual = serializeEditor( unserializeEditor( input ) );
+		const actual = serializeEditor( unserializeEditor( input, TAGS ) );
 
 		expect( actual ).toBe( expected );
 	} );

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "algoliasearch": "^3.22.3",
     "debug": "^3.0.0",
     "draft-js": "^0.10.5",
-    "draft-js-mention-plugin": "^2.0.1",
+    "draft-js-mention-plugin": "^3.0.4",
     "draft-js-plugins-editor": "^2.0.4",
     "grunt-scss-to-json": "^1.0.1",
     "interpolate-components": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2442,12 +2442,12 @@ domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
-draft-js-mention-plugin@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/draft-js-mention-plugin/-/draft-js-mention-plugin-2.0.1.tgz#388e39861df25d61c3de577799a69c92374e206a"
+draft-js-mention-plugin@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/draft-js-mention-plugin/-/draft-js-mention-plugin-3.0.4.tgz#e8530b7c16f23ce5b980515458418b5e24376f4a"
   dependencies:
     decorate-component-with-props "^1.0.2"
-    find-with-regex "^1.0.2"
+    find-with-regex "^1.1.3"
     immutable "~3.7.4"
     lodash.escaperegexp "^4.1.2"
     prop-types "^15.5.8"
@@ -3169,7 +3169,7 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-find-with-regex@^1.0.2, find-with-regex@^1.1.3:
+find-with-regex@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/find-with-regex/-/find-with-regex-1.1.3.tgz#d6c6f2debee898d36b6a77e05709b13dd5dc8a26"
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Updated `draft-js-mention-plugin` to get rid of the console warning.
*  Refactored `serialize` and `unserialize`. Partly for the major version upgrade. And partly for the marking issue.
* Now passes the tags along to ignore non-tag affix matches.

## Test instructions

This PR can be tested by following these steps:

* Run the tests.
* Check in the stand-alone.
* Link with the plugin and test.

Fixes https://github.com/Yoast/wordpress-seo/issues/9684 and https://github.com/Yoast/wordpress-seo/issues/9653
