### PR TITLE
Fix snippet editor JS error with invalid RawDraftContentState

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -215,7 +215,7 @@ class ReplacementVariableEditor extends React.Component {
 
 		if (
 			( nextProps.content !== this._serializedContent && nextProps.content !== content ) ||
-		    nextProps.replacementVariables !== replacementVariables
+			nextProps.replacementVariables !== replacementVariables
 		) {
 			this._serializedContent = nextProps.content;
 			const unserialized = unserializeEditor( nextProps.content, nextProps.replacementVariables );

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -71,6 +71,7 @@ class ReplacementVariableEditor extends React.Component {
 
 		this.state = {
 			editorState: createEditorState( unserialized ),
+			searchValue: "",
 			replacementVariables,
 		};
 
@@ -125,9 +126,9 @@ class ReplacementVariableEditor extends React.Component {
 	onChange( editorState ) {
 		this.setState( {
 			editorState,
+		}, () => {
+			this.serializeContent( editorState );
 		} );
-
-		this.serializeContent( editorState );
 	}
 
 	/**
@@ -139,6 +140,7 @@ class ReplacementVariableEditor extends React.Component {
 	 */
 	onSearchChange( { value } ) {
 		this.setState( {
+			searchValue: value,
 			replacementVariables: defaultSuggestionsFilter( value, this.props.replacementVariables ),
 		} );
 
@@ -208,11 +210,19 @@ class ReplacementVariableEditor extends React.Component {
 	 * @returns {void}
 	 */
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.content !== this._serializedContent ) {
+		const { content, replacementVariables } = this.props;
+		const { searchValue } = this.state;
+
+		if (
+			( nextProps.content !== this._serializedContent && nextProps.content !== content ) ||
+		    nextProps.replacementVariables !== replacementVariables
+		) {
 			this._serializedContent = nextProps.content;
+			const unserialized = unserializeEditor( nextProps.content, nextProps.replacementVariables );
 
 			this.setState( {
-				editorState: createEditorState( nextProps.content ),
+				editorState: createEditorState( unserialized ),
+				replacementVariables: defaultSuggestionsFilter( searchValue, nextProps.replacementVariables ),
 			} );
 		}
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a problem with the Snippet Editor where it would crash when receiving new content.

## Relevant technical choices:

* Unserialize the new content in componentWillReceiveProps.
* Add extra check to test equality for when we received the old content as if it was new.
* Add ReplacementVariables to the componentWillReceiveProps as well to work correctly with the changing custom fields replacement variables.

## Test instructions

This PR can be tested by following these steps:

* In the standalone app, it should no longer crash immediately after changing the title.
* In combination with the Yoast SEO plugin:
  - Test if you no longer see the JS Error (did not occur always like in the standalone).
  - When you add, update or remove a custom field in a post you should see this reflected in the 
 replacement variables in the Snippet Editor right away. Where removing the custom field if you have it in the title you should see the `%%cf_<name_of_custom_field>%%` instead.

Fixes #534 
