### PR TITLE
Fix snippet preview overflow with long text.

### DIFF
--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -60,7 +60,7 @@ const InputContainer = styled.div.attrs( {
 	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
 	font-size: 14px;
 	margin-top: 5px;
-	
+
 	&::before {
 		display: block;
 		position: absolute;

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -70,7 +70,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   align-self: center;
 }
 
-.c29 {
+.c28 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -81,7 +81,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   padding-left: 8px;
 }
 
-.c29 svg {
+.c28 svg {
   margin-right: 7px;
 }
 
@@ -185,11 +185,11 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -215,7 +215,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -223,16 +223,12 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -245,7 +241,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   margin: 0;
 }
 
-.c25 {
+.c24 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -259,8 +255,8 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c25:hover,
-.c25:focus {
+.c24:hover,
+.c24:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -269,7 +265,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   box-shadow: none;
 }
 
-.c27 {
+.c26 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -283,8 +279,8 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c27:hover,
-.c27:focus {
+.c26:hover,
+.c26:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -293,7 +289,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   box-shadow: none;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -311,7 +307,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   flex: none;
 }
 
-.c26 {
+.c25 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -319,7 +315,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   flex: none;
 }
 
-.c28 {
+.c27 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -474,14 +470,14 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c21 c22"
+          className="c21"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
         >
           <div
-            className="c23 c21 c22"
+            className="c22 c21"
             color="#545454"
           >
             Totally different description
@@ -491,17 +487,17 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
     </div>
   </section>
   <div
-    className="c24"
+    className="c23"
   >
     <button
       aria-pressed={true}
-      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c26"
+        className="yoast-svg-icon yoast-svg-icon-mobile c25"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -530,13 +526,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c28"
+        className="yoast-svg-icon yoast-svg-icon-desktop c27"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -566,7 +562,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+    className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
     onClick={[Function]}
     type="button"
   >
@@ -732,7 +728,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   align-self: center;
 }
 
-.c29 {
+.c28 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -743,11 +739,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   padding-left: 8px;
 }
 
-.c29 svg {
+.c28 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -856,11 +852,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -886,7 +882,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -894,16 +890,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -916,71 +908,71 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   margin: 0;
 }
 
-.c34 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c34::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c34::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c34::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c34::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
-  background-color: #ee7c1b;
-  border: 0;
-}
-
 .c33 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c33::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c33::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c33::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c33::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
+  border: 0;
+}
+
+.c32 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -995,7 +987,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   margin-top: 5px;
 }
 
-.c33::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -1007,7 +999,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   content: "";
 }
 
-.c36 {
+.c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -1025,7 +1017,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   line-height: 19.6px;
 }
 
-.c36::before {
+.c35::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -1037,7 +1029,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   content: "";
 }
 
