### PR TITLE
Add metadescription placeholder

### DIFF
--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -299,6 +299,7 @@ class SnippetEditor extends React.Component {
 		const {
 			onChange,
 			data,
+			descriptionPlaceholder,
 			mode,
 			date,
 			locale,
@@ -330,6 +331,7 @@ class SnippetEditor extends React.Component {
 					onMouseLeave={ this.onMouseLeave }
 					onClick={ this.onClick }
 					locale={ locale }
+					descriptionPlaceholder={ descriptionPlaceholder }
 					{ ...mappedData }
 				/>
 
@@ -358,6 +360,7 @@ SnippetEditor.propTypes = {
 		slug: PropTypes.string.isRequired,
 		description: PropTypes.string.isRequired,
 	} ).isRequired,
+	descriptionPlaceholder: PropTypes.string,
 	baseUrl: PropTypes.string.isRequired,
 	mode: PropTypes.oneOf( MODES ),
 	date: PropTypes.string,

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -430,6 +430,10 @@ export default class SnippetPreview extends PureComponent {
 	 * @returns {string} The description to render.
 	 */
 	getDescription() {
+		if ( ! this.props.description && this.props.descriptionPlaceholder ) {
+			return this.props.descriptionPlaceholder;
+		}
+
 		if ( this.props.mode === MODE_MOBILE && this.props.description !== this.state.description ) {
 			return this.state.description + " ...";
 		}
@@ -749,6 +753,7 @@ SnippetPreview.propTypes = {
 	title: PropTypes.string.isRequired,
 	url: PropTypes.string.isRequired,
 	description: PropTypes.string.isRequired,
+	descriptionPlaceholder: PropTypes.string,
 	date: PropTypes.string,
 	breadcrumbs: PropTypes.array,
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* We decided to add a placeholder for the description to be passed as a prop, to which the description should default if it is empty.

## Test instructions

This PR can be tested by following these steps:

* Checkout wordpress-seo PR: 
* Link yoast-components (checked out to this branch).
* See that the snippet preview shows the placeholder when you empty the meta description in the snippet editor.

Fixes #https://github.com/Yoast/wordpress-seo/issues/9736
