### PR TITLE
Added explanatory text for the replacevars

### DIFF
--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -113,6 +113,7 @@ class SnippetEditor extends React.Component {
 			data,
 			titleLengthProgress,
 			descriptionLengthProgress,
+			replacementVariablesExplanation,
 		} = this.props;
 		const replacementVariables = this.decodeSeparatorVariable( this.props.replacementVariables );
 		const { activeField, hoveredField, isOpen } = this.state;
@@ -130,6 +131,7 @@ class SnippetEditor extends React.Component {
 					onChange={ this.handleChange }
 					onFocus={ this.setFieldFocus }
 					replacementVariables={ replacementVariables }
+					replacementVariablesExplanation={ replacementVariablesExplanation }
 					titleLengthProgress={ titleLengthProgress }
 					descriptionLengthProgress={ descriptionLengthProgress }
 				/>
@@ -404,6 +406,7 @@ SnippetEditor.propTypes = {
 	mapDataToPreview: PropTypes.func,
 	keyword: PropTypes.string,
 	locale: PropTypes.string,
+	replacementVariablesExplanation: PropTypes.string,
 };
 
 SnippetEditor.defaultProps = {

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -213,6 +213,7 @@ class SnippetEditorFields extends React.Component {
 			activeField,
 			hoveredField,
 			replacementVariables,
+			replacementVariablesExplanation,
 			titleLengthProgress,
 			descriptionLengthProgress,
 			onFocus,
@@ -298,10 +299,7 @@ class SnippetEditorFields extends React.Component {
 						value={ descriptionLengthProgress.actual }
 						progressColor={ this.getProgressColor( descriptionLengthProgress.score ) }
 					/>
-					<ReplacementVariableExplanation>{
-						__( "Type '%' to add snippet variables. " +
-							"See the 'Help' tab on this page to see all available variables.", "yoast-components" )
-					}</ReplacementVariableExplanation>
+					<ReplacementVariableExplanation>{ replacementVariablesExplanation }</ReplacementVariableExplanation>
 				</FormSection>
 			</StyledEditor>
 		);
@@ -340,6 +338,7 @@ SnippetEditorFields.propTypes = {
 	hoveredField: PropTypes.oneOf( [ "title", "slug", "description" ] ),
 	titleLengthProgress: lengthProgressShape,
 	descriptionLengthProgress: lengthProgressShape,
+	replacementVariablesExplanation: PropTypes.string,
 };
 
 SnippetEditorFields.defaultProps = {
@@ -355,6 +354,8 @@ SnippetEditorFields.defaultProps = {
 		actual: 0,
 		score: 0,
 	},
+	replacementVariablesExplanation: __( "Type '%' to add snippet variables. " +
+		"See the 'Help' tab on this page to see all available variables.", "yoast-components" ),
 };
 
 export default SnippetEditorFields;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -282,8 +282,8 @@ class SnippetEditorFields extends React.Component {
 						progressColor={ this.getProgressColor( descriptionLengthProgress.score ) }
 					/>
 					<ReplacementVariableExplanation>{
-						__( "Type '%' to add snippet variables, " +
-							"see the 'Help' tab on this page to see all available variables.", "yoast-components" )
+						__( "Type '%' to add snippet variables. " +
+							"See the 'Help' tab on this page to see all available variables.", "yoast-components" )
 					}</ReplacementVariableExplanation>
 				</FormSection>
 			</StyledEditor>

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -94,17 +94,22 @@ const InputContainerDescription = InputContainer.extend`
 `;
 
 const FormSection = styled.div`
-	margin: 32px 0;
+	margin: 32px 0 0;
 `;
 
 const StyledEditor = styled.section`
-	padding: 10px 20px 20px 20px;
+	padding: 10px 20px 0 20px;
 `;
 
 const SimulatedLabel = styled.div`
 	cursor: pointer;
 	font-size: 16px;
 	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
+`;
+
+const ReplacementVariableExplanation = styled.p`
+	margin: 16px 0;
+	font-size: 13px;
 `;
 
 class SnippetEditorFields extends React.Component {
@@ -276,6 +281,10 @@ class SnippetEditorFields extends React.Component {
 						value={ descriptionLengthProgress.actual }
 						progressColor={ this.getProgressColor( descriptionLengthProgress.score ) }
 					/>
+					<ReplacementVariableExplanation>{
+						__( "Type '%' to add snippet variables, " +
+							"see the 'Help' tab on this page to see all available variables.", "yoast-components" )
+					}</ReplacementVariableExplanation>
 				</FormSection>
 			</StyledEditor>
 		);

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -641,6 +641,7 @@ exports[`SnippetEditor activates a field on onClick() and opens the editor 1`] =
       onChange={[Function]}
       onFocus={[Function]}
       replacementVariables={Array []}
+      replacementVariablesExplanation="Type '%' to add snippet variables. See the 'Help' tab on this page to see all available variables."
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -2021,6 +2022,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
       onChange={[Function]}
       onFocus={[Function]}
       replacementVariables={Array []}
+      replacementVariablesExplanation="Type '%' to add snippet variables. See the 'Help' tab on this page to see all available variables."
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -3621,6 +3623,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
       onChange={[Function]}
       onFocus={[Function]}
       replacementVariables={Array []}
+      replacementVariablesExplanation="Type '%' to add snippet variables. See the 'Help' tab on this page to see all available variables."
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -5221,6 +5224,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
       onChange={[Function]}
       onFocus={[Function]}
       replacementVariables={Array []}
+      replacementVariablesExplanation="Type '%' to add snippet variables. See the 'Help' tab on this page to see all available variables."
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -6821,6 +6825,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
       onChange={[Function]}
       onFocus={[Function]}
       replacementVariables={Array []}
+      replacementVariablesExplanation="Type '%' to add snippet variables. See the 'Help' tab on this page to see all available variables."
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -9667,6 +9672,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
       onChange={[Function]}
       onFocus={[Function]}
       replacementVariables={Array []}
+      replacementVariablesExplanation="Type '%' to add snippet variables. See the 'Help' tab on this page to see all available variables."
       titleLengthProgress={
         Object {
           "actual": 361,
@@ -11299,6 +11305,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
       onChange={[Function]}
       onFocus={[Function]}
       replacementVariables={Array []}
+      replacementVariablesExplanation="Type '%' to add snippet variables. See the 'Help' tab on this page to see all available variables."
       titleLengthProgress={
         Object {
           "actual": 100,
@@ -12921,6 +12928,7 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
           },
         ]
       }
+      replacementVariablesExplanation="Type '%' to add snippet variables. See the 'Help' tab on this page to see all available variables."
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -13236,6 +13244,7 @@ exports[`SnippetEditor doesn't remove the highlight if the wrong field is left 1
       onChange={[Function]}
       onFocus={[Function]}
       replacementVariables={Array []}
+      replacementVariablesExplanation="Type '%' to add snippet variables. See the 'Help' tab on this page to see all available variables."
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -15806,6 +15815,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
       onChange={[Function]}
       onFocus={[Function]}
       replacementVariables={Array []}
+      replacementVariablesExplanation="Type '%' to add snippet variables. See the 'Help' tab on this page to see all available variables."
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -17426,6 +17436,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
       onChange={[Function]}
       onFocus={[Function]}
       replacementVariables={Array []}
+      replacementVariablesExplanation="Type '%' to add snippet variables. See the 'Help' tab on this page to see all available variables."
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -19026,6 +19037,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
       onChange={[Function]}
       onFocus={[Function]}
       replacementVariables={Array []}
+      replacementVariablesExplanation="Type '%' to add snippet variables. See the 'Help' tab on this page to see all available variables."
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -20648,6 +20660,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           },
         ]
       }
+      replacementVariablesExplanation="Type '%' to add snippet variables. See the 'Help' tab on this page to see all available variables."
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -21558,6 +21571,7 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
       onChange={[Function]}
       onFocus={[Function]}
       replacementVariables={Array []}
+      replacementVariablesExplanation="Type '%' to add snippet variables. See the 'Help' tab on this page to see all available variables."
       titleLengthProgress={
         Object {
           "actual": 0,

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -743,7 +743,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   margin-right: 7px;
 }
 
-.c37 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -1044,17 +1044,22 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 .c30 {
-  margin: 32px 0;
+  margin: 32px 0 0;
 }
 
 .c29 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0 20px;
 }
 
 .c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c37 {
+  margin: 16px 0;
+  font-size: 13px;
 }
 
 .c24 {
@@ -2200,6 +2205,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   value={42}
                 />
               </ProgressBar>
+              <SnippetEditorFields__ReplacementVariableExplanation>
+                <p
+                  className="c37"
+                >
+                  Type '%' to add snippet variables, see the "Help" tab on this page to see all available variables.
+                </p>
+              </SnippetEditorFields__ReplacementVariableExplanation>
             </div>
           </SnippetEditorFields__FormSection>
         </section>
@@ -2212,7 +2224,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c37"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -2221,7 +2233,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c37 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -2230,7 +2242,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -2239,7 +2251,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -2248,13 +2260,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -2355,7 +2367,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   margin-right: 7px;
 }
 
-.c37 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -2656,17 +2668,22 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 .c30 {
-  margin: 32px 0;
+  margin: 32px 0 0;
 }
 
 .c29 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0 20px;
 }
 
 .c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c37 {
+  margin: 16px 0;
+  font-size: 13px;
 }
 
 .c24 {
@@ -3812,6 +3829,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   value={42}
                 />
               </ProgressBar>
+              <SnippetEditorFields__ReplacementVariableExplanation>
+                <p
+                  className="c37"
+                >
+                  Type '%' to add snippet variables, see the "Help" tab on this page to see all available variables.
+                </p>
+              </SnippetEditorFields__ReplacementVariableExplanation>
             </div>
           </SnippetEditorFields__FormSection>
         </section>
@@ -3824,7 +3848,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c37"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -3833,7 +3857,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c37 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -3842,7 +3866,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -3851,7 +3875,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -3860,13 +3884,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -3967,7 +3991,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   margin-right: 7px;
 }
 
-.c37 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -4268,17 +4292,22 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 .c30 {
-  margin: 32px 0;
+  margin: 32px 0 0;
 }
 
 .c29 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0 20px;
 }
 
 .c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c37 {
+  margin: 16px 0;
+  font-size: 13px;
 }
 
 .c24 {
@@ -5424,6 +5453,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   value={42}
                 />
               </ProgressBar>
+              <SnippetEditorFields__ReplacementVariableExplanation>
+                <p
+                  className="c37"
+                >
+                  Type '%' to add snippet variables, see the "Help" tab on this page to see all available variables.
+                </p>
+              </SnippetEditorFields__ReplacementVariableExplanation>
             </div>
           </SnippetEditorFields__FormSection>
         </section>
@@ -5436,7 +5472,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c37"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -5445,7 +5481,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c37 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -5454,7 +5490,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -5463,7 +5499,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -5472,13 +5508,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -5579,7 +5615,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   margin-right: 7px;
 }
 
-.c37 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -5880,17 +5916,22 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 .c30 {
-  margin: 32px 0;
+  margin: 32px 0 0;
 }
 
 .c29 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0 20px;
 }
 
 .c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c37 {
+  margin: 16px 0;
+  font-size: 13px;
 }
 
 .c24 {
@@ -7036,6 +7077,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   value={42}
                 />
               </ProgressBar>
+              <SnippetEditorFields__ReplacementVariableExplanation>
+                <p
+                  className="c37"
+                >
+                  Type '%' to add snippet variables, see the "Help" tab on this page to see all available variables.
+                </p>
+              </SnippetEditorFields__ReplacementVariableExplanation>
             </div>
           </SnippetEditorFields__FormSection>
         </section>
@@ -7048,7 +7096,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c37"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -7057,7 +7105,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c37 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -7066,7 +7114,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -7075,7 +7123,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -7084,13 +7132,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -8405,7 +8453,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   margin-right: 7px;
 }
 
-.c37 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -8706,17 +8754,22 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c30 {
-  margin: 32px 0;
+  margin: 32px 0 0;
 }
 
 .c29 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0 20px;
 }
 
 .c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c37 {
+  margin: 16px 0;
+  font-size: 13px;
 }
 
 .c24 {
@@ -9862,6 +9915,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   value={42}
                 />
               </ProgressBar>
+              <SnippetEditorFields__ReplacementVariableExplanation>
+                <p
+                  className="c37"
+                >
+                  Type '%' to add snippet variables, see the "Help" tab on this page to see all available variables.
+                </p>
+              </SnippetEditorFields__ReplacementVariableExplanation>
             </div>
           </SnippetEditorFields__FormSection>
         </section>
@@ -9874,7 +9934,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c37"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -9883,7 +9943,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c37 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -9892,7 +9952,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -9901,7 +9961,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -9910,13 +9970,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -10017,7 +10077,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   margin-right: 7px;
 }
 
-.c37 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -10318,17 +10378,22 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c30 {
-  margin: 32px 0;
+  margin: 32px 0 0;
 }
 
 .c29 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0 20px;
 }
 
 .c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c37 {
+  margin: 16px 0;
+  font-size: 13px;
 }
 
 .c24 {
@@ -11474,6 +11539,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   value={42}
                 />
               </ProgressBar>
+              <SnippetEditorFields__ReplacementVariableExplanation>
+                <p
+                  className="c37"
+                >
+                  Type '%' to add snippet variables, see the "Help" tab on this page to see all available variables.
+                </p>
+              </SnippetEditorFields__ReplacementVariableExplanation>
             </div>
           </SnippetEditorFields__FormSection>
         </section>
@@ -11486,7 +11558,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c37"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -11495,7 +11567,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c37 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -11504,7 +11576,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -11513,7 +11585,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -11522,13 +11594,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -12872,7 +12944,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   margin-right: 7px;
 }
 
-.c38 {
+.c39 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -13173,17 +13245,22 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 }
 
 .c31 {
-  margin: 32px 0;
+  margin: 32px 0 0;
 }
 
 .c30 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0 20px;
 }
 
 .c32 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c38 {
+  margin: 16px 0;
+  font-size: 13px;
 }
 
 .c25 {
@@ -14349,6 +14426,13 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   value={42}
                 />
               </ProgressBar>
+              <SnippetEditorFields__ReplacementVariableExplanation>
+                <p
+                  className="c38"
+                >
+                  Type '%' to add snippet variables, see the "Help" tab on this page to see all available variables.
+                </p>
+              </SnippetEditorFields__ReplacementVariableExplanation>
             </div>
           </SnippetEditorFields__FormSection>
         </section>
@@ -14361,7 +14445,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c38"
+        className="c39"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -14370,7 +14454,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c39 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -14379,7 +14463,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c39 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -14388,7 +14472,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -14397,13 +14481,13 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -14504,7 +14588,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   margin-right: 7px;
 }
 
-.c38 {
+.c39 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -14805,17 +14889,22 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 }
 
 .c31 {
-  margin: 32px 0;
+  margin: 32px 0 0;
 }
 
 .c30 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0 20px;
 }
 
 .c32 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c38 {
+  margin: 16px 0;
+  font-size: 13px;
 }
 
 .c25 {
@@ -15981,6 +16070,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                   value={42}
                 />
               </ProgressBar>
+              <SnippetEditorFields__ReplacementVariableExplanation>
+                <p
+                  className="c38"
+                >
+                  Type '%' to add snippet variables, see the "Help" tab on this page to see all available variables.
+                </p>
+              </SnippetEditorFields__ReplacementVariableExplanation>
             </div>
           </SnippetEditorFields__FormSection>
         </section>
@@ -15993,7 +16089,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c38"
+        className="c39"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -16002,7 +16098,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c39 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -16011,7 +16107,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c39 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -16020,7 +16116,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -16029,13 +16125,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -16136,7 +16232,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   margin-right: 7px;
 }
 
-.c37 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -16437,17 +16533,22 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 .c30 {
-  margin: 32px 0;
+  margin: 32px 0 0;
 }
 
 .c29 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0 20px;
 }
 
 .c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c37 {
+  margin: 16px 0;
+  font-size: 13px;
 }
 
 .c24 {
@@ -17593,6 +17694,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   value={42}
                 />
               </ProgressBar>
+              <SnippetEditorFields__ReplacementVariableExplanation>
+                <p
+                  className="c37"
+                >
+                  Type '%' to add snippet variables, see the "Help" tab on this page to see all available variables.
+                </p>
+              </SnippetEditorFields__ReplacementVariableExplanation>
             </div>
           </SnippetEditorFields__FormSection>
         </section>
@@ -17605,7 +17713,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c37"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -17614,7 +17722,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c37 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -17623,7 +17731,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -17632,7 +17740,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -17641,13 +17749,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -17748,7 +17856,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   margin-right: 7px;
 }
 
-.c37 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -18049,17 +18157,22 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 .c30 {
-  margin: 32px 0;
+  margin: 32px 0 0;
 }
 
 .c29 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0 20px;
 }
 
 .c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+}
+
+.c37 {
+  margin: 16px 0;
+  font-size: 13px;
 }
 
 .c24 {
@@ -19249,6 +19362,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   value={42}
                 />
               </ProgressBar>
+              <SnippetEditorFields__ReplacementVariableExplanation>
+                <p
+                  className="c37"
+                >
+                  Type '%' to add snippet variables, see the "Help" tab on this page to see all available variables.
+                </p>
+              </SnippetEditorFields__ReplacementVariableExplanation>
             </div>
           </SnippetEditorFields__FormSection>
         </section>
@@ -19261,7 +19381,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c37"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -19270,7 +19390,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c37 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -19279,7 +19399,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -19288,7 +19408,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -19297,13 +19417,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added explanatory text for the replacevars in the snippet editor.

## Relevant technical choices:

* Added the props for the explanation, so that it can be overwritten should the user not want add it. Set the explanation we want to use as the default prop.
* No styles yet. So chosen style is based on surroundings:

<img width="663" alt="add_new_post_ _local_wordpress_test_ _wordpress-2" src="https://user-images.githubusercontent.com/11849359/40476726-08feea48-5f45-11e8-9696-638d0fc17046.png">


## Test instructions

This PR can be tested by following these steps:

* Visit the post page.
* Check if the help text provided in the issue is added between the meta description field and the close editor button.
* Check if tests pass and if it still looks good on scaled screens.

Fixes https://github.com/Yoast/wordpress-seo/issues/9786