-.c35 {
+.c34 {
   border: none;
   width: 100%;
   height: inherit;
@@ -1047,25 +1039,25 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   color: inherit;
 }
 
-.c35:focus {
+.c34:focus {
   outline: 0;
 }
 
-.c31 {
+.c30 {
   margin: 32px 0;
 }
 
-.c30 {
+.c29 {
   padding: 10px 20px 20px 20px;
 }
 
-.c32 {
+.c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c25 {
+.c24 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -1079,8 +1071,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border-radius: 3px 0 0 3px;
 }
 
-.c25:hover,
-.c25:focus {
+.c24:hover,
+.c24:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -1089,7 +1081,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   box-shadow: none;
 }
 
-.c27 {
+.c26 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -1103,8 +1095,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border-radius: 0 3px 3px 0;
 }
 
-.c27:hover,
-.c27:focus {
+.c26:hover,
+.c26:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -1113,7 +1105,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   box-shadow: none;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -1131,7 +1123,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   flex: none;
 }
 
-.c26 {
+.c25 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -1139,7 +1131,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   flex: none;
 }
 
-.c28 {
+.c27 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -1603,14 +1595,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   onMouseOver={[Function]}
                 >
                   <SnippetPreview__DesktopDescription
-                    className="c21"
+                    className=""
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
                     onMouseOver={[Function]}
                   >
                     <div
-                      className="c21 c22"
+                      className="c21"
                       color="#545454"
                       onClick={[Function]}
                       onMouseLeave={[Function]}
@@ -1620,15 +1612,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         innerRef={[Function]}
                       >
                         <SnippetPreview__MobileDescription
-                          className="c23"
+                          className="c22"
                           innerRef={[Function]}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c23 c21"
+                            className="c22 "
                             innerRef={[Function]}
                           >
                             <div
-                              className="c23 c21 c22"
+                              className="c22 c21"
                               color="#545454"
                             >
                               Test description, %%replacement_variable%%
@@ -1651,7 +1643,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c24"
+          className="c23"
         >
           <ModeSwitcher__SwitcherButton
             aria-pressed={true}
@@ -1660,7 +1652,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           >
             <Button
               aria-pressed={true}
-              className="c25"
+              className="c24"
               isActive={true}
               onClick={[Function]}
             >
@@ -1669,7 +1661,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c24 c2"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -1680,7 +1672,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c24 c2 Button-kDSBcD c3"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -1691,7 +1683,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -1702,7 +1694,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -1713,7 +1705,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -1721,7 +1713,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       >
                         <button
                           aria-pressed={true}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -1742,7 +1734,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c26"
+                                className="yoast-svg-icon yoast-svg-icon-mobile c25"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -1798,7 +1790,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           >
             <Button
               aria-pressed={false}
-              className="c27"
+              className="c26"
               isActive={false}
               onClick={[Function]}
             >
@@ -1807,7 +1799,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 c2"
+                className="c26 c2"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -1818,7 +1810,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 c2 Button-kDSBcD c3"
+                  className="c26 c2 Button-kDSBcD c3"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -1829,7 +1821,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -1840,7 +1832,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -1851,7 +1843,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
@@ -1859,7 +1851,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       >
                         <button
                           aria-pressed={false}
-                          className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -1880,7 +1872,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c28"
+                                className="yoast-svg-icon yoast-svg-icon-desktop c27"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -1942,7 +1934,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c29"
+        className="c28"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -1953,7 +1945,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c29 Button-kDSBcD c3"
+          className="c28 Button-kDSBcD c3"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -1964,7 +1956,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c29 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -1975,7 +1967,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -1986,7 +1978,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -1994,7 +1986,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               >
                 <button
                   aria-expanded={true}
-                  className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -2064,18 +2056,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
     >
       <SnippetEditorFields__StyledEditor>
         <section
-          className="c30"
+          className="c29"
         >
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-5-title"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-5-title"
                   onClick={[Function]}
                 >
@@ -2087,7 +2079,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-5-title"
@@ -2110,7 +2102,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               >
                 <progress
                   aria-hidden="true"
-                  className="c34"
+                  className="c33"
                   max={600}
                   value={0}
                 />
@@ -2119,14 +2111,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-5-slug"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-5-slug"
                   onClick={[Function]}
                 >
@@ -2138,7 +2130,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <SnippetEditorFields__SlugInput
                     aria-labelledby="snippet-editor-field-5-slug"
@@ -2149,7 +2141,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   >
                     <ControlledInput
                       aria-labelledby="snippet-editor-field-5-slug"
-                      className="c35"
+                      className="c34"
                       initialValue="test-slug"
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -2157,7 +2149,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     >
                       <input
                         aria-labelledby="snippet-editor-field-5-slug"
-                        className="c35"
+                        className="c34"
                         onChange={[Function]}
                         onFocus={[Function]}
                         value="test-slug"
@@ -2170,14 +2162,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-5-description"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-5-description"
                   onClick={[Function]}
                 >
@@ -2189,7 +2181,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 isHovered={false}
               >
                 <div
-                  className="c36"
+                  className="c35"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-5-description"
@@ -2212,7 +2204,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               >
                 <progress
                   aria-hidden="true"
-                  className="c37"
+                  className="c36"
                   max={320}
                   value={42}
                 />
@@ -2229,7 +2221,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c38"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -2238,7 +2230,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -2247,7 +2239,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -2256,7 +2248,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -2265,13 +2257,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -2357,7 +2349,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   align-self: center;
 }
 
-.c29 {
+.c28 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -2368,11 +2360,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   padding-left: 8px;
 }
 
-.c29 svg {
+.c28 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -2481,11 +2473,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -2511,7 +2503,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -2519,16 +2511,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -2541,71 +2529,71 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   margin: 0;
 }
 
-.c34 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c34::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c34::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c34::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c34::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
-  background-color: #ee7c1b;
-  border: 0;
-}
-
 .c33 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c33::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c33::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c33::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c33::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
+  border: 0;
+}
+
+.c32 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -2620,7 +2608,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   margin-top: 5px;
 }
 
-.c33::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -2632,7 +2620,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   content: "";
 }
 
-.c36 {
+.c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -2650,7 +2638,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   line-height: 19.6px;
 }
 
-.c36::before {
+.c35::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -2662,7 +2650,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   content: "";
 }
 
-.c35 {
+.c34 {
   border: none;
   width: 100%;
   height: inherit;
@@ -2672,25 +2660,25 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   color: inherit;
 }
 
-.c35:focus {
+.c34:focus {
   outline: 0;
 }
 
-.c31 {
+.c30 {
   margin: 32px 0;
 }
 
-.c30 {
+.c29 {
   padding: 10px 20px 20px 20px;
 }
 
-.c32 {
+.c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c25 {
+.c24 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -2704,8 +2692,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border-radius: 3px 0 0 3px;
 }
 
-.c25:hover,
-.c25:focus {
+.c24:hover,
+.c24:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -2714,7 +2702,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   box-shadow: none;
 }
 
-.c27 {
+.c26 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -2728,8 +2716,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border-radius: 0 3px 3px 0;
 }
 
-.c27:hover,
-.c27:focus {
+.c26:hover,
+.c26:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -2738,7 +2726,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   box-shadow: none;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -2756,7 +2744,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   flex: none;
 }
 
-.c26 {
+.c25 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -2764,7 +2752,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   flex: none;
 }
 
-.c28 {
+.c27 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -3228,14 +3216,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   onMouseOver={[Function]}
                 >
                   <SnippetPreview__DesktopDescription
-                    className="c21"
+                    className=""
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
                     onMouseOver={[Function]}
                   >
                     <div
-                      className="c21 c22"
+                      className="c21"
                       color="#545454"
                       onClick={[Function]}
                       onMouseLeave={[Function]}
@@ -3245,15 +3233,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         innerRef={[Function]}
                       >
                         <SnippetPreview__MobileDescription
-                          className="c23"
+                          className="c22"
                           innerRef={[Function]}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c23 c21"
+                            className="c22 "
                             innerRef={[Function]}
                           >
                             <div
-                              className="c23 c21 c22"
+                              className="c22 c21"
                               color="#545454"
                             >
                               Test description, %%replacement_variable%%
@@ -3276,7 +3264,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c24"
+          className="c23"
         >
           <ModeSwitcher__SwitcherButton
             aria-pressed={true}
@@ -3285,7 +3273,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           >
             <Button
               aria-pressed={true}
-              className="c25"
+              className="c24"
               isActive={true}
               onClick={[Function]}
             >
@@ -3294,7 +3282,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c24 c2"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -3305,7 +3293,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c24 c2 Button-kDSBcD c3"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -3316,7 +3304,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -3327,7 +3315,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -3338,7 +3326,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -3346,7 +3334,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       >
                         <button
                           aria-pressed={true}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -3367,7 +3355,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c26"
+                                className="yoast-svg-icon yoast-svg-icon-mobile c25"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -3423,7 +3411,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           >
             <Button
               aria-pressed={false}
-              className="c27"
+              className="c26"
               isActive={false}
               onClick={[Function]}
             >
@@ -3432,7 +3420,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 c2"
+                className="c26 c2"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -3443,7 +3431,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 c2 Button-kDSBcD c3"
+                  className="c26 c2 Button-kDSBcD c3"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -3454,7 +3442,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -3465,7 +3453,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -3476,7 +3464,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
@@ -3484,7 +3472,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       >
                         <button
                           aria-pressed={false}
-                          className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -3505,7 +3493,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c28"
+                                className="yoast-svg-icon yoast-svg-icon-desktop c27"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -3567,7 +3555,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c29"
+        className="c28"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -3578,7 +3566,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c29 Button-kDSBcD c3"
+          className="c28 Button-kDSBcD c3"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -3589,7 +3577,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c29 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -3600,7 +3588,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -3611,7 +3599,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -3619,7 +3607,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               >
                 <button
                   aria-expanded={true}
-                  className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -3689,18 +3677,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
     >
       <SnippetEditorFields__StyledEditor>
         <section
-          className="c30"
+          className="c29"
         >
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-5-title"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-5-title"
                   onClick={[Function]}
                 >
@@ -3712,7 +3700,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-5-title"
@@ -3735,7 +3723,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               >
                 <progress
                   aria-hidden="true"
-                  className="c34"
+                  className="c33"
                   max={600}
                   value={0}
                 />
@@ -3744,14 +3732,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-5-slug"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-5-slug"
                   onClick={[Function]}
                 >
@@ -3763,7 +3751,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <SnippetEditorFields__SlugInput
                     aria-labelledby="snippet-editor-field-5-slug"
@@ -3774,7 +3762,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   >
                     <ControlledInput
                       aria-labelledby="snippet-editor-field-5-slug"
-                      className="c35"
+                      className="c34"
                       initialValue="test-slug"
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -3782,7 +3770,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     >
                       <input
                         aria-labelledby="snippet-editor-field-5-slug"
-                        className="c35"
+                        className="c34"
                         onChange={[Function]}
                         onFocus={[Function]}
                         value="test-slug"
@@ -3795,14 +3783,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-5-description"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-5-description"
                   onClick={[Function]}
                 >
@@ -3814,7 +3802,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 isHovered={false}
               >
                 <div
-                  className="c36"
+                  className="c35"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-5-description"
@@ -3837,7 +3825,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               >
                 <progress
                   aria-hidden="true"
-                  className="c37"
+                  className="c36"
                   max={320}
                   value={42}
                 />
@@ -3854,7 +3842,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c38"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -3863,7 +3851,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -3872,7 +3860,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -3881,7 +3869,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -3890,13 +3878,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -3982,7 +3970,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   align-self: center;
 }
 
-.c29 {
+.c28 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -3993,11 +3981,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   padding-left: 8px;
 }
 
-.c29 svg {
+.c28 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -4106,11 +4094,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -4136,7 +4124,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -4144,16 +4132,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -4166,71 +4150,71 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   margin: 0;
 }
 
-.c34 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c34::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c34::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c34::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c34::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
-  background-color: #ee7c1b;
-  border: 0;
-}
-
 .c33 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c33::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c33::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c33::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c33::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
+  border: 0;
+}
+
+.c32 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -4245,7 +4229,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   margin-top: 5px;
 }
 
-.c33::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -4257,7 +4241,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   content: "";
 }
 
-.c36 {
+.c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -4275,7 +4259,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   line-height: 19.6px;
 }
 
-.c36::before {
+.c35::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -4287,7 +4271,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   content: "";
 }
 
-.c35 {
+.c34 {
   border: none;
   width: 100%;
   height: inherit;
@@ -4297,25 +4281,25 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   color: inherit;
 }
 
-.c35:focus {
+.c34:focus {
   outline: 0;
 }
 
-.c31 {
+.c30 {
   margin: 32px 0;
 }
 
-.c30 {
+.c29 {
   padding: 10px 20px 20px 20px;
 }
 
-.c32 {
+.c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c25 {
+.c24 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -4329,8 +4313,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border-radius: 3px 0 0 3px;
 }
 
-.c25:hover,
-.c25:focus {
+.c24:hover,
+.c24:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -4339,7 +4323,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   box-shadow: none;
 }
 
-.c27 {
+.c26 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -4353,8 +4337,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border-radius: 0 3px 3px 0;
 }
 
-.c27:hover,
-.c27:focus {
+.c26:hover,
+.c26:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -4363,7 +4347,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   box-shadow: none;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -4381,7 +4365,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   flex: none;
 }
 
-.c26 {
+.c25 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -4389,7 +4373,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   flex: none;
 }
 
-.c28 {
+.c27 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -4853,14 +4837,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   onMouseOver={[Function]}
                 >
                   <SnippetPreview__DesktopDescription
-                    className="c21"
+                    className=""
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
                     onMouseOver={[Function]}
                   >
                     <div
-                      className="c21 c22"
+                      className="c21"
                       color="#545454"
                       onClick={[Function]}
                       onMouseLeave={[Function]}
@@ -4870,15 +4854,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         innerRef={[Function]}
                       >
                         <SnippetPreview__MobileDescription
-                          className="c23"
+                          className="c22"
                           innerRef={[Function]}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c23 c21"
+                            className="c22 "
                             innerRef={[Function]}
                           >
                             <div
-                              className="c23 c21 c22"
+                              className="c22 c21"
                               color="#545454"
                             >
                               Test description, %%replacement_variable%%
@@ -4901,7 +4885,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c24"
+          className="c23"
         >
           <ModeSwitcher__SwitcherButton
             aria-pressed={true}
@@ -4910,7 +4894,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           >
             <Button
               aria-pressed={true}
-              className="c25"
+              className="c24"
               isActive={true}
               onClick={[Function]}
             >
@@ -4919,7 +4903,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c24 c2"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -4930,7 +4914,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c24 c2 Button-kDSBcD c3"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -4941,7 +4925,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -4952,7 +4936,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -4963,7 +4947,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -4971,7 +4955,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       >
                         <button
                           aria-pressed={true}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -4992,7 +4976,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c26"
+                                className="yoast-svg-icon yoast-svg-icon-mobile c25"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -5048,7 +5032,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           >
             <Button
               aria-pressed={false}
-              className="c27"
+              className="c26"
               isActive={false}
               onClick={[Function]}
             >
@@ -5057,7 +5041,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 c2"
+                className="c26 c2"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -5068,7 +5052,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 c2 Button-kDSBcD c3"
+                  className="c26 c2 Button-kDSBcD c3"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -5079,7 +5063,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -5090,7 +5074,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -5101,7 +5085,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
@@ -5109,7 +5093,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       >
                         <button
                           aria-pressed={false}
-                          className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -5130,7 +5114,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c28"
+                                className="yoast-svg-icon yoast-svg-icon-desktop c27"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -5192,7 +5176,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c29"
+        className="c28"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -5203,7 +5187,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c29 Button-kDSBcD c3"
+          className="c28 Button-kDSBcD c3"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -5214,7 +5198,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c29 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -5225,7 +5209,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -5236,7 +5220,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -5244,7 +5228,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               >
                 <button
                   aria-expanded={true}
-                  className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -5314,18 +5298,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
     >
       <SnippetEditorFields__StyledEditor>
         <section
-          className="c30"
+          className="c29"
         >
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-5-title"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-5-title"
                   onClick={[Function]}
                 >
@@ -5337,7 +5321,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-5-title"
@@ -5360,7 +5344,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               >
                 <progress
                   aria-hidden="true"
-                  className="c34"
+                  className="c33"
                   max={600}
                   value={0}
                 />
@@ -5369,14 +5353,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-5-slug"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-5-slug"
                   onClick={[Function]}
                 >
@@ -5388,7 +5372,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <SnippetEditorFields__SlugInput
                     aria-labelledby="snippet-editor-field-5-slug"
@@ -5399,7 +5383,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   >
                     <ControlledInput
                       aria-labelledby="snippet-editor-field-5-slug"
-                      className="c35"
+                      className="c34"
                       initialValue="test-slug"
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -5407,7 +5391,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     >
                       <input
                         aria-labelledby="snippet-editor-field-5-slug"
-                        className="c35"
+                        className="c34"
                         onChange={[Function]}
                         onFocus={[Function]}
                         value="test-slug"
@@ -5420,14 +5404,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-5-description"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-5-description"
                   onClick={[Function]}
                 >
@@ -5439,7 +5423,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 isHovered={false}
               >
                 <div
-                  className="c36"
+                  className="c35"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-5-description"
@@ -5462,7 +5446,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               >
                 <progress
                   aria-hidden="true"
-                  className="c37"
+                  className="c36"
                   max={320}
                   value={42}
                 />
@@ -5479,7 +5463,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c38"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -5488,7 +5472,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -5497,7 +5481,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -5506,7 +5490,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -5515,13 +5499,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -5607,7 +5591,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   align-self: center;
 }
 
-.c29 {
+.c28 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -5618,11 +5602,11 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   padding-left: 8px;
 }
 
-.c29 svg {
+.c28 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -5731,11 +5715,11 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -5761,7 +5745,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -5769,16 +5753,12 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -5791,71 +5771,71 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   margin: 0;
 }
 
-.c34 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c34::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c34::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c34::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c34::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
-  background-color: #ee7c1b;
-  border: 0;
-}
-
 .c33 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c33::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c33::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c33::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c33::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
+  border: 0;
+}
+
+.c32 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -5870,7 +5850,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   margin-top: 5px;
 }
 
-.c33::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -5882,7 +5862,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   content: "";
 }
 
-.c36 {
+.c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -5900,7 +5880,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   line-height: 19.6px;
 }
 
-.c36::before {
+.c35::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -5912,7 +5892,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   content: "";
 }
 
-.c35 {
+.c34 {
   border: none;
   width: 100%;
   height: inherit;
@@ -5922,25 +5902,25 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   color: inherit;
 }
 
-.c35:focus {
+.c34:focus {
   outline: 0;
 }
 
-.c31 {
+.c30 {
   margin: 32px 0;
 }
 
-.c30 {
+.c29 {
   padding: 10px 20px 20px 20px;
 }
 
-.c32 {
+.c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c25 {
+.c24 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -5954,8 +5934,8 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c25:hover,
-.c25:focus {
+.c24:hover,
+.c24:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -5964,7 +5944,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   box-shadow: none;
 }
 
-.c27 {
+.c26 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -5978,8 +5958,8 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c27:hover,
-.c27:focus {
+.c26:hover,
+.c26:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -5988,7 +5968,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   box-shadow: none;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -6006,7 +5986,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   flex: none;
 }
 
-.c26 {
+.c25 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -6014,7 +5994,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   flex: none;
 }
 
-.c28 {
+.c27 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -6478,14 +6458,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   onMouseOver={[Function]}
                 >
                   <SnippetPreview__DesktopDescription
-                    className="c21"
+                    className=""
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
                     onMouseOver={[Function]}
                   >
                     <div
-                      className="c21 c22"
+                      className="c21"
                       color="#545454"
                       onClick={[Function]}
                       onMouseLeave={[Function]}
@@ -6495,15 +6475,15 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         innerRef={[Function]}
                       >
                         <SnippetPreview__MobileDescription
-                          className="c23"
+                          className="c22"
                           innerRef={[Function]}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c23 c21"
+                            className="c22 "
                             innerRef={[Function]}
                           >
                             <div
-                              className="c23 c21 c22"
+                              className="c22 c21"
                               color="#545454"
                             >
                               Test description, %%replacement_variable%%
@@ -6526,7 +6506,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c24"
+          className="c23"
         >
           <ModeSwitcher__SwitcherButton
             aria-pressed={true}
@@ -6535,7 +6515,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           >
             <Button
               aria-pressed={true}
-              className="c25"
+              className="c24"
               isActive={true}
               onClick={[Function]}
             >
@@ -6544,7 +6524,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c24 c2"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -6555,7 +6535,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c24 c2 Button-kDSBcD c3"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -6566,7 +6546,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -6577,7 +6557,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -6588,7 +6568,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -6596,7 +6576,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       >
                         <button
                           aria-pressed={true}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -6617,7 +6597,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c26"
+                                className="yoast-svg-icon yoast-svg-icon-mobile c25"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -6673,7 +6653,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           >
             <Button
               aria-pressed={false}
-              className="c27"
+              className="c26"
               isActive={false}
               onClick={[Function]}
             >
@@ -6682,7 +6662,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 c2"
+                className="c26 c2"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -6693,7 +6673,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 c2 Button-kDSBcD c3"
+                  className="c26 c2 Button-kDSBcD c3"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -6704,7 +6684,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -6715,7 +6695,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -6726,7 +6706,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
@@ -6734,7 +6714,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       >
                         <button
                           aria-pressed={false}
-                          className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -6755,7 +6735,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c28"
+                                className="yoast-svg-icon yoast-svg-icon-desktop c27"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -6817,7 +6797,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c29"
+        className="c28"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -6828,7 +6808,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c29 Button-kDSBcD c3"
+          className="c28 Button-kDSBcD c3"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -6839,7 +6819,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c29 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -6850,7 +6830,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -6861,7 +6841,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -6869,7 +6849,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               >
                 <button
                   aria-expanded={true}
-                  className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -6939,18 +6919,18 @@ exports[`SnippetEditor closes when calling close() 1`] = `
     >
       <SnippetEditorFields__StyledEditor>
         <section
-          className="c30"
+          className="c29"
         >
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-2-title"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-2-title"
                   onClick={[Function]}
                 >
@@ -6962,7 +6942,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-2-title"
@@ -6985,7 +6965,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               >
                 <progress
                   aria-hidden="true"
-                  className="c34"
+                  className="c33"
                   max={600}
                   value={0}
                 />
@@ -6994,14 +6974,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-2-slug"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-2-slug"
                   onClick={[Function]}
                 >
@@ -7013,7 +6993,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <SnippetEditorFields__SlugInput
                     aria-labelledby="snippet-editor-field-2-slug"
@@ -7024,7 +7004,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   >
                     <ControlledInput
                       aria-labelledby="snippet-editor-field-2-slug"
-                      className="c35"
+                      className="c34"
                       initialValue="test-slug"
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -7032,7 +7012,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     >
                       <input
                         aria-labelledby="snippet-editor-field-2-slug"
-                        className="c35"
+                        className="c34"
                         onChange={[Function]}
                         onFocus={[Function]}
                         value="test-slug"
@@ -7045,14 +7025,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-2-description"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-2-description"
                   onClick={[Function]}
                 >
@@ -7064,7 +7044,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 isHovered={false}
               >
                 <div
-                  className="c36"
+                  className="c35"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-2-description"
@@ -7087,7 +7067,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               >
                 <progress
                   aria-hidden="true"
-                  className="c37"
+                  className="c36"
                   max={320}
                   value={42}
                 />
@@ -7104,7 +7084,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c38"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -7113,7 +7093,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -7122,7 +7102,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -7131,7 +7111,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -7140,13 +7120,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -7232,7 +7212,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   align-self: center;
 }
 
-.c29 {
+.c28 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -7243,7 +7223,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   padding-left: 8px;
 }
 
-.c29 svg {
+.c28 svg {
   margin-right: 7px;
 }
 
@@ -7347,11 +7327,11 @@ exports[`SnippetEditor closes when calling close() 2`] = `
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -7377,7 +7357,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -7385,16 +7365,12 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -7407,7 +7383,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   margin: 0;
 }
 
-.c25 {
+.c24 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -7421,8 +7397,8 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c25:hover,
-.c25:focus {
+.c24:hover,
+.c24:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -7431,7 +7407,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   box-shadow: none;
 }
 
-.c27 {
+.c26 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -7445,8 +7421,8 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c27:hover,
-.c27:focus {
+.c26:hover,
+.c26:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -7455,7 +7431,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   box-shadow: none;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -7473,7 +7449,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   flex: none;
 }
 
-.c26 {
+.c25 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -7481,7 +7457,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   flex: none;
 }
 
-.c28 {
+.c27 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -7945,14 +7921,14 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                   onMouseOver={[Function]}
                 >
                   <SnippetPreview__DesktopDescription
-                    className="c21"
+                    className=""
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
                     onMouseOver={[Function]}
                   >
                     <div
-                      className="c21 c22"
+                      className="c21"
                       color="#545454"
                       onClick={[Function]}
                       onMouseLeave={[Function]}
@@ -7962,15 +7938,15 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                         innerRef={[Function]}
                       >
                         <SnippetPreview__MobileDescription
-                          className="c23"
+                          className="c22"
                           innerRef={[Function]}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c23 c21"
+                            className="c22 "
                             innerRef={[Function]}
                           >
                             <div
-                              className="c23 c21 c22"
+                              className="c22 c21"
                               color="#545454"
                             >
                               Test description, %%replacement_variable%%
@@ -7993,7 +7969,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c24"
+          className="c23"
         >
           <ModeSwitcher__SwitcherButton
             aria-pressed={true}
@@ -8002,7 +7978,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
           >
             <Button
               aria-pressed={true}
-              className="c25"
+              className="c24"
               isActive={true}
               onClick={[Function]}
             >
@@ -8011,7 +7987,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c24 c2"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -8022,7 +7998,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c24 c2 Button-kDSBcD c3"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -8033,7 +8009,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -8044,7 +8020,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -8055,7 +8031,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -8063,7 +8039,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                       >
                         <button
                           aria-pressed={true}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -8084,7 +8060,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c26"
+                                className="yoast-svg-icon yoast-svg-icon-mobile c25"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -8140,7 +8116,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
           >
             <Button
               aria-pressed={false}
-              className="c27"
+              className="c26"
               isActive={false}
               onClick={[Function]}
             >
@@ -8149,7 +8125,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 c2"
+                className="c26 c2"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -8160,7 +8136,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 c2 Button-kDSBcD c3"
+                  className="c26 c2 Button-kDSBcD c3"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -8171,7 +8147,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -8182,7 +8158,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -8193,7 +8169,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
@@ -8201,7 +8177,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                       >
                         <button
                           aria-pressed={false}
-                          className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -8222,7 +8198,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c28"
+                                className="yoast-svg-icon yoast-svg-icon-desktop c27"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -8284,7 +8260,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c29"
+        className="c28"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -8295,7 +8271,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c29 Button-kDSBcD c3"
+          className="c28 Button-kDSBcD c3"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -8306,7 +8282,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c29 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -8317,7 +8293,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -8328,7 +8304,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -8336,7 +8312,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
               >
                 <button
                   aria-expanded={false}
-                  className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -8450,7 +8426,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   align-self: center;
 }
 
-.c29 {
+.c28 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -8461,11 +8437,11 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   padding-left: 8px;
 }
 
-.c29 svg {
+.c28 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -8574,11 +8550,11 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -8604,7 +8580,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -8612,16 +8588,12 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -8634,71 +8606,71 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   margin: 0;
 }
 
-.c34 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c34::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c34::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c34::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c34::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
-  background-color: #ee7c1b;
-  border: 0;
-}
-
 .c33 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c33::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c33::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c33::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c33::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
+  border: 0;
+}
+
+.c32 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -8713,7 +8685,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   margin-top: 5px;
 }
 
-.c33::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -8725,7 +8697,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   content: "";
 }
 
-.c36 {
+.c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -8743,7 +8715,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   line-height: 19.6px;
 }
 
-.c36::before {
+.c35::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -8755,7 +8727,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   content: "";
 }
 
-.c35 {
+.c34 {
   border: none;
   width: 100%;
   height: inherit;
@@ -8765,25 +8737,25 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   color: inherit;
 }
 
-.c35:focus {
+.c34:focus {
   outline: 0;
 }
 
-.c31 {
+.c30 {
   margin: 32px 0;
 }
 
-.c30 {
+.c29 {
   padding: 10px 20px 20px 20px;
 }
 
-.c32 {
+.c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c25 {
+.c24 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -8797,8 +8769,8 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c25:hover,
-.c25:focus {
+.c24:hover,
+.c24:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -8807,7 +8779,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   box-shadow: none;
 }
 
-.c27 {
+.c26 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -8821,8 +8793,8 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c27:hover,
-.c27:focus {
+.c26:hover,
+.c26:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -8831,7 +8803,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   box-shadow: none;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -8849,7 +8821,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   flex: none;
 }
 
-.c26 {
+.c25 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -8857,7 +8829,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   flex: none;
 }
 
-.c28 {
+.c27 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -9321,14 +9293,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   onMouseOver={[Function]}
                 >
                   <SnippetPreview__DesktopDescription
-                    className="c21"
+                    className=""
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
                     onMouseOver={[Function]}
                   >
                     <div
-                      className="c21 c22"
+                      className="c21"
                       color="#545454"
                       onClick={[Function]}
                       onMouseLeave={[Function]}
@@ -9338,15 +9310,15 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         innerRef={[Function]}
                       >
                         <SnippetPreview__MobileDescription
-                          className="c23"
+                          className="c22"
                           innerRef={[Function]}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c23 c21"
+                            className="c22 "
                             innerRef={[Function]}
                           >
                             <div
-                              className="c23 c21 c22"
+                              className="c22 c21"
                               color="#545454"
                             >
                               Test description, %%replacement_variable%%
@@ -9369,7 +9341,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c24"
+          className="c23"
         >
           <ModeSwitcher__SwitcherButton
             aria-pressed={true}
@@ -9378,7 +9350,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           >
             <Button
               aria-pressed={true}
-              className="c25"
+              className="c24"
               isActive={true}
               onClick={[Function]}
             >
@@ -9387,7 +9359,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c24 c2"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -9398,7 +9370,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c24 c2 Button-kDSBcD c3"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -9409,7 +9381,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -9420,7 +9392,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -9431,7 +9403,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -9439,7 +9411,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       >
                         <button
                           aria-pressed={true}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -9460,7 +9432,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c26"
+                                className="yoast-svg-icon yoast-svg-icon-mobile c25"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -9516,7 +9488,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           >
             <Button
               aria-pressed={false}
-              className="c27"
+              className="c26"
               isActive={false}
               onClick={[Function]}
             >
@@ -9525,7 +9497,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 c2"
+                className="c26 c2"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -9536,7 +9508,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 c2 Button-kDSBcD c3"
+                  className="c26 c2 Button-kDSBcD c3"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -9547,7 +9519,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -9558,7 +9530,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -9569,7 +9541,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
@@ -9577,7 +9549,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       >
                         <button
                           aria-pressed={false}
-                          className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -9598,7 +9570,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c28"
+                                className="yoast-svg-icon yoast-svg-icon-desktop c27"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -9660,7 +9632,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c29"
+        className="c28"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -9671,7 +9643,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c29 Button-kDSBcD c3"
+          className="c28 Button-kDSBcD c3"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -9682,7 +9654,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c29 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -9693,7 +9665,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -9704,7 +9676,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -9712,7 +9684,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               >
                 <button
                   aria-expanded={true}
-                  className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -9782,18 +9754,18 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
     >
       <SnippetEditorFields__StyledEditor>
         <section
-          className="c30"
+          className="c29"
         >
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-8-title"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-8-title"
                   onClick={[Function]}
                 >
@@ -9805,7 +9777,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-8-title"
@@ -9828,7 +9800,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               >
                 <progress
                   aria-hidden="true"
-                  className="c34"
+                  className="c33"
                   max={600}
                   value={0}
                 />
@@ -9837,14 +9809,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-8-slug"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-8-slug"
                   onClick={[Function]}
                 >
@@ -9856,7 +9828,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <SnippetEditorFields__SlugInput
                     aria-labelledby="snippet-editor-field-8-slug"
@@ -9867,7 +9839,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   >
                     <ControlledInput
                       aria-labelledby="snippet-editor-field-8-slug"
-                      className="c35"
+                      className="c34"
                       initialValue="test-slug"
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -9875,7 +9847,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     >
                       <input
                         aria-labelledby="snippet-editor-field-8-slug"
-                        className="c35"
+                        className="c34"
                         onChange={[Function]}
                         onFocus={[Function]}
                         value="test-slug"
@@ -9888,14 +9860,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-8-description"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-8-description"
                   onClick={[Function]}
                 >
@@ -9907,7 +9879,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 isHovered={false}
               >
                 <div
-                  className="c36"
+                  className="c35"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-8-description"
@@ -9930,7 +9902,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               >
                 <progress
                   aria-hidden="true"
-                  className="c37"
+                  className="c36"
                   max={320}
                   value={42}
                 />
@@ -9947,7 +9919,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c38"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -9956,7 +9928,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -9965,7 +9937,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -9974,7 +9946,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -9983,13 +9955,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -10075,7 +10047,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   align-self: center;
 }
 
-.c29 {
+.c28 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -10086,11 +10058,11 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   padding-left: 8px;
 }
 
-.c29 svg {
+.c28 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -10199,11 +10171,11 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -10229,7 +10201,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -10237,16 +10209,12 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -10259,71 +10227,71 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   margin: 0;
 }
 
-.c34 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c34::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c34::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c34::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c34::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
-  background-color: #ee7c1b;
-  border: 0;
-}
-
 .c33 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c33::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c33::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c33::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c33::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
+  border: 0;
+}
+
+.c32 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -10338,7 +10306,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   margin-top: 5px;
 }
 
-.c33::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -10350,7 +10318,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   content: "";
 }
 
-.c36 {
+.c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -10368,7 +10336,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   line-height: 19.6px;
 }
 
-.c36::before {
+.c35::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -10380,7 +10348,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   content: "";
 }
 
-.c35 {
+.c34 {
   border: none;
   width: 100%;
   height: inherit;
@@ -10390,25 +10358,25 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   color: inherit;
 }
 
-.c35:focus {
+.c34:focus {
   outline: 0;
 }
 
-.c31 {
+.c30 {
   margin: 32px 0;
 }
 
-.c30 {
+.c29 {
   padding: 10px 20px 20px 20px;
 }
 
-.c32 {
+.c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c25 {
+.c24 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -10422,8 +10390,8 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border-radius: 3px 0 0 3px;
 }
 
-.c25:hover,
-.c25:focus {
+.c24:hover,
+.c24:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -10432,7 +10400,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   box-shadow: none;
 }
 
-.c27 {
+.c26 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -10446,8 +10414,8 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border-radius: 0 3px 3px 0;
 }
 
-.c27:hover,
-.c27:focus {
+.c26:hover,
+.c26:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -10456,7 +10424,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   box-shadow: none;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -10474,7 +10442,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   flex: none;
 }
 
-.c26 {
+.c25 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -10482,7 +10450,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   flex: none;
 }
 
-.c28 {
+.c27 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -10946,14 +10914,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   onMouseOver={[Function]}
                 >
                   <SnippetPreview__DesktopDescription
-                    className="c21"
+                    className=""
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
                     onMouseOver={[Function]}
                   >
                     <div
-                      className="c21 c22"
+                      className="c21"
                       color="#545454"
                       onClick={[Function]}
                       onMouseLeave={[Function]}
@@ -10963,15 +10931,15 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         innerRef={[Function]}
                       >
                         <SnippetPreview__MobileDescription
-                          className="c23"
+                          className="c22"
                           innerRef={[Function]}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c23 c21"
+                            className="c22 "
                             innerRef={[Function]}
                           >
                             <div
-                              className="c23 c21 c22"
+                              className="c22 c21"
                               color="#545454"
                             >
                               Test description, %%replacement_variable%%
@@ -10994,7 +10962,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c24"
+          className="c23"
         >
           <ModeSwitcher__SwitcherButton
             aria-pressed={true}
@@ -11003,7 +10971,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           >
             <Button
               aria-pressed={true}
-              className="c25"
+              className="c24"
               isActive={true}
               onClick={[Function]}
             >
@@ -11012,7 +10980,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c24 c2"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -11023,7 +10991,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c24 c2 Button-kDSBcD c3"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -11034,7 +11002,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -11045,7 +11013,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -11056,7 +11024,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -11064,7 +11032,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       >
                         <button
                           aria-pressed={true}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -11085,7 +11053,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c26"
+                                className="yoast-svg-icon yoast-svg-icon-mobile c25"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -11141,7 +11109,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           >
             <Button
               aria-pressed={false}
-              className="c27"
+              className="c26"
               isActive={false}
               onClick={[Function]}
             >
@@ -11150,7 +11118,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 c2"
+                className="c26 c2"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -11161,7 +11129,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 c2 Button-kDSBcD c3"
+                  className="c26 c2 Button-kDSBcD c3"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -11172,7 +11140,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -11183,7 +11151,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -11194,7 +11162,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
@@ -11202,7 +11170,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       >
                         <button
                           aria-pressed={false}
-                          className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -11223,7 +11191,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c28"
+                                className="yoast-svg-icon yoast-svg-icon-desktop c27"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -11285,7 +11253,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c29"
+        className="c28"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -11296,7 +11264,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c29 Button-kDSBcD c3"
+          className="c28 Button-kDSBcD c3"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -11307,7 +11275,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c29 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -11318,7 +11286,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -11329,7 +11297,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -11337,7 +11305,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               >
                 <button
                   aria-expanded={true}
-                  className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -11407,18 +11375,18 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
     >
       <SnippetEditorFields__StyledEditor>
         <section
-          className="c30"
+          className="c29"
         >
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-7-title"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-7-title"
                   onClick={[Function]}
                 >
@@ -11430,7 +11398,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-7-title"
@@ -11453,7 +11421,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               >
                 <progress
                   aria-hidden="true"
-                  className="c34"
+                  className="c33"
                   max={600}
                   value={0}
                 />
@@ -11462,14 +11430,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-7-slug"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-7-slug"
                   onClick={[Function]}
                 >
@@ -11481,7 +11449,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <SnippetEditorFields__SlugInput
                     aria-labelledby="snippet-editor-field-7-slug"
@@ -11492,7 +11460,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   >
                     <ControlledInput
                       aria-labelledby="snippet-editor-field-7-slug"
-                      className="c35"
+                      className="c34"
                       initialValue="test-slug"
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -11500,7 +11468,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     >
                       <input
                         aria-labelledby="snippet-editor-field-7-slug"
-                        className="c35"
+                        className="c34"
                         onChange={[Function]}
                         onFocus={[Function]}
                         value="test-slug"
@@ -11513,14 +11481,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-7-description"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-7-description"
                   onClick={[Function]}
                 >
@@ -11532,7 +11500,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 isHovered={false}
               >
                 <div
-                  className="c36"
+                  className="c35"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-7-description"
@@ -11555,7 +11523,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               >
                 <progress
                   aria-hidden="true"
-                  className="c37"
+                  className="c36"
                   max={320}
                   value={42}
                 />
@@ -11572,7 +11540,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c38"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -11581,7 +11549,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -11590,7 +11558,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -11599,7 +11567,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -11608,13 +11576,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -11773,7 +11741,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   align-self: center;
 }
 
-.c29 {
+.c28 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -11784,7 +11752,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   padding-left: 8px;
 }
 
-.c29 svg {
+.c28 svg {
   margin-right: 7px;
 }
 
@@ -11888,11 +11856,11 @@ exports[`SnippetEditor highlights a focused field 1`] = `
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -11918,7 +11886,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -11926,16 +11894,12 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -11948,7 +11912,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   margin: 0;
 }
 
-.c25 {
+.c24 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -11962,8 +11926,8 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c25:hover,
-.c25:focus {
+.c24:hover,
+.c24:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -11972,7 +11936,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   box-shadow: none;
 }
 
-.c27 {
+.c26 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -11986,8 +11950,8 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c27:hover,
-.c27:focus {
+.c26:hover,
+.c26:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -11996,7 +11960,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   box-shadow: none;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -12014,7 +11978,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   flex: none;
 }
 
-.c26 {
+.c25 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -12022,7 +11986,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   flex: none;
 }
 
-.c28 {
+.c27 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -12177,14 +12141,14 @@ exports[`SnippetEditor highlights a focused field 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c21 c22"
+          className="c21"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
         >
           <div
-            className="c23 c21 c22"
+            className="c22 c21"
             color="#545454"
           >
             Test description, %%replacement_variable%%
@@ -12194,17 +12158,17 @@ exports[`SnippetEditor highlights a focused field 1`] = `
     </div>
   </section>
   <div
-    className="c24"
+    className="c23"
   >
     <button
       aria-pressed={true}
-      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c26"
+        className="yoast-svg-icon yoast-svg-icon-mobile c25"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -12233,13 +12197,13 @@ exports[`SnippetEditor highlights a focused field 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c28"
+        className="yoast-svg-icon yoast-svg-icon-desktop c27"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -12269,7 +12233,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+    className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
     onClick={[Function]}
     type="button"
   >
@@ -12362,7 +12326,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   align-self: center;
 }
 
-.c29 {
+.c28 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -12373,7 +12337,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   padding-left: 8px;
 }
 
-.c29 svg {
+.c28 svg {
   margin-right: 7px;
 }
 
@@ -12477,11 +12441,11 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -12507,7 +12471,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -12515,16 +12479,12 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -12537,7 +12497,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   margin: 0;
 }
 
-.c25 {
+.c24 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -12551,8 +12511,8 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c25:hover,
-.c25:focus {
+.c24:hover,
+.c24:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -12561,7 +12521,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   box-shadow: none;
 }
 
-.c27 {
+.c26 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -12575,8 +12535,8 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c27:hover,
-.c27:focus {
+.c26:hover,
+.c26:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -12585,7 +12545,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   box-shadow: none;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -12603,7 +12563,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   flex: none;
 }
 
-.c26 {
+.c25 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -12611,7 +12571,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   flex: none;
 }
 
-.c28 {
+.c27 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -12766,14 +12726,14 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c21 c22"
+          className="c21"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
         >
           <div
-            className="c23 c21 c22"
+            className="c22 c21"
             color="#545454"
           >
             Test description, %%replacement_variable%%
@@ -12783,17 +12743,17 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
     </div>
   </section>
   <div
-    className="c24"
+    className="c23"
   >
     <button
       aria-pressed={true}
-      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c26"
+        className="yoast-svg-icon yoast-svg-icon-mobile c25"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -12822,13 +12782,13 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c28"
+        className="yoast-svg-icon yoast-svg-icon-desktop c27"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -12858,7 +12818,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+    className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
     onClick={[Function]}
     type="button"
   >
@@ -12951,7 +12911,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   align-self: center;
 }
 
-.c30 {
+.c29 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -12962,11 +12922,11 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   padding-left: 8px;
 }
 
-.c30 svg {
+.c29 svg {
   margin-right: 7px;
 }
 
-.c39 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -13075,11 +13035,11 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -13105,7 +13065,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   max-width: 100%;
 }
 
-.c23 {
+.c22 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -13113,16 +13073,12 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   font-size: 13px;
 }
 
-.c22 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c24 {
-  overflow: hidden;
+.c23 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -13135,71 +13091,71 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   margin: 0;
 }
 
-.c35 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c35::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c35::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c35::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c35::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c38 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c38::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c38::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c38::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c38::-ms-fill {
-  background-color: #ee7c1b;
-  border: 0;
-}
-
 .c34 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c34::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c34::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c34::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c34::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c37 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c37::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c37::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c37::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c37::-ms-fill {
+  background-color: #ee7c1b;
+  border: 0;
+}
+
+.c33 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -13214,7 +13170,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   margin-top: 5px;
 }
 
-.c34::before {
+.c33::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -13226,7 +13182,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   content: "";
 }
 
-.c37 {
+.c36 {
   padding: 3px 5px;
   border: 1px solid #5b9dd9;
   box-shadow: 0 0 2px rgba(30,140,190,.8);
@@ -13244,7 +13200,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   line-height: 19.6px;
 }
 
-.c37::before {
+.c36::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -13256,7 +13212,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   content: "";
 }
 
-.c36 {
+.c35 {
   border: none;
   width: 100%;
   height: inherit;
@@ -13266,25 +13222,25 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   color: inherit;
 }
 
-.c36:focus {
+.c35:focus {
   outline: 0;
 }
 
-.c32 {
+.c31 {
   margin: 32px 0;
 }
 
-.c31 {
+.c30 {
   padding: 10px 20px 20px 20px;
 }
 
-.c33 {
+.c32 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c26 {
+.c25 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -13298,8 +13254,8 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   border-radius: 3px 0 0 3px;
 }
 
-.c26:hover,
-.c26:focus {
+.c25:hover,
+.c25:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -13308,7 +13264,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   box-shadow: none;
 }
 
-.c28 {
+.c27 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -13322,8 +13278,8 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   border-radius: 0 3px 3px 0;
 }
 
-.c28:hover,
-.c28:focus {
+.c27:hover,
+.c27:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -13332,7 +13288,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   box-shadow: none;
 }
 
-.c25 {
+.c24 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -13350,7 +13306,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   flex: none;
 }
 
-.c27 {
+.c26 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -13358,7 +13314,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   flex: none;
 }
 
-.c29 {
+.c28 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -13841,14 +13797,14 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     onMouseOver={[Function]}
                   >
                     <SnippetPreview__DesktopDescription
-                      className="c21 c22"
+                      className="c21 "
                       isDescriptionGenerated={false}
                       onClick={[Function]}
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
                       <div
-                        className="c21 c22 c23"
+                        className="c21 c22"
                         color="#545454"
                         onClick={[Function]}
                         onMouseLeave={[Function]}
@@ -13858,15 +13814,15 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                           innerRef={[Function]}
                         >
                           <SnippetPreview__MobileDescription
-                            className="c24"
+                            className="c23"
                             innerRef={[Function]}
                           >
                             <SnippetPreview__DesktopDescription
-                              className="c24 c22"
+                              className="c23 "
                               innerRef={[Function]}
                             >
                               <div
-                                className="c24 c22 c23"
+                                className="c23 c22"
                                 color="#545454"
                               >
                                 Test description, %%replacement_variable%%
@@ -13890,7 +13846,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c25"
+          className="c24"
         >
           <ModeSwitcher__SwitcherButton
             aria-pressed={true}
@@ -13899,7 +13855,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           >
             <Button
               aria-pressed={true}
-              className="c26"
+              className="c25"
               isActive={true}
               onClick={[Function]}
             >
@@ -13908,7 +13864,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c26 c2"
+                className="c25 c2"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -13919,7 +13875,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c26 c2 Button-kDSBcD c3"
+                  className="c25 c2 Button-kDSBcD c3"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -13930,7 +13886,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -13941,7 +13897,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -13952,7 +13908,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -13960,7 +13916,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       >
                         <button
                           aria-pressed={true}
-                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -13981,7 +13937,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c27"
+                                className="yoast-svg-icon yoast-svg-icon-mobile c26"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -14037,7 +13993,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           >
             <Button
               aria-pressed={false}
-              className="c28"
+              className="c27"
               isActive={false}
               onClick={[Function]}
             >
@@ -14046,7 +14002,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c28 c2"
+                className="c27 c2"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -14057,7 +14013,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c28 c2 Button-kDSBcD c3"
+                  className="c27 c2 Button-kDSBcD c3"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -14068,7 +14024,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c28 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -14079,7 +14035,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c28 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -14090,7 +14046,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c28 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
@@ -14098,7 +14054,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       >
                         <button
                           aria-pressed={false}
-                          className="c28 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -14119,7 +14075,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c29"
+                                className="yoast-svg-icon yoast-svg-icon-desktop c28"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -14181,7 +14137,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c30"
+        className="c29"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -14192,7 +14148,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c30 Button-kDSBcD c3"
+          className="c29 Button-kDSBcD c3"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -14203,7 +14159,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c30 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c29 Button-kDSBcD c3 Button-kDSBcD c4"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -14214,7 +14170,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c30 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -14225,7 +14181,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c30 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -14233,7 +14189,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
               >
                 <button
                   aria-expanded={true}
-                  className="c30 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -14303,18 +14259,18 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
     >
       <SnippetEditorFields__StyledEditor>
         <section
-          className="c31"
+          className="c30"
         >
           <SnippetEditorFields__FormSection>
             <div
-              className="c32"
+              className="c31"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-4-title"
                 onClick={[Function]}
               >
                 <div
-                  className="c33"
+                  className="c32"
                   id="snippet-editor-field-4-title"
                   onClick={[Function]}
                 >
@@ -14326,7 +14282,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 isHovered={false}
               >
                 <div
-                  className="c34"
+                  className="c33"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-4-title"
@@ -14349,7 +14305,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
               >
                 <progress
                   aria-hidden="true"
-                  className="c35"
+                  className="c34"
                   max={600}
                   value={0}
                 />
@@ -14358,14 +14314,14 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c32"
+              className="c31"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-4-slug"
                 onClick={[Function]}
               >
                 <div
-                  className="c33"
+                  className="c32"
                   id="snippet-editor-field-4-slug"
                   onClick={[Function]}
                 >
@@ -14377,7 +14333,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 isHovered={false}
               >
                 <div
-                  className="c34"
+                  className="c33"
                 >
                   <SnippetEditorFields__SlugInput
                     aria-labelledby="snippet-editor-field-4-slug"
@@ -14388,7 +14344,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   >
                     <ControlledInput
                       aria-labelledby="snippet-editor-field-4-slug"
-                      className="c36"
+                      className="c35"
                       initialValue="test-slug"
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -14396,7 +14352,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     >
                       <input
                         aria-labelledby="snippet-editor-field-4-slug"
-                        className="c36"
+                        className="c35"
                         onChange={[Function]}
                         onFocus={[Function]}
                         value="test-slug"
@@ -14409,14 +14365,14 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c32"
+              className="c31"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-4-description"
                 onClick={[Function]}
               >
                 <div
-                  className="c33"
+                  className="c32"
                   id="snippet-editor-field-4-description"
                   onClick={[Function]}
                 >
@@ -14428,7 +14384,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 isHovered={false}
               >
                 <div
-                  className="c37"
+                  className="c36"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-4-description"
@@ -14451,7 +14407,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
               >
                 <progress
                   aria-hidden="true"
-                  className="c38"
+                  className="c37"
                   max={320}
                   value={42}
                 />
@@ -14468,7 +14424,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c39"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -14477,7 +14433,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c39 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -14486,7 +14442,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c39 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -14495,7 +14451,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -14504,13 +14460,13 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -14596,7 +14552,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   align-self: center;
 }
 
-.c30 {
+.c29 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -14607,11 +14563,11 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   padding-left: 8px;
 }
 
-.c30 svg {
+.c29 svg {
   margin-right: 7px;
 }
 
-.c39 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -14720,11 +14676,11 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -14750,7 +14706,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   max-width: 100%;
 }
 
-.c23 {
+.c22 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -14758,16 +14714,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   font-size: 13px;
 }
 
-.c22 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c24 {
-  overflow: hidden;
+.c23 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -14780,71 +14732,71 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   margin: 0;
 }
 
-.c35 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c35::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c35::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c35::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c35::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c38 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c38::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c38::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c38::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c38::-ms-fill {
-  background-color: #ee7c1b;
-  border: 0;
-}
-
 .c34 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c34::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c34::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c34::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c34::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c37 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c37::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c37::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c37::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c37::-ms-fill {
+  background-color: #ee7c1b;
+  border: 0;
+}
+
+.c33 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -14859,7 +14811,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   margin-top: 5px;
 }
 
-.c34::before {
+.c33::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -14871,7 +14823,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   content: "";
 }
 
-.c37 {
+.c36 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -14889,7 +14841,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   line-height: 19.6px;
 }
 
-.c37::before {
+.c36::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -14901,7 +14853,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   content: "";
 }
 
-.c36 {
+.c35 {
   border: none;
   width: 100%;
   height: inherit;
@@ -14911,25 +14863,25 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   color: inherit;
 }
 
-.c36:focus {
+.c35:focus {
   outline: 0;
 }
 
-.c32 {
+.c31 {
   margin: 32px 0;
 }
 
-.c31 {
+.c30 {
   padding: 10px 20px 20px 20px;
 }
 
-.c33 {
+.c32 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c26 {
+.c25 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -14943,8 +14895,8 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   border-radius: 3px 0 0 3px;
 }
 
-.c26:hover,
-.c26:focus {
+.c25:hover,
+.c25:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -14953,7 +14905,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   box-shadow: none;
 }
 
-.c28 {
+.c27 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -14967,8 +14919,8 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   border-radius: 0 3px 3px 0;
 }
 
-.c28:hover,
-.c28:focus {
+.c27:hover,
+.c27:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -14977,7 +14929,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   box-shadow: none;
 }
 
-.c25 {
+.c24 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -14995,7 +14947,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   flex: none;
 }
 
-.c27 {
+.c26 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -15003,7 +14955,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   flex: none;
 }
 
-.c29 {
+.c28 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -15486,14 +15438,14 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                     onMouseOver={[Function]}
                   >
                     <SnippetPreview__DesktopDescription
-                      className="c21 c22"
+                      className="c21 "
                       isDescriptionGenerated={false}
                       onClick={[Function]}
                       onMouseLeave={[Function]}
                       onMouseOver={[Function]}
                     >
                       <div
-                        className="c21 c22 c23"
+                        className="c21 c22"
                         color="#545454"
                         onClick={[Function]}
                         onMouseLeave={[Function]}
@@ -15503,15 +15455,15 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                           innerRef={[Function]}
                         >
                           <SnippetPreview__MobileDescription
-                            className="c24"
+                            className="c23"
                             innerRef={[Function]}
                           >
                             <SnippetPreview__DesktopDescription
-                              className="c24 c22"
+                              className="c23 "
                               innerRef={[Function]}
                             >
                               <div
-                                className="c24 c22 c23"
+                                className="c23 c22"
                                 color="#545454"
                               >
                                 Test description, %%replacement_variable%%
@@ -15535,7 +15487,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c25"
+          className="c24"
         >
           <ModeSwitcher__SwitcherButton
             aria-pressed={true}
@@ -15544,7 +15496,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
           >
             <Button
               aria-pressed={true}
-              className="c26"
+              className="c25"
               isActive={true}
               onClick={[Function]}
             >
@@ -15553,7 +15505,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c26 c2"
+                className="c25 c2"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -15564,7 +15516,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c26 c2 Button-kDSBcD c3"
+                  className="c25 c2 Button-kDSBcD c3"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -15575,7 +15527,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -15586,7 +15538,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -15597,7 +15549,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -15605,7 +15557,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                       >
                         <button
                           aria-pressed={true}
-                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -15626,7 +15578,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c27"
+                                className="yoast-svg-icon yoast-svg-icon-mobile c26"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -15682,7 +15634,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
           >
             <Button
               aria-pressed={false}
-              className="c28"
+              className="c27"
               isActive={false}
               onClick={[Function]}
             >
@@ -15691,7 +15643,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c28 c2"
+                className="c27 c2"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -15702,7 +15654,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c28 c2 Button-kDSBcD c3"
+                  className="c27 c2 Button-kDSBcD c3"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -15713,7 +15665,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c28 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -15724,7 +15676,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c28 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -15735,7 +15687,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c28 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
@@ -15743,7 +15695,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                       >
                         <button
                           aria-pressed={false}
-                          className="c28 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -15764,7 +15716,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c29"
+                                className="yoast-svg-icon yoast-svg-icon-desktop c28"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -15826,7 +15778,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c30"
+        className="c29"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -15837,7 +15789,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c30 Button-kDSBcD c3"
+          className="c29 Button-kDSBcD c3"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -15848,7 +15800,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c30 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c29 Button-kDSBcD c3 Button-kDSBcD c4"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -15859,7 +15811,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c30 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -15870,7 +15822,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c30 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -15878,7 +15830,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
               >
                 <button
                   aria-expanded={true}
-                  className="c30 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -15948,18 +15900,18 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
     >
       <SnippetEditorFields__StyledEditor>
         <section
-          className="c31"
+          className="c30"
         >
           <SnippetEditorFields__FormSection>
             <div
-              className="c32"
+              className="c31"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-3-title"
                 onClick={[Function]}
               >
                 <div
-                  className="c33"
+                  className="c32"
                   id="snippet-editor-field-3-title"
                   onClick={[Function]}
                 >
@@ -15971,7 +15923,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 isHovered={false}
               >
                 <div
-                  className="c34"
+                  className="c33"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-3-title"
@@ -15994,7 +15946,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
               >
                 <progress
                   aria-hidden="true"
-                  className="c35"
+                  className="c34"
                   max={600}
                   value={0}
                 />
@@ -16003,14 +15955,14 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c32"
+              className="c31"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-3-slug"
                 onClick={[Function]}
               >
                 <div
-                  className="c33"
+                  className="c32"
                   id="snippet-editor-field-3-slug"
                   onClick={[Function]}
                 >
@@ -16022,7 +15974,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 isHovered={false}
               >
                 <div
-                  className="c34"
+                  className="c33"
                 >
                   <SnippetEditorFields__SlugInput
                     aria-labelledby="snippet-editor-field-3-slug"
@@ -16033,7 +15985,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                   >
                     <ControlledInput
                       aria-labelledby="snippet-editor-field-3-slug"
-                      className="c36"
+                      className="c35"
                       initialValue="test-slug"
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -16041,7 +15993,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                     >
                       <input
                         aria-labelledby="snippet-editor-field-3-slug"
-                        className="c36"
+                        className="c35"
                         onChange={[Function]}
                         onFocus={[Function]}
                         value="test-slug"
@@ -16054,14 +16006,14 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c32"
+              className="c31"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-3-description"
                 onClick={[Function]}
               >
                 <div
-                  className="c33"
+                  className="c32"
                   id="snippet-editor-field-3-description"
                   onClick={[Function]}
                 >
@@ -16073,7 +16025,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 isHovered={true}
               >
                 <div
-                  className="c37"
+                  className="c36"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-3-description"
@@ -16096,7 +16048,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
               >
                 <progress
                   aria-hidden="true"
-                  className="c38"
+                  className="c37"
                   max={320}
                   value={42}
                 />
@@ -16113,7 +16065,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c39"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -16122,7 +16074,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c39 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -16131,7 +16083,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c39 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -16140,7 +16092,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -16149,13 +16101,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -16241,7 +16193,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   align-self: center;
 }
 
-.c29 {
+.c28 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -16252,11 +16204,11 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   padding-left: 8px;
 }
 
-.c29 svg {
+.c28 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -16365,11 +16317,11 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -16395,7 +16347,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -16403,16 +16355,12 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -16425,71 +16373,71 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   margin: 0;
 }
 
-.c34 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c34::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c34::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c34::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c34::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
-  background-color: #ee7c1b;
-  border: 0;
-}
-
 .c33 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c33::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c33::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c33::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c33::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
+  border: 0;
+}
+
+.c32 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -16504,7 +16452,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   margin-top: 5px;
 }
 
-.c33::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -16516,7 +16464,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   content: "";
 }
 
-.c36 {
+.c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -16534,7 +16482,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   line-height: 19.6px;
 }
 
-.c36::before {
+.c35::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -16546,7 +16494,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   content: "";
 }
 
-.c35 {
+.c34 {
   border: none;
   width: 100%;
   height: inherit;
@@ -16556,25 +16504,25 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   color: inherit;
 }
 
-.c35:focus {
+.c34:focus {
   outline: 0;
 }
 
-.c31 {
+.c30 {
   margin: 32px 0;
 }
 
-.c30 {
+.c29 {
   padding: 10px 20px 20px 20px;
 }
 
-.c32 {
+.c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c25 {
+.c24 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -16588,8 +16536,8 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c25:hover,
-.c25:focus {
+.c24:hover,
+.c24:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -16598,7 +16546,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   box-shadow: none;
 }
 
-.c27 {
+.c26 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -16612,8 +16560,8 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c27:hover,
-.c27:focus {
+.c26:hover,
+.c26:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -16622,7 +16570,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   box-shadow: none;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -16640,7 +16588,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   flex: none;
 }
 
-.c26 {
+.c25 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -16648,7 +16596,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   flex: none;
 }
 
-.c28 {
+.c27 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -17112,14 +17060,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   onMouseOver={[Function]}
                 >
                   <SnippetPreview__DesktopDescription
-                    className="c21"
+                    className=""
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
                     onMouseOver={[Function]}
                   >
                     <div
-                      className="c21 c22"
+                      className="c21"
                       color="#545454"
                       onClick={[Function]}
                       onMouseLeave={[Function]}
@@ -17129,15 +17077,15 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         innerRef={[Function]}
                       >
                         <SnippetPreview__MobileDescription
-                          className="c23"
+                          className="c22"
                           innerRef={[Function]}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c23 c21"
+                            className="c22 "
                             innerRef={[Function]}
                           >
                             <div
-                              className="c23 c21 c22"
+                              className="c22 c21"
                               color="#545454"
                             >
                               Test description, %%replacement_variable%%
@@ -17160,7 +17108,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c24"
+          className="c23"
         >
           <ModeSwitcher__SwitcherButton
             aria-pressed={true}
@@ -17169,7 +17117,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           >
             <Button
               aria-pressed={true}
-              className="c25"
+              className="c24"
               isActive={true}
               onClick={[Function]}
             >
@@ -17178,7 +17126,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c24 c2"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -17189,7 +17137,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c24 c2 Button-kDSBcD c3"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -17200,7 +17148,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -17211,7 +17159,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -17222,7 +17170,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -17230,7 +17178,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       >
                         <button
                           aria-pressed={true}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -17251,7 +17199,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c26"
+                                className="yoast-svg-icon yoast-svg-icon-mobile c25"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -17307,7 +17255,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           >
             <Button
               aria-pressed={false}
-              className="c27"
+              className="c26"
               isActive={false}
               onClick={[Function]}
             >
@@ -17316,7 +17264,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 c2"
+                className="c26 c2"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -17327,7 +17275,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 c2 Button-kDSBcD c3"
+                  className="c26 c2 Button-kDSBcD c3"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -17338,7 +17286,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -17349,7 +17297,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -17360,7 +17308,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
@@ -17368,7 +17316,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       >
                         <button
                           aria-pressed={false}
-                          className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -17389,7 +17337,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c28"
+                                className="yoast-svg-icon yoast-svg-icon-desktop c27"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -17451,7 +17399,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c29"
+        className="c28"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -17462,7 +17410,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c29 Button-kDSBcD c3"
+          className="c28 Button-kDSBcD c3"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -17473,7 +17421,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c29 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -17484,7 +17432,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -17495,7 +17443,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -17503,7 +17451,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               >
                 <button
                   aria-expanded={true}
-                  className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -17573,18 +17521,18 @@ exports[`SnippetEditor opens when calling open() 1`] = `
     >
       <SnippetEditorFields__StyledEditor>
         <section
-          className="c30"
+          className="c29"
         >
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-1-title"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-1-title"
                   onClick={[Function]}
                 >
@@ -17596,7 +17544,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-1-title"
@@ -17619,7 +17567,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               >
                 <progress
                   aria-hidden="true"
-                  className="c34"
+                  className="c33"
                   max={600}
                   value={0}
                 />
@@ -17628,14 +17576,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-1-slug"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-1-slug"
                   onClick={[Function]}
                 >
@@ -17647,7 +17595,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <SnippetEditorFields__SlugInput
                     aria-labelledby="snippet-editor-field-1-slug"
@@ -17658,7 +17606,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   >
                     <ControlledInput
                       aria-labelledby="snippet-editor-field-1-slug"
-                      className="c35"
+                      className="c34"
                       initialValue="test-slug"
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -17666,7 +17614,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     >
                       <input
                         aria-labelledby="snippet-editor-field-1-slug"
-                        className="c35"
+                        className="c34"
                         onChange={[Function]}
                         onFocus={[Function]}
                         value="test-slug"
@@ -17679,14 +17627,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-1-description"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-1-description"
                   onClick={[Function]}
                 >
@@ -17698,7 +17646,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 isHovered={false}
               >
                 <div
-                  className="c36"
+                  className="c35"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-1-description"
@@ -17721,7 +17669,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               >
                 <progress
                   aria-hidden="true"
-                  className="c37"
+                  className="c36"
                   max={320}
                   value={42}
                 />
@@ -17738,7 +17686,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c38"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -17747,7 +17695,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -17756,7 +17704,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -17765,7 +17713,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -17774,13 +17722,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -17866,7 +17814,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   align-self: center;
 }
 
-.c29 {
+.c28 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -17877,11 +17825,11 @@ exports[`SnippetEditor passes replacement variables to the title and description
   padding-left: 8px;
 }
 
-.c29 svg {
+.c28 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -17990,11 +17938,11 @@ exports[`SnippetEditor passes replacement variables to the title and description
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -18020,7 +17968,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -18028,16 +17976,12 @@ exports[`SnippetEditor passes replacement variables to the title and description
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -18050,71 +17994,71 @@ exports[`SnippetEditor passes replacement variables to the title and description
   margin: 0;
 }
 
-.c34 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c34::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c34::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c34::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c34::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
-  background-color: #ee7c1b;
-  border: 0;
-}
-
 .c33 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c33::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c33::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c33::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c33::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
+  border: 0;
+}
+
+.c32 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -18129,7 +18073,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   margin-top: 5px;
 }
 
-.c33::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -18141,7 +18085,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   content: "";
 }
 
-.c36 {
+.c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -18159,7 +18103,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   line-height: 19.6px;
 }
 
-.c36::before {
+.c35::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -18171,7 +18115,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   content: "";
 }
 
-.c35 {
+.c34 {
   border: none;
   width: 100%;
   height: inherit;
@@ -18181,25 +18125,25 @@ exports[`SnippetEditor passes replacement variables to the title and description
   color: inherit;
 }
 
-.c35:focus {
+.c34:focus {
   outline: 0;
 }
 
-.c31 {
+.c30 {
   margin: 32px 0;
 }
 
-.c30 {
+.c29 {
   padding: 10px 20px 20px 20px;
 }
 
-.c32 {
+.c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c25 {
+.c24 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -18213,8 +18157,8 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border-radius: 3px 0 0 3px;
 }
 
-.c25:hover,
-.c25:focus {
+.c24:hover,
+.c24:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -18223,7 +18167,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   box-shadow: none;
 }
 
-.c27 {
+.c26 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -18237,8 +18181,8 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border-radius: 0 3px 3px 0;
 }
 
-.c27:hover,
-.c27:focus {
+.c26:hover,
+.c26:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -18247,7 +18191,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   box-shadow: none;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -18265,7 +18209,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   flex: none;
 }
 
-.c26 {
+.c25 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -18273,7 +18217,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   flex: none;
 }
 
-.c28 {
+.c27 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -18748,14 +18692,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   onMouseOver={[Function]}
                 >
                   <SnippetPreview__DesktopDescription
-                    className="c21"
+                    className=""
                     isDescriptionGenerated={false}
                     onClick={[Function]}
                     onMouseLeave={[Function]}
                     onMouseOver={[Function]}
                   >
                     <div
-                      className="c21 c22"
+                      className="c21"
                       color="#545454"
                       onClick={[Function]}
                       onMouseLeave={[Function]}
@@ -18765,15 +18709,15 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         innerRef={[Function]}
                       >
                         <SnippetPreview__MobileDescription
-                          className="c23"
+                          className="c22"
                           innerRef={[Function]}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c23 c21"
+                            className="c22 "
                             innerRef={[Function]}
                           >
                             <div
-                              className="c23 c21 c22"
+                              className="c22 c21"
                               color="#545454"
                             >
                               Test description, %%replacement_variable%%
@@ -18796,7 +18740,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
     >
       <ModeSwitcher__Switcher>
         <div
-          className="c24"
+          className="c23"
         >
           <ModeSwitcher__SwitcherButton
             aria-pressed={true}
@@ -18805,7 +18749,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           >
             <Button
               aria-pressed={true}
-              className="c25"
+              className="c24"
               isActive={true}
               onClick={[Function]}
             >
@@ -18814,7 +18758,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c24 c2"
                 isActive={true}
                 onClick={[Function]}
                 textColor="#555"
@@ -18825,7 +18769,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c24 c2 Button-kDSBcD c3"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -18836,7 +18780,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -18847,7 +18791,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
@@ -18858,7 +18802,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -18866,7 +18810,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       >
                         <button
                           aria-pressed={true}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -18887,7 +18831,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c26"
+                                className="yoast-svg-icon yoast-svg-icon-mobile c25"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -18943,7 +18887,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           >
             <Button
               aria-pressed={false}
-              className="c27"
+              className="c26"
               isActive={false}
               onClick={[Function]}
             >
@@ -18952,7 +18896,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 c2"
+                className="c26 c2"
                 isActive={false}
                 onClick={[Function]}
                 textColor="#555"
@@ -18963,7 +18907,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 c2 Button-kDSBcD c3"
+                  className="c26 c2 Button-kDSBcD c3"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -18974,7 +18918,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -18985,7 +18929,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
@@ -18996,7 +18940,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
@@ -19004,7 +18948,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       >
                         <button
                           aria-pressed={false}
-                          className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                           onClick={[Function]}
                           type="button"
                         >
@@ -19025,7 +18969,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             >
                               <svg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c28"
+                                className="yoast-svg-icon yoast-svg-icon-desktop c27"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -19087,7 +19031,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c29"
+        className="c28"
         innerRef={[Function]}
         onClick={[Function]}
         textColor="#555"
@@ -19098,7 +19042,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c29 Button-kDSBcD c3"
+          className="c28 Button-kDSBcD c3"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -19109,7 +19053,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c29 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -19120,7 +19064,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
@@ -19131,7 +19075,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
@@ -19139,7 +19083,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               >
                 <button
                   aria-expanded={true}
-                  className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -19220,18 +19164,18 @@ exports[`SnippetEditor passes replacement variables to the title and description
     >
       <SnippetEditorFields__StyledEditor>
         <section
-          className="c30"
+          className="c29"
         >
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-6-title"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-6-title"
                   onClick={[Function]}
                 >
@@ -19243,7 +19187,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-6-title"
@@ -19277,7 +19221,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               >
                 <progress
                   aria-hidden="true"
-                  className="c34"
+                  className="c33"
                   max={600}
                   value={0}
                 />
@@ -19286,14 +19230,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-6-slug"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-6-slug"
                   onClick={[Function]}
                 >
@@ -19305,7 +19249,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 isHovered={false}
               >
                 <div
-                  className="c33"
+                  className="c32"
                 >
                   <SnippetEditorFields__SlugInput
                     aria-labelledby="snippet-editor-field-6-slug"
@@ -19316,7 +19260,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   >
                     <ControlledInput
                       aria-labelledby="snippet-editor-field-6-slug"
-                      className="c35"
+                      className="c34"
                       initialValue="test-slug"
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -19324,7 +19268,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     >
                       <input
                         aria-labelledby="snippet-editor-field-6-slug"
-                        className="c35"
+                        className="c34"
                         onChange={[Function]}
                         onFocus={[Function]}
                         value="test-slug"
@@ -19337,14 +19281,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
           </SnippetEditorFields__FormSection>
           <SnippetEditorFields__FormSection>
             <div
-              className="c31"
+              className="c30"
             >
               <SnippetEditorFields__SimulatedLabel
                 id="snippet-editor-field-6-description"
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c31"
                   id="snippet-editor-field-6-description"
                   onClick={[Function]}
                 >
@@ -19356,7 +19300,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 isHovered={false}
               >
                 <div
-                  className="c36"
+                  className="c35"
                 >
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-6-description"
@@ -19390,7 +19334,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               >
                 <progress
                   aria-hidden="true"
-                  className="c37"
+                  className="c36"
                   max={320}
                   value={42}
                 />
@@ -19407,7 +19351,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c38"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -19416,7 +19360,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -19425,7 +19369,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -19434,7 +19378,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -19443,13 +19387,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -19535,7 +19479,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   align-self: center;
 }
 
-.c30 {
+.c29 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -19546,7 +19490,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   padding-left: 8px;
 }
 
-.c30 svg {
+.c29 svg {
   margin-right: 7px;
 }
 
@@ -19650,11 +19594,11 @@ exports[`SnippetEditor passes the date prop 1`] = `
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -19680,7 +19624,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -19688,23 +19632,19 @@ exports[`SnippetEditor passes the date prop 1`] = `
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
   padding: 8px 16px;
 }
 
-.c24 {
+.c23 {
   color: #808080;
 }
 
@@ -19714,7 +19654,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   margin: 0;
 }
 
-.c26 {
+.c25 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -19728,8 +19668,8 @@ exports[`SnippetEditor passes the date prop 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c26:hover,
-.c26:focus {
+.c25:hover,
+.c25:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -19738,7 +19678,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   box-shadow: none;
 }
 
-.c28 {
+.c27 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -19752,8 +19692,8 @@ exports[`SnippetEditor passes the date prop 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c28:hover,
-.c28:focus {
+.c27:hover,
+.c27:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -19762,7 +19702,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   box-shadow: none;
 }
 
-.c25 {
+.c24 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -19780,7 +19720,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   flex: none;
 }
 
-.c27 {
+.c26 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -19788,7 +19728,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   flex: none;
 }
 
-.c29 {
+.c28 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -19943,18 +19883,18 @@ exports[`SnippetEditor passes the date prop 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c21 c22"
+          className="c21"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
         >
           <div
-            className="c23 c21 c22"
+            className="c22 c21"
             color="#545454"
           >
             <span
-              className="c24"
+              className="c23"
             >
               date string
                - 
@@ -19966,17 +19906,17 @@ exports[`SnippetEditor passes the date prop 1`] = `
     </div>
   </section>
   <div
-    className="c25"
+    className="c24"
   >
     <button
       aria-pressed={true}
-      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c27"
+        className="yoast-svg-icon yoast-svg-icon-mobile c26"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -20005,13 +19945,13 @@ exports[`SnippetEditor passes the date prop 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c28 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c29"
+        className="yoast-svg-icon yoast-svg-icon-desktop c28"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -20041,7 +19981,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c30 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+    className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
     onClick={[Function]}
     type="button"
   >
@@ -20785,7 +20725,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   align-self: center;
 }
 
-.c29 {
+.c28 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -20796,7 +20736,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   padding-left: 8px;
 }
 
-.c29 svg {
+.c28 svg {
   margin-right: 7px;
 }
 
@@ -20900,11 +20840,11 @@ exports[`SnippetEditor shows and editor 1`] = `
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -20930,7 +20870,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -20938,16 +20878,12 @@ exports[`SnippetEditor shows and editor 1`] = `
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -20960,7 +20896,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   margin: 0;
 }
 
-.c25 {
+.c24 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -20974,8 +20910,8 @@ exports[`SnippetEditor shows and editor 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c25:hover,
-.c25:focus {
+.c24:hover,
+.c24:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -20984,7 +20920,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   box-shadow: none;
 }
 
-.c27 {
+.c26 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -20998,8 +20934,8 @@ exports[`SnippetEditor shows and editor 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c27:hover,
-.c27:focus {
+.c26:hover,
+.c26:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -21008,7 +20944,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   box-shadow: none;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
@@ -21026,7 +20962,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   flex: none;
 }
 
-.c26 {
+.c25 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -21034,7 +20970,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   flex: none;
 }
 
-.c28 {
+.c27 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -21189,14 +21125,14 @@ exports[`SnippetEditor shows and editor 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c21 c22"
+          className="c21"
           color="#545454"
           onClick={[Function]}
           onMouseLeave={[Function]}
           onMouseOver={[Function]}
         >
           <div
-            className="c23 c21 c22"
+            className="c22 c21"
             color="#545454"
           >
             Test description, %%replacement_variable%%
@@ -21206,17 +21142,17 @@ exports[`SnippetEditor shows and editor 1`] = `
     </div>
   </section>
   <div
-    className="c24"
+    className="c23"
   >
     <button
       aria-pressed={true}
-      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c26"
+        className="yoast-svg-icon yoast-svg-icon-mobile c25"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -21245,13 +21181,13 @@ exports[`SnippetEditor shows and editor 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c27 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c28"
+        className="yoast-svg-icon yoast-svg-icon-desktop c27"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -21281,7 +21217,7 @@ exports[`SnippetEditor shows and editor 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c29 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+    className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
     onClick={[Function]}
     type="button"
   >

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -117,11 +117,11 @@ export const TitleUnboundedDesktop = styled.span`
 
 export const TitleUnboundedMobile = styled.span`
 	display: inline-block;
+	font-size: 16px;
 	line-height: 1.2em;
-	max-height: 2.4em;
+	max-height: 2.4em; // max two lines of text
 	overflow: hidden;
 	text-overflow: ellipsis;
-	font-size: 16px;
 `;
 
 export const BaseUrl = styled.div`
@@ -153,15 +153,14 @@ export const DesktopDescription = styled.div.attrs( {
 `;
 
 const MobileDescription = styled( DesktopDescription )`
-	max-height: 4em;
-	padding-bottom: 3px;
 `;
 
 const MobileDescriptionOverflowContainer = styled( MobileDescription )`
-	overflow: hidden;
 	font-size: 14px;
 	line-height: 20px;
-	max-height: calc( 4em + 3px );
+	max-height: 80px; // max four lines of text
+	overflow: hidden;
+	text-overflow: ellipsis;
 `;
 
 const MobilePartContainer = styled.div`
@@ -619,8 +618,10 @@ export default class SnippetPreview extends PureComponent {
 		if ( mode === MODE_DESKTOP ) {
 			const DesktopDescriptionWithCaret = this.addCaretStyles( "description", DesktopDescription );
 			return (
-				<DesktopDescriptionWithCaret { ...outerContainerProps }
-											  innerRef={ this.setDescriptionRef }>
+				<DesktopDescriptionWithCaret
+					{ ...outerContainerProps }
+					innerRef={ this.setDescriptionRef }
+				>
 					{ renderedDate }
 					{ highlightKeyword( locale, keyword, this.getDescription() ) }
 				</DesktopDescriptionWithCaret>
@@ -629,9 +630,11 @@ export default class SnippetPreview extends PureComponent {
 			const MobileDescriptionWithCaret = this.addCaretStyles( "description", MobileDescription );
 			return (
 				<MobileDescriptionWithCaret
-					{ ...outerContainerProps } >
+					{ ...outerContainerProps }
+				>
 					<MobileDescriptionOverflowContainer
-						innerRef={ this.setDescriptionRef } >
+						innerRef={ this.setDescriptionRef }
+					>
 						{ renderedDate }
 						{ highlightKeyword( locale, keyword, this.getDescription() ) }
 					</MobileDescriptionOverflowContainer>
@@ -677,18 +680,22 @@ export default class SnippetPreview extends PureComponent {
 				<div>
 					<HelpTextWrapper helpText={ helpText } />
 				</div>
-				<Container onMouseLeave={ this.onMouseLeave }
-				           width={ MAX_WIDTH + 2 * WIDTH_PADDING }
-				           padding={ WIDTH_PADDING }>
+				<Container
+					onMouseLeave={ this.onMouseLeave }
+					width={ MAX_WIDTH + 2 * WIDTH_PADDING }
+					padding={ WIDTH_PADDING }
+				>
 					<PartContainer>
 						<FormattedScreenReaderMessage
 							id="snippetPreview.seoTitlePreview"
 							defaultMessage="SEO title preview"
 							after=":"
 						/>
-						<Title onClick={ onClick.bind( null, "title" ) }
-						       onMouseOver={ partial( onMouseOver, "title" ) }
-						       onMouseLeave={ partial( onMouseLeave, "title" ) }>
+						<Title
+							onClick={ onClick.bind( null, "title" ) }
+							onMouseOver={ partial( onMouseOver, "title" ) }
+							onMouseLeave={ partial( onMouseLeave, "title" ) }
+						>
 							<TitleBounded>
 								<TitleUnbounded innerRef={ this.setTitleRef } >
 									{ this.getTitle() }

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -1349,11 +1349,11 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c19 {
@@ -1379,7 +1379,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   max-width: 100%;
 }
 
-.c23 {
+.c22 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -1387,16 +1387,12 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   font-size: 13px;
 }
 
-.c22 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c24 {
-  overflow: hidden;
+.c23 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -1577,14 +1573,14 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
         Meta description preview:
       </span>
       <div
-        className="c22 c23"
+        className="c22"
         color="#545454"
         onClick={[Function]}
         onMouseLeave={[Function]}
         onMouseOver={[Function]}
       >
         <div
-          className="c24 c22 c23"
+          className="c23 c22"
           color="#545454"
         >
           Description
@@ -1765,11 +1761,11 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -1795,7 +1791,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -1803,16 +1799,12 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -1979,14 +1971,14 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
         Meta description preview:
       </span>
       <div
-        className="c21 c22"
+        className="c21"
         color="#545454"
         onClick={[Function]}
         onMouseLeave={[Function]}
         onMouseOver={[Function]}
       >
         <div
-          className="c23 c21 c22"
+          className="c22 c21"
           color="#545454"
         >
           Description
@@ -2167,11 +2159,11 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
 
 .c17 {
   display: inline-block;
+  font-size: 16px;
   line-height: 1.2em;
   max-height: 2.4em;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 16px;
 }
 
 .c18 {
@@ -2197,7 +2189,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c21 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -2205,16 +2197,12 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   font-size: 13px;
 }
 
-.c21 {
-  max-height: 4em;
-  padding-bottom: 3px;
-}
-
-.c23 {
-  overflow: hidden;
+.c22 {
   font-size: 14px;
   line-height: 20px;
-  max-height: calc( 4em + 3px );
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c13 {
@@ -2381,14 +2369,14 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
         Meta description preview:
       </span>
       <div
-        className="c21 c22"
+        className="c21"
         color="#545454"
         onClick={[Function]}
         onMouseLeave={[Function]}
         onMouseOver={[Function]}
       >
         <div
-          className="c23 c21 c22"
+          className="c22 c21"
           color="#545454"
         >
           Description


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improve the Snippet Preview rendering with long text.

## Relevant technical choices:

- unless I'm missing something, the description should have maximum 4 lines of text
- adjusts the max-height to a proper value, based on the line height
- also improves some indentation, as we shouldn't have lines with a mix of tab characters and spaces

## Test instructions

- to test on the standalone version, I've merged develop so the fix from #539 is in
- run `yarn start` and go on localhost:3333
- first, observe the behavior in the title field
- depending on the text added, you may see the overflowing word appear for some milliseconds and then disappear (suggestion: try repeatedly with very short words)
- then compare with the description field behavior
- the max number of lines is 4: when adding overflowing words, they disappear almost instantly (behavior should be the same of the title field)
- optionally, yarn link to the plugin and test in the meta box

Fixes https://github.com/Yoast/wordpress-seo/issues/9735
