### PR TITLE
Move translation to React render method

### DIFF
--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -55,11 +55,6 @@ const angleRight = ( color ) => "data:image/svg+xml;charset=utf8," + encodeURICo
 	"</svg>"
 );
 
-export const helpText = [ __( "This is a rendering of what this post might look like in Google's search results. ", "yoast-components" ),
-	<a key="1" href="https://yoa.st/snippet-preview" rel="noopener noreferrer" target="_blank">
-		{ __( "Learn more about the Snippet Preview.", "yoast-components" ) }
-	</a> ];
-
 export const BaseTitle = styled.div`
 	cursor: pointer;
 	position: relative;
@@ -672,6 +667,11 @@ export default class SnippetPreview extends PureComponent {
 		const separator = mode === MODE_DESKTOP ? null : <Separator/>;
 		const downArrow = mode === MODE_DESKTOP ? <UrlDownArrow/> : null;
 		const amp       = mode === MODE_DESKTOP || ! isAmp ? null : <Amp/>;
+
+		const helpText = [ __( "This is a rendering of what this post might look like in Google's search results. ", "yoast-components" ),
+			<a key="1" href="https://yoa.st/snippet-preview" rel="noopener noreferrer" target="_blank">
+				{ __( "Learn more about the Snippet Preview.", "yoast-components" ) }
+			</a> ];
 
 		/*
 		 * The jsx-a11y eslint plugin is asking for an onFocus accompanying the onMouseOver.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a translation would be executed too early.

## Relevant technical choices:

If we translate upon loading the file we don't have a chance to load the translations before this point, resulting in a Jed error.

## Test instructions

This PR can be tested by following these steps:

* Load the term edit page in WordPress with yoast-components linked
* You shouldn't see an error now.

Fixes https://github.com/Yoast/wordpress-seo/issues/9779