### PR TITLE
Pass meta description placeholder to editor

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -82,6 +82,7 @@ class ReplacementVariableEditor extends React.Component {
 		 * `rawContent === serialize( unserialize( rawContent ) )`
 		 */
 		this._serializedContent = rawContent;
+		this.styleDraftEditor = styleDraftEditor;
 
 		this.onChange = this.onChange.bind( this );
 		this.onSearchChange = this.onSearchChange.bind( this );
@@ -243,10 +244,12 @@ class ReplacementVariableEditor extends React.Component {
 	 * @returns {ReactElement} The rendered element.
 	 */
 	render() {
-		console.log( this.props.descriptionEditorFieldPlaceholder );
+		console.log( "placeholder: ", this.props.descriptionEditorFieldPlaceholder );
+		console.log( "blockStyleFn: ", this.props.blockStyleFn );
 		const { MentionSuggestions } = this.mentionsPlugin;
-		const { onFocus, onBlur, ariaLabelledBy, descriptionEditorFieldPlaceholder } = this.props;
+		const { onFocus, onBlur, ariaLabelledBy, descriptionEditorFieldPlaceholder, blockStyleFn } = this.props;
 		const { editorState, replacementVariables } = this.state;
+		const styleDraftEditor = this.styleDraftEditor;
 
 		return (
 			<React.Fragment>
@@ -259,6 +262,7 @@ class ReplacementVariableEditor extends React.Component {
 					ref={ this.setEditorRef }
 					stripPastedStyles={ true }
 					ariaLabelledBy={ ariaLabelledBy }
+					customStyleMap={ styleDraftEditor }
 					placeholder={ descriptionEditorFieldPlaceholder }
 				/>
 				<MentionSuggestions

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -243,8 +243,9 @@ class ReplacementVariableEditor extends React.Component {
 	 * @returns {ReactElement} The rendered element.
 	 */
 	render() {
+		console.log( this.props.descriptionEditorFieldPlaceholder );
 		const { MentionSuggestions } = this.mentionsPlugin;
-		const { onFocus, onBlur, ariaLabelledBy } = this.props;
+		const { onFocus, onBlur, ariaLabelledBy, descriptionEditorFieldPlaceholder } = this.props;
 		const { editorState, replacementVariables } = this.state;
 
 		return (
@@ -258,6 +259,7 @@ class ReplacementVariableEditor extends React.Component {
 					ref={ this.setEditorRef }
 					stripPastedStyles={ true }
 					ariaLabelledBy={ ariaLabelledBy }
+					placeholder={ descriptionEditorFieldPlaceholder }
 				/>
 				<MentionSuggestions
 					onSearchChange={ this.onSearchChange }
@@ -276,12 +278,14 @@ ReplacementVariableEditor.propTypes = {
 	onChange: PropTypes.func.isRequired,
 	onFocus: PropTypes.func,
 	onBlur: PropTypes.func,
+	descriptionEditorFieldPlaceholder: PropTypes.string,
 };
 
 ReplacementVariableEditor.defaultProps = {
 	onFocus: () => {},
 	onBlur: () => {},
 	className: "",
+	descriptionEditorFieldPlaceholder: "",
 };
 
 export default ReplacementVariableEditor;

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -82,7 +82,6 @@ class ReplacementVariableEditor extends React.Component {
 		 * `rawContent === serialize( unserialize( rawContent ) )`
 		 */
 		this._serializedContent = rawContent;
-		this.styleDraftEditor = styleDraftEditor;
 
 		this.onChange = this.onChange.bind( this );
 		this.onSearchChange = this.onSearchChange.bind( this );
@@ -244,12 +243,9 @@ class ReplacementVariableEditor extends React.Component {
 	 * @returns {ReactElement} The rendered element.
 	 */
 	render() {
-		console.log( "placeholder: ", this.props.descriptionEditorFieldPlaceholder );
-		console.log( "blockStyleFn: ", this.props.blockStyleFn );
 		const { MentionSuggestions } = this.mentionsPlugin;
-		const { onFocus, onBlur, ariaLabelledBy, descriptionEditorFieldPlaceholder, blockStyleFn } = this.props;
+		const { onFocus, onBlur, ariaLabelledBy, descriptionEditorFieldPlaceholder } = this.props;
 		const { editorState, replacementVariables } = this.state;
-		const styleDraftEditor = this.styleDraftEditor;
 
 		return (
 			<React.Fragment>
@@ -262,7 +258,6 @@ class ReplacementVariableEditor extends React.Component {
 					ref={ this.setEditorRef }
 					stripPastedStyles={ true }
 					ariaLabelledBy={ ariaLabelledBy }
-					customStyleMap={ styleDraftEditor }
 					placeholder={ descriptionEditorFieldPlaceholder }
 				/>
 				<MentionSuggestions

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -38,7 +38,7 @@ const CloseEditorButton = SnippetEditorButton.extend`
 	margin-left: 20px;
 `;
 
-const MetaDescriptionPlaceholder = "Modify your meta description by editing right here";
+const MetaDescriptionPlaceholder = "Modify your meta description by editing it right here";
 
 class SnippetEditor extends React.Component {
 	/**

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -368,7 +368,6 @@ class SnippetEditor extends React.Component {
 					onMouseLeave={ this.onMouseLeave }
 					onMouseUp={ this.onMouseUp }
 					locale={ locale }
-					descriptionPlaceholder={ descriptionPlaceholder }
 					{ ...mappedData }
 				/>
 

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -37,8 +37,6 @@ const CloseEditorButton = SnippetEditorButton.extend`
 	margin-left: 20px;
 `;
 
-const MetaDescriptionPlaceholder = "Modify your meta description by editing it right here";
-
 class SnippetEditor extends React.Component {
 	/**
 	 * Constructs the snippet editor.
@@ -115,6 +113,7 @@ class SnippetEditor extends React.Component {
 			titleLengthProgress,
 			descriptionLengthProgress,
 			replacementVariables,
+			descriptionEditorFieldPlaceholder,
 		} = this.props;
 		const { activeField, hoveredField, isOpen } = this.state;
 
@@ -134,7 +133,7 @@ class SnippetEditor extends React.Component {
 					replacementVariables={ replacementVariables }
 					titleLengthProgress={ titleLengthProgress }
 					descriptionLengthProgress={ descriptionLengthProgress }
-					descriptionEditorFieldPlaceholder={ MetaDescriptionPlaceholder }
+					descriptionEditorFieldPlaceholder={ descriptionEditorFieldPlaceholder }
 				/>
 				<CloseEditorButton onClick={ this.close }>
 					{ __( "Close snippet editor", "yoast-components" ) }
@@ -428,6 +427,7 @@ SnippetEditor.defaultProps = {
 	mapDataToPreview: null,
 	generatedDescription: "",
 	locale: "en",
+	descriptionEditorFieldPlaceholder: "Modify your meta description by editing it right here",
 };
 
 export default SnippetEditor;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -368,6 +368,7 @@ class SnippetEditor extends React.Component {
 					onMouseLeave={ this.onMouseLeave }
 					onMouseUp={ this.onMouseUp }
 					locale={ locale }
+					descriptionPlaceholder={ descriptionPlaceholder }
 					{ ...mappedData }
 				/>
 

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -115,12 +115,9 @@ class SnippetEditor extends React.Component {
 			data,
 			titleLengthProgress,
 			descriptionLengthProgress,
-			descriptionFieldPlaceholder,
 		} = this.props;
 		const replacementVariables = this.decodeSeparatorVariable( this.props.replacementVariables );
 		const { activeField, hoveredField, isOpen } = this.state;
-
-		console.log( "SnippetEditorFields placeholder: ", descriptionFieldPlaceholder );
 
 		if ( ! isOpen ) {
 			return null;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -38,6 +38,8 @@ const CloseEditorButton = SnippetEditorButton.extend`
 	margin-left: 20px;
 `;
 
+const MetaDescriptionPlaceholder = "Modify your meta description by editing right here";
+
 class SnippetEditor extends React.Component {
 	/**
 	 * Constructs the snippet editor.
@@ -113,9 +115,12 @@ class SnippetEditor extends React.Component {
 			data,
 			titleLengthProgress,
 			descriptionLengthProgress,
+			descriptionFieldPlaceholder,
 		} = this.props;
 		const replacementVariables = this.decodeSeparatorVariable( this.props.replacementVariables );
 		const { activeField, hoveredField, isOpen } = this.state;
+
+		console.log( "SnippetEditorFields placeholder: ", descriptionFieldPlaceholder );
 
 		if ( ! isOpen ) {
 			return null;
@@ -132,6 +137,7 @@ class SnippetEditor extends React.Component {
 					replacementVariables={ replacementVariables }
 					titleLengthProgress={ titleLengthProgress }
 					descriptionLengthProgress={ descriptionLengthProgress }
+					descriptionEditorFieldPlaceholder={ MetaDescriptionPlaceholder }
 				/>
 				<CloseEditorButton onClick={ this.close }>
 					{ __( "Close snippet editor", "yoast-components" ) }
@@ -395,6 +401,7 @@ SnippetEditor.propTypes = {
 		description: PropTypes.string.isRequired,
 	} ).isRequired,
 	descriptionPlaceholder: PropTypes.string,
+	descriptionEditorFieldPlaceholder: PropTypes.string,
 	baseUrl: PropTypes.string.isRequired,
 	mode: PropTypes.oneOf( MODES ),
 	date: PropTypes.string,

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -217,7 +217,6 @@ class SnippetEditorFields extends React.Component {
 	 * @returns {ReactElement} The snippet editor element.
 	 */
 	render() {
-		console.log( "PROPS: ", this.props );
 		const {
 			activeField,
 			hoveredField,
@@ -233,8 +232,6 @@ class SnippetEditorFields extends React.Component {
 				description,
 			},
 		} = this.props;
-
-		console.log( "SnippetEditorFields placeholder: ", descriptionEditorFieldPlaceholder );
 
 		const titleLabelId = `${ this.uniqueId }-title`;
 		const slugLabelId = `${ this.uniqueId }-slug`;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -204,6 +204,7 @@ class SnippetEditorFields extends React.Component {
 	 * @returns {ReactElement} The snippet editor element.
 	 */
 	render() {
+		console.log( "PROPS: ", this.props );
 		const {
 			activeField,
 			hoveredField,
@@ -212,12 +213,15 @@ class SnippetEditorFields extends React.Component {
 			descriptionLengthProgress,
 			onFocus,
 			onChange,
+			descriptionEditorFieldPlaceholder,
 			data: {
 				title,
 				slug,
 				description,
 			},
 		} = this.props;
+
+		console.log( "SnippetEditorFields placeholder: ", descriptionEditorFieldPlaceholder );
 
 		const titleLabelId = `${ this.uniqueId }-title`;
 		const slugLabelId = `${ this.uniqueId }-slug`;
@@ -286,6 +290,7 @@ class SnippetEditorFields extends React.Component {
 							replacementVariables={ replacementVariables }
 							ref={ ( ref ) => this.setRef( "description", ref ) }
 							ariaLabelledBy={ descriptionLabelId }
+							descriptionEditorFieldPlaceholder={ descriptionEditorFieldPlaceholder }
 						/>
 					</InputContainerDescription>
 					<ProgressBar
@@ -331,6 +336,7 @@ SnippetEditorFields.propTypes = {
 	hoveredField: PropTypes.oneOf( [ "title", "slug", "description" ] ),
 	titleLengthProgress: lengthProgressShape,
 	descriptionLengthProgress: lengthProgressShape,
+	descriptionEditorFieldPlaceholder: PropTypes.string,
 };
 
 SnippetEditorFields.defaultProps = {

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -71,19 +71,6 @@ const InputContainer = styled.div.attrs( {
 		background-size: 25px;
 		content: "";
 	}
-	
-	&::webkit-input-placeholder {
-		color: #72777c ! important;
-	}
-
-	&::moz-placeholder {
-		color: #72777c ! important;
-		opacity: 1;
-	}
-	
-	&::ms-input-placeholder {
-		color: #72777c ! important;
-	}
 `;
 
 const SlugInput = styled.input`

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -71,6 +71,19 @@ const InputContainer = styled.div.attrs( {
 		background-size: 25px;
 		content: "";
 	}
+	
+	&::webkit-input-placeholder {
+		color: #72777c ! important;
+	}
+
+	&::moz-placeholder {
+		color: #72777c ! important;
+		opacity: 1;
+	}
+	
+	&::ms-input-placeholder {
+		color: #72777c ! important;
+	}
 `;
 
 const SlugInput = styled.input`

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
@@ -134,6 +134,7 @@ exports[`ReplacementVariableEditor wraps a Draft.js editor instance 1`] = `
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
+    placeholder=""
     plugins={
       Array [
         Object {

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -630,6 +630,7 @@ exports[`SnippetEditor activates a field on onClick() and opens the editor 1`] =
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -968,6 +969,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -997,6 +1011,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -2005,6 +2032,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -2153,6 +2181,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-5-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onChange={[Function]}
                     onFocus={[Function]}
                     replacementVariables={Array []}
@@ -2556,6 +2585,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -2585,6 +2627,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -3593,6 +3648,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -3741,6 +3797,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-5-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onChange={[Function]}
                     onFocus={[Function]}
                     replacementVariables={Array []}
@@ -4144,6 +4201,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -4173,6 +4243,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -5181,6 +5264,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -5329,6 +5413,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-5-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onChange={[Function]}
                     onFocus={[Function]}
                     replacementVariables={Array []}
@@ -5732,6 +5817,19 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -5761,6 +5859,19 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -6769,6 +6880,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -6917,6 +7029,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-2-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onChange={[Function]}
                     onFocus={[Function]}
                     replacementVariables={Array []}
@@ -8566,6 +8679,19 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -8595,6 +8721,19 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -9603,6 +9742,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -9751,6 +9891,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-9-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onChange={[Function]}
                     onFocus={[Function]}
                     replacementVariables={Array []}
@@ -10186,6 +10327,19 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -10215,6 +10369,19 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -11223,6 +11390,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 330,
@@ -11371,6 +11539,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-8-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onChange={[Function]}
                     onFocus={[Function]}
                     replacementVariables={Array []}
@@ -11774,6 +11943,19 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -11803,6 +11985,19 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -12822,6 +13017,7 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -12992,6 +13188,7 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-7-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onChange={[Function]}
                     onFocus={[Function]}
                     replacementVariables={
@@ -13141,6 +13338,7 @@ exports[`SnippetEditor doesn't remove the highlight if the wrong field is left 1
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -14649,6 +14847,19 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   content: "";
 }
 
+.c33::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c33::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c33::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c36 {
   padding: 3px 5px;
   border: 1px solid #5b9dd9;
@@ -14678,6 +14889,19 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%231e8cbe%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c36::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c36::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c36::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c35 {
@@ -15706,6 +15930,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -15854,6 +16079,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-4-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onChange={[Function]}
                     onFocus={[Function]}
                     replacementVariables={Array []}
@@ -16257,6 +16483,19 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   content: "";
 }
 
+.c33::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c33::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c33::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c36 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -16286,6 +16525,19 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c36::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c36::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c36::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c35 {
@@ -17314,6 +17566,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -17462,6 +17715,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-3-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onChange={[Function]}
                     onFocus={[Function]}
                     replacementVariables={Array []}
@@ -17865,6 +18119,19 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -17894,6 +18161,19 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -18902,6 +19182,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -19050,6 +19331,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-1-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onChange={[Function]}
                     onFocus={[Function]}
                     replacementVariables={Array []}
@@ -19453,6 +19735,19 @@ exports[`SnippetEditor passes replacement variables to the title and description
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -19482,6 +19777,19 @@ exports[`SnippetEditor passes replacement variables to the title and description
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -20501,6 +20809,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -20671,6 +20980,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-6-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onChange={[Function]}
                     onFocus={[Function]}
                     replacementVariables={
@@ -21415,6 +21725,7 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -627,6 +627,7 @@ exports[`SnippetEditor activates a field on onMouseUp() and opens the editor 1`]
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -963,6 +964,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -992,6 +1006,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -1995,6 +2022,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -2147,6 +2175,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-6-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -2548,6 +2577,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -2577,6 +2619,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -3580,6 +3635,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -3732,6 +3788,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-6-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -4133,6 +4190,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -4162,6 +4232,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -5165,6 +5248,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -5317,6 +5401,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-6-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -5718,6 +5803,19 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -5747,6 +5845,19 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -6750,6 +6861,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -6902,6 +7014,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-2-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -8541,6 +8654,19 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -8570,6 +8696,19 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -9573,6 +9712,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -9725,6 +9865,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-9-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -10158,6 +10299,19 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -10187,6 +10341,19 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -11190,6 +11357,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 330,
@@ -11342,6 +11510,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-8-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -12907,6 +13076,19 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   content: "";
 }
 
+.c33::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c33::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c33::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c36 {
   padding: 3px 5px;
   border: 1px solid #5b9dd9;
@@ -12936,6 +13118,19 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%231e8cbe%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c36::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c36::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c36::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c35 {
@@ -13959,6 +14154,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -14111,6 +14307,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-4-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -14512,6 +14709,19 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   content: "";
 }
 
+.c33::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c33::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c33::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c36 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -14541,6 +14751,19 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c36::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c36::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c36::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c35 {
@@ -15564,6 +15787,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -15716,6 +15940,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-3-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -16117,6 +16342,19 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -16146,6 +16384,19 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -17149,6 +17400,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -17301,6 +17553,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-1-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -17702,6 +17955,19 @@ exports[`SnippetEditor passes replacement variables to the title and description
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -17731,6 +17997,19 @@ exports[`SnippetEditor passes replacement variables to the title and description
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -18745,6 +19024,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -18919,6 +19199,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-7-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -19661,6 +19942,7 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -19997,6 +20279,19 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   content: "";
 }
 
+.c32::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c32::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c32::ms-input-placeholder {
+  color: #72777c ! important;
+}
+
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -20026,6 +20321,19 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
+}
+
+.c35::webkit-input-placeholder {
+  color: #72777c ! important;
+}
+
+.c35::moz-placeholder {
+  color: #72777c ! important;
+  opacity: 1;
+}
+
+.c35::ms-input-placeholder {
+  color: #72777c ! important;
 }
 
 .c34 {
@@ -21029,6 +21337,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
           "title": "Test title",
         }
       }
+      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionLengthProgress={
         Object {
           "actual": 0,
@@ -21181,6 +21490,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-5-description"
                     content="Test description, %%replacement_variable%%"
+                    descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -961,19 +961,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   content: "";
 }
 
-.c32::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c32::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c32::ms-input-placeholder {
-  color: #72777c ! important;
-}
-
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -1003,19 +990,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
-}
-
-.c35::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c35::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c35::ms-input-placeholder {
-  color: #72777c ! important;
 }
 
 .c34 {
@@ -1146,6 +1120,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
     }
   }
   date=""
+  descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
   descriptionLengthProgress={
     Object {
       "actual": 0,
@@ -2574,19 +2549,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   content: "";
 }
 
-.c32::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c32::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c32::ms-input-placeholder {
-  color: #72777c ! important;
-}
-
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -2616,19 +2578,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
-}
-
-.c35::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c35::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c35::ms-input-placeholder {
-  color: #72777c ! important;
 }
 
 .c34 {
@@ -2759,6 +2708,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
     }
   }
   date=""
+  descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
   descriptionLengthProgress={
     Object {
       "actual": 0,
@@ -4187,19 +4137,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   content: "";
 }
 
-.c32::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c32::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c32::ms-input-placeholder {
-  color: #72777c ! important;
-}
-
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -4229,19 +4166,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
-}
-
-.c35::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c35::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c35::ms-input-placeholder {
-  color: #72777c ! important;
 }
 
 .c34 {
@@ -4372,6 +4296,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
     }
   }
   date=""
+  descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
   descriptionLengthProgress={
     Object {
       "actual": 0,
@@ -5800,19 +5725,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   content: "";
 }
 
-.c32::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c32::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c32::ms-input-placeholder {
-  color: #72777c ! important;
-}
-
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -5842,19 +5754,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
-}
-
-.c35::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c35::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c35::ms-input-placeholder {
-  color: #72777c ! important;
 }
 
 .c34 {
@@ -5985,6 +5884,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
     }
   }
   date=""
+  descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
   descriptionLengthProgress={
     Object {
       "actual": 0,
@@ -7444,6 +7344,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
     }
   }
   date=""
+  descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
   descriptionLengthProgress={
     Object {
       "actual": 0,
@@ -8651,19 +8552,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   content: "";
 }
 
-.c32::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c32::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c32::ms-input-placeholder {
-  color: #72777c ! important;
-}
-
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -8693,19 +8581,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
-}
-
-.c35::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c35::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c35::ms-input-placeholder {
-  color: #72777c ! important;
 }
 
 .c34 {
@@ -8836,6 +8711,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
     }
   }
   date=""
+  descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
   descriptionLengthProgress={
     Object {
       "actual": 0,
@@ -10296,19 +10172,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   content: "";
 }
 
-.c32::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c32::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c32::ms-input-placeholder {
-  color: #72777c ! important;
-}
-
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -10338,19 +10201,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
-}
-
-.c35::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c35::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c35::ms-input-placeholder {
-  color: #72777c ! important;
 }
 
 .c34 {
@@ -10481,6 +10331,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
     }
   }
   date=""
+  descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
   descriptionLengthProgress={
     Object {
       "actual": 330,
@@ -13069,19 +12920,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   content: "";
 }
 
-.c33::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c33::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c33::ms-input-placeholder {
-  color: #72777c ! important;
-}
-
 .c36 {
   padding: 3px 5px;
   border: 1px solid #5b9dd9;
@@ -13111,19 +12949,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%231e8cbe%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
-}
-
-.c36::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c36::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c36::ms-input-placeholder {
-  color: #72777c ! important;
 }
 
 .c35 {
@@ -13266,6 +13091,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
     }
   }
   date=""
+  descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
   descriptionLengthProgress={
     Object {
       "actual": 0,
@@ -14702,19 +14528,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   content: "";
 }
 
-.c33::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c33::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c33::ms-input-placeholder {
-  color: #72777c ! important;
-}
-
 .c36 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -14744,19 +14557,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
-}
-
-.c36::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c36::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c36::ms-input-placeholder {
-  color: #72777c ! important;
 }
 
 .c35 {
@@ -14899,6 +14699,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
     }
   }
   date=""
+  descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
   descriptionLengthProgress={
     Object {
       "actual": 0,
@@ -16335,19 +16136,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   content: "";
 }
 
-.c32::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c32::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c32::ms-input-placeholder {
-  color: #72777c ! important;
-}
-
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -16377,19 +16165,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
-}
-
-.c35::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c35::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c35::ms-input-placeholder {
-  color: #72777c ! important;
 }
 
 .c34 {
@@ -16520,6 +16295,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
     }
   }
   date=""
+  descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
   descriptionLengthProgress={
     Object {
       "actual": 0,
@@ -17948,19 +17724,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
   content: "";
 }
 
-.c32::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c32::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c32::ms-input-placeholder {
-  color: #72777c ! important;
-}
-
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -17990,19 +17753,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
-}
-
-.c35::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c35::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c35::ms-input-placeholder {
-  color: #72777c ! important;
 }
 
 .c34 {
@@ -18133,6 +17883,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
     }
   }
   date=""
+  descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
   descriptionLengthProgress={
     Object {
       "actual": 0,
@@ -20269,19 +20020,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   content: "";
 }
 
-.c32::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c32::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c32::ms-input-placeholder {
-  color: #72777c ! important;
-}
-
 .c35 {
   padding: 3px 5px;
   border: 1px solid #ddd;
@@ -20311,19 +20049,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
   background-size: 25px;
   content: "";
-}
-
-.c35::webkit-input-placeholder {
-  color: #72777c ! important;
-}
-
-.c35::moz-placeholder {
-  color: #72777c ! important;
-  opacity: 1;
-}
-
-.c35::ms-input-placeholder {
-  color: #72777c ! important;
 }
 
 .c34 {
@@ -20454,6 +20179,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
     }
   }
   date=""
+  descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
   descriptionLengthProgress={
     Object {
       "actual": 0,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a meta description placeholder text

## Relevant technical choices:

* Adds a descriptionEditorFieldPlaceholder prop to the snippet editor that is passed along to the draftJS editor (the name of the variable is very long and can be changed but was specified in this way in order to avoid confusion with the already existing variable `descriptionPlaceholder`)
* The color of the placeholder text is currently a lighter shade of grey compared to how it is in the old snippet editor. An [issue](https://github.com/Yoast/wordpress-seo/issues/9874) has been created for that.

## Test instructions

This PR can be tested by following these steps:

* Empty your title and meta description templates in SEO > Search Appearance > Content Types
* Go to the snippet editor, edit snippet, and empty the meta description field
* There should be a placeholder text that says "Modify your meta description by editing it right here"
* Changing focus from the meta description field should cause the text color of the placeholder to be a darker grey
* Empty the title field and save the post/page
* The text in the title field should be %%title%% - %%sitename%%
* The title field text should act like normal text, i.e. be editable
* Test these functionalities for both posts and pages

Fixes https://github.com/Yoast/wordpress-seo/issues/9830
