### PR TITLE
Implement displaydata support

### DIFF
--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -325,13 +325,13 @@ class SnippetEditor extends React.Component {
 	 *
 	 * @returns {Object} The data for the preview.
 	 */
-	mapDataToPreview( originalData ) {
+	mapDataToPreview( originalData, displayData ) {
 		const { baseUrl, mapDataToPreview } = this.props;
 
 		const mappedData = {
 			title: this.processReplacementVariables( originalData.title ),
 			url: baseUrl.replace( "https://", "" ) + originalData.slug,
-			description: this.processReplacementVariables( originalData.description ),
+			description: this.processReplacementVariables( originalData.description || displayData.description ),
 		};
 
 		if ( mapDataToPreview ) {
@@ -389,6 +389,7 @@ class SnippetEditor extends React.Component {
 		const {
 			onChange,
 			data,
+			displayData,
 			descriptionPlaceholder,
 			mode,
 			date,
@@ -402,7 +403,7 @@ class SnippetEditor extends React.Component {
 			isOpen,
 		} = this.state;
 
-		const mappedData = this.mapDataToPreview( data );
+		const mappedData = this.mapDataToPreview( data, displayData );
 
 		/*
 		 * The SnippetPreview is not a build-in HTML element so this check is not
@@ -446,6 +447,11 @@ class SnippetEditor extends React.Component {
 SnippetEditor.propTypes = {
 	replacementVariables: replacementVariablesShape,
 	data: PropTypes.shape( {
+		title: PropTypes.string.isRequired,
+		slug: PropTypes.string.isRequired,
+		description: PropTypes.string.isRequired,
+	} ).isRequired,
+	displayData: PropTypes.shape( {
 		title: PropTypes.string.isRequired,
 		slug: PropTypes.string.isRequired,
 		description: PropTypes.string.isRequired,

--- a/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
@@ -20,9 +20,16 @@ const defaultData = {
 	description: "Test description, %%replacement_variable%%",
 };
 
+const defaultDisplay = {
+	title: "Test displaytitle",
+	slug: "test-display-slug",
+	description: "Test display description, %%replacement_variable%%",
+};
+
 const defaultArgs = {
 	baseUrl: "https://example.org/",
 	data: defaultData,
+	displayData: defaultDisplay,
 	onChange: () => {},
 };
 

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -1164,6 +1164,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
       "score": 0,
     }
   }
+  displayData={
+    Object {
+      "description": "Test display description, %%replacement_variable%%",
+      "slug": "test-display-slug",
+      "title": "Test displaytitle",
+    }
+  }
   intl={
     Object {
       "defaultFormats": Object {},
@@ -2783,6 +2790,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
       "actual": 0,
       "max": 320,
       "score": 0,
+    }
+  }
+  displayData={
+    Object {
+      "description": "Test display description, %%replacement_variable%%",
+      "slug": "test-display-slug",
+      "title": "Test displaytitle",
     }
   }
   intl={
@@ -4406,6 +4420,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
       "score": 0,
     }
   }
+  displayData={
+    Object {
+      "description": "Test display description, %%replacement_variable%%",
+      "slug": "test-display-slug",
+      "title": "Test displaytitle",
+    }
+  }
   intl={
     Object {
       "defaultFormats": Object {},
@@ -6027,6 +6048,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
       "score": 0,
     }
   }
+  displayData={
+    Object {
+      "description": "Test display description, %%replacement_variable%%",
+      "slug": "test-display-slug",
+      "title": "Test displaytitle",
+    }
+  }
   intl={
     Object {
       "defaultFormats": Object {},
@@ -7490,6 +7518,13 @@ exports[`SnippetEditor closes when calling close() 2`] = `
       "score": 0,
     }
   }
+  displayData={
+    Object {
+      "description": "Test display description, %%replacement_variable%%",
+      "slug": "test-display-slug",
+      "title": "Test displaytitle",
+    }
+  }
   intl={
     Object {
       "defaultFormats": Object {},
@@ -8860,6 +8895,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
       "actual": 0,
       "max": 320,
       "score": 0,
+    }
+  }
+  displayData={
+    Object {
+      "description": "Test display description, %%replacement_variable%%",
+      "slug": "test-display-slug",
+      "title": "Test displaytitle",
     }
   }
   intl={
@@ -10481,6 +10523,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
       "actual": 330,
       "max": 650,
       "score": 9,
+    }
+  }
+  displayData={
+    Object {
+      "description": "Test display description, %%replacement_variable%%",
+      "slug": "test-display-slug",
+      "title": "Test displaytitle",
     }
   }
   intl={
@@ -13359,6 +13408,13 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
       "score": 0,
     }
   }
+  displayData={
+    Object {
+      "description": "Test display description, %%replacement_variable%%",
+      "slug": "test-display-slug",
+      "title": "Test displaytitle",
+    }
+  }
   intl={
     Object {
       "defaultFormats": Object {},
@@ -15000,6 +15056,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
       "score": 0,
     }
   }
+  displayData={
+    Object {
+      "description": "Test display description, %%replacement_variable%%",
+      "slug": "test-display-slug",
+      "title": "Test displaytitle",
+    }
+  }
   intl={
     Object {
       "defaultFormats": Object {},
@@ -16629,6 +16692,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
       "score": 0,
     }
   }
+  displayData={
+    Object {
+      "description": "Test display description, %%replacement_variable%%",
+      "slug": "test-display-slug",
+      "title": "Test displaytitle",
+    }
+  }
   intl={
     Object {
       "defaultFormats": Object {},
@@ -18248,6 +18318,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
       "actual": 0,
       "max": 320,
       "score": 0,
+    }
+  }
+  displayData={
+    Object {
+      "description": "Test display description, %%replacement_variable%%",
+      "slug": "test-display-slug",
+      "title": "Test displaytitle",
     }
   }
   intl={


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Use the displayData field from the redux store to inform what text should be displayed in the snippet preview.

## Relevant technical choices:

* See https://github.com/Yoast/wordpress-seo/pull/9806

## Test instructions

This PR can be tested by following these steps:

* See https://github.com/Yoast/wordpress-seo/pull/9806

Fixes https://github.com/Yoast/wordpress-seo/issues/9752
