### PR TITLE
Snippet preview title and description progress measurement overhaul

### DIFF
--- a/app/SnippetEditorExample.js
+++ b/app/SnippetEditorExample.js
@@ -10,6 +10,7 @@ import SnippetEditor from "../composites/Plugin/SnippetEditor/components/Snippet
 const Container = styled.div`
 	background-color: white;
 	margin: 5em auto 0;
+	padding: 0 0 10px;
 `;
 
 const replacementVariables = [
@@ -203,20 +204,6 @@ export default class SnippetEditorExample extends Component {
 				replacementVariables={ replacementVariables }
 				titleLengthProgress={ titleLengthProgress }
 				descriptionLengthProgress={ descriptionLengthProgress }
-			/>
-
-			<h2>Test sliders for progress bars</h2>
-			<input
-				type="range"
-				min={ 0 }
-				max={ titleLengthProgress.max }
-				onChange={ ( event ) => this.onChangedData( "currentTitleLength", parseInt( event.target.value, 10 ) ) }
-			/>
-			<input
-				type="range"
-				min={ 0 }
-				max={ descriptionLengthProgress.max }
-				onChange={ ( event ) => this.onChangedData( "currentDescriptionLength", parseInt( event.target.value, 10 ) ) }
 			/>
 		</Container>;
 	}

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -2,6 +2,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
+import MetaDescriptionLengthAssessment from "yoastseo/js/assessments/seo/metaDescriptionLengthAssessment";
+import PageTitleWidthAssesment from "yoastseo/js/assessments/seo/pageTitleWidthAssessment";
+import { measureTextWidth } from "yoastseo/js/helpers/createMeasurementElement";
 
 // Internal dependencies.
 import SnippetPreview from "../../SnippetPreview/components/SnippetPreview";
@@ -37,6 +40,46 @@ const EditSnippetButton = SnippetEditorButton.extend`
 const CloseEditorButton = SnippetEditorButton.extend`
 	margin-left: 20px;
 `;
+
+/**
+ * Gets the title progress.
+ *
+ * @param {string} title The title.
+ *
+ * @returns {Object} The title progress.
+ */
+function getTitleProgress( title ) {
+	const titleWidth = measureTextWidth( title );
+	const pageTitleWidthAssessment = new PageTitleWidthAssesment();
+	const score = pageTitleWidthAssessment.calculateScore( titleWidth );
+	const maximumLength = pageTitleWidthAssessment.getMaximumLength();
+
+	return {
+		max: maximumLength,
+		actual: titleWidth,
+		score: score,
+	};
+}
+
+/**
+ * Gets the description progress.
+ *
+ * @param {string} description The description.
+ *
+ * @returns {Object} The description progress.
+ */
+function getDescriptionProgress( description ) {
+	const descriptionLength = description.length;
+	const metaDescriptionLengthAssessment = new MetaDescriptionLengthAssessment();
+	const score = metaDescriptionLengthAssessment.calculateScore( descriptionLength );
+	const maximumLength = metaDescriptionLengthAssessment.getMaximumLength();
+
+	return {
+		max: maximumLength,
+		actual: descriptionLength,
+		score: score,
+	};
+}
 
 class SnippetEditor extends React.Component {
 	/**
@@ -75,6 +118,8 @@ class SnippetEditor extends React.Component {
 			isOpen: false,
 			activeField: null,
 			hoveredField: null,
+			titleLengthProgress: getTitleProgress( props.data.title ),
+			descriptionLengthProgress: getDescriptionProgress( props.data.description ),
 		};
 
 		this.setFieldFocus = this.setFieldFocus.bind( this );
@@ -89,6 +134,21 @@ class SnippetEditor extends React.Component {
 	}
 
 	/**
+	 * Updates the state when the component receives new props.
+	 *
+	 * @param {Object} nextProps The new props.
+	 * @returns {void}
+	 */
+	componentWillReceiveProps( nextProps ) {
+		this.setState(
+			{
+				titleLengthProgress: getTitleProgress( nextProps.data.title ),
+				descriptionLengthProgress: getDescriptionProgress( nextProps.data.description ),
+			}
+		);
+	}
+
+	/**
 	 * Handles the onChange event.
 	 *
 	 * First updates the description progress and title progress.
@@ -100,6 +160,17 @@ class SnippetEditor extends React.Component {
 	 * @returns {void}
 	 */
 	handleChange( type, content ) {
+		let descriptionProgress, titleProgress;
+		switch( type ) {
+			case "description":
+				descriptionProgress = getDescriptionProgress( content );
+				this.setState( { descriptionLengthProgress: descriptionProgress } );
+				break;
+			case "title":
+				titleProgress = getTitleProgress( content );
+				this.setState( { titleLengthProgress: titleProgress } );
+				break;
+		}
 		this.props.onChange( type, content );
 	}
 
@@ -111,11 +182,10 @@ class SnippetEditor extends React.Component {
 	renderEditor() {
 		const {
 			data,
-			titleLengthProgress,
-			descriptionLengthProgress,
+
 		} = this.props;
 		const replacementVariables = this.decodeSeparatorVariable( this.props.replacementVariables );
-		const { activeField, hoveredField, isOpen } = this.state;
+		const { activeField, hoveredField, isOpen, titleLengthProgress, descriptionLengthProgress } = this.state;
 
 		if ( ! isOpen ) {
 			return null;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -187,13 +187,15 @@ class SnippetEditor extends React.Component {
 	 */
 	handleChange( type, content ) {
 		let descriptionProgress, titleProgress;
+		let processedContent = this.processReplacementVariables( content );
+
 		switch( type ) {
 			case "description":
-				descriptionProgress = getDescriptionProgress( content );
+				descriptionProgress = getDescriptionProgress( processedContent );
 				this.setState( { descriptionLengthProgress: descriptionProgress } );
 				break;
 			case "title":
-				titleProgress = getTitleProgress( content );
+				titleProgress = getTitleProgress( processedContent );
 				this.setState( { titleLengthProgress: titleProgress } );
 				break;
 		}

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -127,7 +127,6 @@ class SnippetEditor extends React.Component {
 
 		this.setFieldFocus = this.setFieldFocus.bind( this );
 		this.unsetFieldFocus = this.unsetFieldFocus.bind( this );
-		this.handleChange = this.handleChange.bind( this );
 		this.onMouseUp = this.onMouseUp.bind( this );
 		this.onMouseEnter = this.onMouseEnter.bind( this );
 		this.onMouseLeave = this.onMouseLeave.bind( this );
@@ -175,34 +174,6 @@ class SnippetEditor extends React.Component {
 	}
 
 	/**
-	 * Handles the onChange event.
-	 *
-	 * First updates the description progress and title progress.
-	 * Then calls the onChange function that is passed through the props.
-	 *
-	 * @param {string} type The type of change.
-	 * @param {string} content The content of the changed field.
-	 *
-	 * @returns {void}
-	 */
-	handleChange( type, content ) {
-		let descriptionProgress, titleProgress;
-		let processedContent = this.processReplacementVariables( content );
-
-		switch( type ) {
-			case "description":
-				descriptionProgress = getDescriptionProgress( processedContent );
-				this.setState( { descriptionLengthProgress: descriptionProgress } );
-				break;
-			case "title":
-				titleProgress = getTitleProgress( processedContent );
-				this.setState( { titleLengthProgress: titleProgress } );
-				break;
-		}
-		this.props.onChange( type, content );
-	}
-
-	/**
 	 * Renders the editor fields if the editor is open.
 	 *
 	 * @returns {ReactElement} The rendered react element.
@@ -212,6 +183,7 @@ class SnippetEditor extends React.Component {
 			data,
 			replacementVariables,
 			descriptionEditorFieldPlaceholder,
+			onChange,
 		} = this.props;
 		const { activeField, hoveredField, isOpen, titleLengthProgress, descriptionLengthProgress } = this.state;
 
@@ -225,7 +197,7 @@ class SnippetEditor extends React.Component {
 					data={ data }
 					activeField={ activeField }
 					hoveredField={ hoveredField }
-					onChange={ this.handleChange }
+					onChange={ onChange }
 					onFocus={ this.setFieldFocus }
 					onBlur={ this.unsetFieldFocus }
 					replacementVariables={ replacementVariables }

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -114,7 +114,7 @@ class SnippetEditor extends React.Component {
 	constructor( props ) {
 		super( props );
 
-		const mappedData = this.mapDataToPreview( props.data );
+		const mappedData = this.mapDataToPreview( props.data, "" );
 
 		this.state = {
 			isOpen: false,
@@ -164,7 +164,7 @@ class SnippetEditor extends React.Component {
 	componentWillReceiveProps( nextProps ) {
 		// Only set a new state when the data is dirty.
 		if ( this.shallowCompareData( this.props.data, nextProps.data ) ) {
-			const data = this.mapDataToPreview( nextProps.data );
+			const data = this.mapDataToPreview( nextProps.data, nextProps.generatedDescription );
 			this.setState(
 				{
 					titleLengthProgress: getTitleProgress( data.title ),

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -115,12 +115,15 @@ class SnippetEditor extends React.Component {
 	constructor( props ) {
 		super( props );
 
+		const mappedData = this.mapDataToPreview( props.data );
+
 		this.state = {
 			isOpen: false,
 			activeField: null,
 			hoveredField: null,
-			titleLengthProgress: getTitleProgress( props.data.title ),
-			descriptionLengthProgress: getDescriptionProgress( props.data.description ),
+			mappedData: mappedData,
+			titleLengthProgress: getTitleProgress( mappedData.title ),
+			descriptionLengthProgress: getDescriptionProgress( mappedData.description ),
 		};
 
 		this.setFieldFocus = this.setFieldFocus.bind( this );
@@ -141,10 +144,12 @@ class SnippetEditor extends React.Component {
 	 * @returns {void}
 	 */
 	componentWillReceiveProps( nextProps ) {
+		console.log(nextProps)
+		const data = this.mapDataToPreview( nextProps.data );
 		this.setState(
 			{
-				titleLengthProgress: getTitleProgress( nextProps.data.title ),
-				descriptionLengthProgress: getDescriptionProgress( nextProps.data.description ),
+				titleLengthProgress: getTitleProgress( data.title ),
+				descriptionLengthProgress: getDescriptionProgress( data.description ),
 			}
 		);
 	}

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -163,7 +163,7 @@ class SnippetEditor extends React.Component {
 	componentWillReceiveProps( nextProps ) {
 		// Only set a new state when the data is dirty.
 		if ( this.shallowCompareData( this.props.data, nextProps.data ) ) {
-			const data = this.mapDataToPreview( nextProps.data, nextProps.generatedDescription );
+			const data = this.mapDataToPreview( nextProps.data, "" );
 			this.setState(
 				{
 					titleLengthProgress: getTitleProgress( data.title ),

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -137,7 +137,7 @@ class SnippetEditor extends React.Component {
 	}
 
 	/**
-	 * Returns whether the old and the new data are the same.
+	 * Returns whether the old and the new data are different.
 	 *
 	 * @param {Object} oldData The old data.
 	 * @param {Object} newData The new data.

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -138,20 +138,41 @@ class SnippetEditor extends React.Component {
 	}
 
 	/**
+	 * Returns whether the old and the new data are the same.
+	 *
+	 * @param {Object} oldData The old data.
+	 * @param {Object} newData The new data.
+	 * @returns {boolean} True if any of the data points has changed.
+	 */
+	shallowCompareData( oldData, newData ) {
+		let isDirty = false;
+		if (
+			oldData.description !== newData.description ||
+			oldData.slug !== newData.slug ||
+			oldData.title !== newData.title
+		) {
+			isDirty = true;
+		}
+		return isDirty;
+	}
+
+	/**
 	 * Updates the state when the component receives new props.
 	 *
 	 * @param {Object} nextProps The new props.
 	 * @returns {void}
 	 */
 	componentWillReceiveProps( nextProps ) {
-		console.log(nextProps)
-		const data = this.mapDataToPreview( nextProps.data );
-		this.setState(
-			{
-				titleLengthProgress: getTitleProgress( data.title ),
-				descriptionLengthProgress: getDescriptionProgress( data.description ),
-			}
-		);
+		// Only set a new state when the data is dirty.
+		if ( this.shallowCompareData( this.props.data, nextProps.data ) ) {
+			const data = this.mapDataToPreview( nextProps.data );
+			this.setState(
+				{
+					titleLengthProgress: getTitleProgress( data.title ),
+					descriptionLengthProgress: getDescriptionProgress( data.description ),
+				}
+			);
+		}
 	}
 
 	/**

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -5,6 +5,7 @@ import { __ } from "@wordpress/i18n";
 import MetaDescriptionLengthAssessment from "yoastseo/js/assessments/seo/metaDescriptionLengthAssessment";
 import PageTitleWidthAssesment from "yoastseo/js/assessments/seo/pageTitleWidthAssessment";
 import { measureTextWidth } from "yoastseo/js/helpers/createMeasurementElement";
+import stripSpaces from "yoastseo/js/stringProcessing/stripSpaces";
 
 // Internal dependencies.
 import SnippetPreview from "../../SnippetPreview/components/SnippetPreview";
@@ -342,10 +343,15 @@ class SnippetEditor extends React.Component {
 	mapDataToPreview( originalData ) {
 		const { baseUrl, mapDataToPreview } = this.props;
 
+		let description = this.processReplacementVariables( originalData.description );
+
+		// Strip multiple spaces and spaces at the beginning and end.
+		description = stripSpaces( description );
+
 		const mappedData = {
 			title: this.processReplacementVariables( originalData.title ),
 			url: baseUrl.replace( "https://", "" ) + originalData.slug,
-			description: this.processReplacementVariables( originalData.description ),
+			description: description,
 		};
 
 		if ( mapDataToPreview ) {

--- a/composites/Plugin/SnippetEditor/serialization.js
+++ b/composites/Plugin/SnippetEditor/serialization.js
@@ -58,9 +58,8 @@ export function serializeBlock( entityMap, block ) {
 export function serializeEditor( rawContent ) {
 	const { blocks, entityMap } = rawContent;
 
-	return reduce( blocks, ( serialized, block ) => {
-		return serialized + serializeBlock( entityMap, block );
-	}, "" );
+	// Every line is a block. Join the lines with a space between them.
+	return blocks.map( block => serializeBlock( entityMap, block ) ).join( " " );
 }
 
 /**

--- a/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
@@ -88,7 +88,8 @@ describe( "SnippetEditor", () => {
 
 		renderSnapshotWithArgs( { mapDataToPreview: mapper, replacementVariables } );
 
-		expect( mapper ).toHaveBeenCalledTimes( 1 );
+		// The mapper is called both in the constructor, as well as the render function.
+		expect( mapper ).toHaveBeenCalledTimes( 2 );
 		expect( mapper ).toHaveBeenCalledWith( defaultMappedData, defaultData );
 	} );
 

--- a/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
@@ -287,4 +287,63 @@ describe( "SnippetEditor", () => {
 			expect( editor ).toMatchSnapshot();
 		} );
 	} );
+
+	describe( "shallowCompareData", () => {
+		it( "returns false when there is no new data", () => {
+			const editor = mountWithArgs( {} );
+
+			const oldData = {
+				title: "old title",
+				description: "old description",
+				slug: "old slug",
+			};
+			const newData = {
+				title: "old title",
+				description: "old description",
+				slug: "old slug",
+			};
+
+			const isDirty = editor.instance().shallowCompareData( oldData, newData );
+
+			expect( isDirty ).toBe( false );
+		} );
+
+		it( "returns true when one data point has changed", () => {
+			const editor = mountWithArgs( {} );
+
+			const oldData = {
+				title: "old title",
+				description: "old description",
+				slug: "old slug",
+			};
+			const newData = {
+				title: "new title",
+				description: "old description",
+				slug: "old slug",
+			};
+
+			const isDirty = editor.instance().shallowCompareData( oldData, newData );
+
+			expect( isDirty ).toBe( true );
+		} );
+
+		it( "returns true when multiple data points have changed", () => {
+			const editor = mountWithArgs( {} );
+
+			const oldData = {
+				title: "old title",
+				description: "old description",
+				slug: "old slug",
+			};
+			const newData = {
+				title: "new title",
+				description: "new description",
+				slug: "old slug",
+			};
+
+			const isDirty = editor.instance().shallowCompareData( oldData, newData );
+
+			expect( isDirty ).toBe( true );
+		} );
+	} );
 } );

--- a/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
@@ -23,7 +23,7 @@ const defaultData = {
 const defaultArgs = {
 	baseUrl: "https://example.org/",
 	data: defaultData,
-	onChange: () => {},
+	onChange: jest.fn(),
 };
 
 const renderSnapshotWithArgs = ( changedArgs ) => {

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -634,7 +634,7 @@ exports[`SnippetEditor activates a field on onMouseUp() and opens the editor 1`]
       }
       hoveredField={null}
       onBlur={[Function]}
-      onChange={[Function]}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={Array []}
       titleLengthProgress={
@@ -2071,7 +2071,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
       }
       hoveredField={null}
       onBlur={[Function]}
-      onChange={[Function]}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={Array []}
       titleLengthProgress={
@@ -3726,7 +3726,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
       }
       hoveredField={null}
       onBlur={[Function]}
-      onChange={[Function]}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={Array []}
       titleLengthProgress={
@@ -5381,7 +5381,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
       }
       hoveredField={null}
       onBlur={[Function]}
-      onChange={[Function]}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={Array []}
       titleLengthProgress={
@@ -6189,7 +6189,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   locale="en"
   mapDataToPreview={null}
   mode="mobile"
-  onChange={[Function]}
+  onChange={[MockFunction]}
   replacementVariables={Array []}
   titleLengthProgress={
     Object {
@@ -7036,7 +7036,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
       }
       hoveredField={null}
       onBlur={[Function]}
-      onChange={[Function]}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={Array []}
       titleLengthProgress={
@@ -7649,7 +7649,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   locale="en"
   mapDataToPreview={null}
   mode="mobile"
-  onChange={[Function]}
+  onChange={[MockFunction]}
   replacementVariables={Array []}
   titleLengthProgress={
     Object {
@@ -9051,7 +9051,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   locale="en"
   mapDataToPreview={null}
   mode="mobile"
-  onChange={[Function]}
+  onChange={[MockFunction]}
   replacementVariables={Array []}
   titleLengthProgress={
     Object {
@@ -9898,7 +9898,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
       }
       hoveredField={null}
       onBlur={[Function]}
-      onChange={[Function]}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={Array []}
       titleLengthProgress={
@@ -10706,7 +10706,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   locale="en"
   mapDataToPreview={null}
   mode="mobile"
-  onChange={[Function]}
+  onChange={[MockFunction]}
   replacementVariables={Array []}
   titleLengthProgress={
     Object {
@@ -11553,7 +11553,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
       }
       hoveredField={null}
       onBlur={[Function]}
-      onChange={[Function]}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={Array []}
       titleLengthProgress={
@@ -13533,7 +13533,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   locale="en"
   mapDataToPreview={null}
   mode="mobile"
-  onChange={[Function]}
+  onChange={[MockFunction]}
   replacementVariables={Array []}
   titleLengthProgress={
     Object {
@@ -14388,7 +14388,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
       }
       hoveredField={null}
       onBlur={[Function]}
-      onChange={[Function]}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={Array []}
       titleLengthProgress={
@@ -15208,7 +15208,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   locale="en"
   mapDataToPreview={null}
   mode="mobile"
-  onChange={[Function]}
+  onChange={[MockFunction]}
   replacementVariables={Array []}
   titleLengthProgress={
     Object {
@@ -16063,7 +16063,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
       }
       hoveredField="description"
       onBlur={[Function]}
-      onChange={[Function]}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={Array []}
       titleLengthProgress={
@@ -16871,7 +16871,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   locale="en"
   mapDataToPreview={null}
   mode="mobile"
-  onChange={[Function]}
+  onChange={[MockFunction]}
   replacementVariables={Array []}
   titleLengthProgress={
     Object {
@@ -17718,7 +17718,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
       }
       hoveredField={null}
       onBlur={[Function]}
-      onChange={[Function]}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={Array []}
       titleLengthProgress={
@@ -18526,7 +18526,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   locale="en"
   mapDataToPreview={null}
   mode="mobile"
-  onChange={[Function]}
+  onChange={[MockFunction]}
   replacementVariables={
     Array [
       Object {
@@ -19384,7 +19384,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
       }
       hoveredField={null}
       onBlur={[Function]}
-      onChange={[Function]}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={
         Array [
@@ -20299,7 +20299,7 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
       }
       hoveredField={null}
       onBlur={[Function]}
-      onChange={[Function]}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={Array []}
       titleLengthProgress={
@@ -20889,7 +20889,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   locale="en"
   mapDataToPreview={null}
   mode="mobile"
-  onChange={[Function]}
+  onChange={[MockFunction]}
   replacementVariables={Array []}
   titleLengthProgress={
     Object {
@@ -21736,7 +21736,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
       }
       hoveredField={null}
       onBlur={[Function]}
-      onChange={[Function]}
+      onChange={[MockFunction]}
       onFocus={[Function]}
       replacementVariables={Array []}
       titleLengthProgress={

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -632,9 +632,9 @@ exports[`SnippetEditor activates a field on onClick() and opens the editor 1`] =
       }
       descriptionLengthProgress={
         Object {
-          "actual": 0,
+          "actual": 42,
           "max": 156,
-          "score": 0,
+          "score": 6,
         }
       }
       hoveredField={null}
@@ -645,7 +645,7 @@ exports[`SnippetEditor activates a field on onClick() and opens the editor 1`] =
         Object {
           "actual": 0,
           "max": 600,
-          "score": 0,
+          "score": 1,
         }
       }
     />
@@ -743,7 +743,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   margin-right: 7px;
 }
 
-.c36 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -937,6 +937,38 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 
 .c33::-ms-fill {
   background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
   border: 0;
 }
 
@@ -2007,9 +2039,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
       }
       descriptionLengthProgress={
         Object {
-          "actual": 0,
+          "actual": 42,
           "max": 156,
-          "score": 0,
+          "score": 6,
         }
       }
       hoveredField={null}
@@ -2020,7 +2052,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
         Object {
           "actual": 0,
           "max": 600,
-          "score": 0,
+          "score": 1,
         }
       }
     >
@@ -2166,14 +2198,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ddd"
                 max={156}
-                progressColor="#dc3232"
-                value={0}
+                progressColor="#ee7c1b"
+                value={42}
               >
                 <progress
                   aria-hidden="true"
-                  className="c33"
+                  className="c36"
                   max={156}
-                  value={0}
+                  value={42}
                 />
               </ProgressBar>
             </div>
@@ -2188,7 +2220,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c36"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -2197,7 +2229,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c36 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -2206,7 +2238,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c36 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -2215,7 +2247,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -2224,13 +2256,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -2331,7 +2363,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   margin-right: 7px;
 }
 
-.c36 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -2525,6 +2557,38 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 
 .c33::-ms-fill {
   background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
   border: 0;
 }
 
@@ -3595,9 +3659,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
       }
       descriptionLengthProgress={
         Object {
-          "actual": 0,
+          "actual": 42,
           "max": 156,
-          "score": 0,
+          "score": 6,
         }
       }
       hoveredField={null}
@@ -3608,7 +3672,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
         Object {
           "actual": 0,
           "max": 600,
-          "score": 0,
+          "score": 1,
         }
       }
     >
@@ -3754,14 +3818,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ddd"
                 max={156}
-                progressColor="#dc3232"
-                value={0}
+                progressColor="#ee7c1b"
+                value={42}
               >
                 <progress
                   aria-hidden="true"
-                  className="c33"
+                  className="c36"
                   max={156}
-                  value={0}
+                  value={42}
                 />
               </ProgressBar>
             </div>
@@ -3776,7 +3840,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c36"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -3785,7 +3849,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c36 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -3794,7 +3858,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c36 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -3803,7 +3867,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -3812,13 +3876,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -3919,7 +3983,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   margin-right: 7px;
 }
 
-.c36 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -4113,6 +4177,38 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 
 .c33::-ms-fill {
   background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
   border: 0;
 }
 
@@ -5183,9 +5279,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
       }
       descriptionLengthProgress={
         Object {
-          "actual": 0,
+          "actual": 42,
           "max": 156,
-          "score": 0,
+          "score": 6,
         }
       }
       hoveredField={null}
@@ -5196,7 +5292,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
         Object {
           "actual": 0,
           "max": 600,
-          "score": 0,
+          "score": 1,
         }
       }
     >
@@ -5342,14 +5438,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ddd"
                 max={156}
-                progressColor="#dc3232"
-                value={0}
+                progressColor="#ee7c1b"
+                value={42}
               >
                 <progress
                   aria-hidden="true"
-                  className="c33"
+                  className="c36"
                   max={156}
-                  value={0}
+                  value={42}
                 />
               </ProgressBar>
             </div>
@@ -5364,7 +5460,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c36"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -5373,7 +5469,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c36 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -5382,7 +5478,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c36 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -5391,7 +5487,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -5400,13 +5496,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -5507,7 +5603,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   margin-right: 7px;
 }
 
-.c36 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -5701,6 +5797,38 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 
 .c33::-ms-fill {
   background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
   border: 0;
 }
 
@@ -6771,9 +6899,9 @@ exports[`SnippetEditor closes when calling close() 1`] = `
       }
       descriptionLengthProgress={
         Object {
-          "actual": 0,
+          "actual": 42,
           "max": 156,
-          "score": 0,
+          "score": 6,
         }
       }
       hoveredField={null}
@@ -6784,7 +6912,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         Object {
           "actual": 0,
           "max": 600,
-          "score": 0,
+          "score": 1,
         }
       }
     >
@@ -6930,14 +7058,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ddd"
                 max={156}
-                progressColor="#dc3232"
-                value={0}
+                progressColor="#ee7c1b"
+                value={42}
               >
                 <progress
                   aria-hidden="true"
-                  className="c33"
+                  className="c36"
                   max={156}
-                  value={0}
+                  value={42}
                 />
               </ProgressBar>
             </div>
@@ -6952,7 +7080,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c36"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -6961,7 +7089,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c36 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -6970,7 +7098,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c36 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -6979,7 +7107,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -6988,13 +7116,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -8474,38 +8602,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   margin: 0;
 }
 
-.c36 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c36::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c36::-webkit-progress-value {
-  background-color: #dc3232;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c36::-moz-progress-bar {
-  background-color: #dc3232;
-}
-
-.c36::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
 .c33 {
   box-sizing: border-box;
   width: 100%;
@@ -8524,16 +8620,48 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c33::-webkit-progress-value {
-  background-color: #ee7c1b;
+  background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c33::-moz-progress-bar {
-  background-color: #ee7c1b;
+  background-color: #dc3232;
 }
 
 .c33::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
   background-color: #ee7c1b;
   border: 0;
 }
@@ -9605,9 +9733,9 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
       }
       descriptionLengthProgress={
         Object {
-          "actual": 0,
+          "actual": 42,
           "max": 156,
-          "score": 0,
+          "score": 6,
         }
       }
       hoveredField={null}
@@ -9616,9 +9744,9 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
       replacementVariables={Array []}
       titleLengthProgress={
         Object {
-          "actual": 361,
-          "max": 550,
-          "score": 6,
+          "actual": 0,
+          "max": 600,
+          "score": 1,
         }
       }
     >
@@ -9666,15 +9794,15 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 aria-hidden="true"
                 backgroundColor="#f7f7f7"
                 borderColor="#ddd"
-                max={550}
-                progressColor="#ee7c1b"
-                value={361}
+                max={600}
+                progressColor="#dc3232"
+                value={0}
               >
                 <progress
                   aria-hidden="true"
                   className="c33"
-                  max={550}
-                  value={361}
+                  max={600}
+                  value={0}
                 />
               </ProgressBar>
             </div>
@@ -9764,14 +9892,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ddd"
                 max={156}
-                progressColor="#dc3232"
-                value={0}
+                progressColor="#ee7c1b"
+                value={42}
               >
                 <progress
                   aria-hidden="true"
                   className="c36"
                   max={156}
-                  value={0}
+                  value={42}
                 />
               </ProgressBar>
             </div>
@@ -10144,17 +10272,17 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c36::-webkit-progress-value {
-  background-color: #7ad03a;
+  background-color: #ee7c1b;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c36::-moz-progress-bar {
-  background-color: #7ad03a;
+  background-color: #ee7c1b;
 }
 
 .c36::-ms-fill {
-  background-color: #7ad03a;
+  background-color: #ee7c1b;
   border: 0;
 }
 
@@ -11225,9 +11353,9 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
       }
       descriptionLengthProgress={
         Object {
-          "actual": 330,
-          "max": 650,
-          "score": 9,
+          "actual": 42,
+          "max": 156,
+          "score": 6,
         }
       }
       hoveredField={null}
@@ -11236,9 +11364,9 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
       replacementVariables={Array []}
       titleLengthProgress={
         Object {
-          "actual": 100,
-          "max": 550,
-          "score": 3,
+          "actual": 0,
+          "max": 600,
+          "score": 1,
         }
       }
     >
@@ -11286,15 +11414,15 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 aria-hidden="true"
                 backgroundColor="#f7f7f7"
                 borderColor="#ddd"
-                max={550}
+                max={600}
                 progressColor="#dc3232"
-                value={100}
+                value={0}
               >
                 <progress
                   aria-hidden="true"
                   className="c33"
-                  max={550}
-                  value={100}
+                  max={600}
+                  value={0}
                 />
               </ProgressBar>
             </div>
@@ -11383,15 +11511,15 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 aria-hidden="true"
                 backgroundColor="#f7f7f7"
                 borderColor="#ddd"
-                max={650}
-                progressColor="#7ad03a"
-                value={330}
+                max={156}
+                progressColor="#ee7c1b"
+                value={42}
               >
                 <progress
                   aria-hidden="true"
                   className="c36"
-                  max={650}
-                  value={330}
+                  max={156}
+                  value={42}
                 />
               </ProgressBar>
             </div>
@@ -11549,7 +11677,7 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
   margin-right: 7px;
 }
 
-.c36 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -11743,6 +11871,38 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
 
 .c33::-ms-fill {
   background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
   border: 0;
 }
 
@@ -12824,9 +12984,9 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
       }
       descriptionLengthProgress={
         Object {
-          "actual": 0,
+          "actual": 42,
           "max": 156,
-          "score": 0,
+          "score": 6,
         }
       }
       hoveredField={null}
@@ -12848,7 +13008,7 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
         Object {
           "actual": 0,
           "max": 600,
-          "score": 0,
+          "score": 1,
         }
       }
     >
@@ -13016,14 +13176,14 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ddd"
                 max={156}
-                progressColor="#dc3232"
-                value={0}
+                progressColor="#ee7c1b"
+                value={42}
               >
                 <progress
                   aria-hidden="true"
-                  className="c33"
+                  className="c36"
                   max={156}
-                  value={0}
+                  value={42}
                 />
               </ProgressBar>
             </div>
@@ -13038,7 +13198,7 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c36"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -13047,7 +13207,7 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c36 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -13056,7 +13216,7 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c36 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -13065,7 +13225,7 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -13074,13 +13234,13 @@ exports[`SnippetEditor decodes separator replacement variables in the  1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -13143,9 +13303,9 @@ exports[`SnippetEditor doesn't remove the highlight if the wrong field is left 1
       }
       descriptionLengthProgress={
         Object {
-          "actual": 0,
+          "actual": 42,
           "max": 156,
-          "score": 0,
+          "score": 6,
         }
       }
       hoveredField="description"
@@ -13156,7 +13316,7 @@ exports[`SnippetEditor doesn't remove the highlight if the wrong field is left 1
         Object {
           "actual": 0,
           "max": 600,
-          "score": 0,
+          "score": 1,
         }
       }
     />
@@ -14424,7 +14584,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   margin-right: 7px;
 }
 
-.c37 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -14618,6 +14778,38 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 
 .c34::-ms-fill {
   background-color: #dc3232;
+  border: 0;
+}
+
+.c37 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c37::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c37::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c37::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c37::-ms-fill {
+  background-color: #ee7c1b;
   border: 0;
 }
 
@@ -15708,9 +15900,9 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
       }
       descriptionLengthProgress={
         Object {
-          "actual": 0,
+          "actual": 42,
           "max": 156,
-          "score": 0,
+          "score": 6,
         }
       }
       hoveredField={null}
@@ -15721,7 +15913,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
         Object {
           "actual": 0,
           "max": 600,
-          "score": 0,
+          "score": 1,
         }
       }
     >
@@ -15867,14 +16059,14 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 backgroundColor="#f7f7f7"
                 borderColor="#ddd"
                 max={156}
-                progressColor="#dc3232"
-                value={0}
+                progressColor="#ee7c1b"
+                value={42}
               >
                 <progress
                   aria-hidden="true"
-                  className="c34"
+                  className="c37"
                   max={156}
-                  value={0}
+                  value={42}
                 />
               </ProgressBar>
             </div>
@@ -15889,7 +16081,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c37"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -15898,7 +16090,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c37 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -15907,7 +16099,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -15916,7 +16108,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -15925,13 +16117,13 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -16032,7 +16224,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
   margin-right: 7px;
 }
 
-.c37 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -16226,6 +16418,38 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
 
 .c34::-ms-fill {
   background-color: #dc3232;
+  border: 0;
+}
+
+.c37 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c37::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c37::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c37::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c37::-ms-fill {
+  background-color: #ee7c1b;
   border: 0;
 }
 
@@ -17316,9 +17540,9 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
       }
       descriptionLengthProgress={
         Object {
-          "actual": 0,
+          "actual": 42,
           "max": 156,
-          "score": 0,
+          "score": 6,
         }
       }
       hoveredField="description"
@@ -17329,7 +17553,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
         Object {
           "actual": 0,
           "max": 600,
-          "score": 0,
+          "score": 1,
         }
       }
     >
@@ -17475,14 +17699,14 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 backgroundColor="#f7f7f7"
                 borderColor="#ddd"
                 max={156}
-                progressColor="#dc3232"
-                value={0}
+                progressColor="#ee7c1b"
+                value={42}
               >
                 <progress
                   aria-hidden="true"
-                  className="c34"
+                  className="c37"
                   max={156}
-                  value={0}
+                  value={42}
                 />
               </ProgressBar>
             </div>
@@ -17497,7 +17721,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c37"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -17506,7 +17730,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c37 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -17515,7 +17739,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -17524,7 +17748,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -17533,13 +17757,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseOver() is called
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -17640,7 +17864,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   margin-right: 7px;
 }
 
-.c36 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -17834,6 +18058,38 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 
 .c33::-ms-fill {
   background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
   border: 0;
 }
 
@@ -18904,9 +19160,9 @@ exports[`SnippetEditor opens when calling open() 1`] = `
       }
       descriptionLengthProgress={
         Object {
-          "actual": 0,
+          "actual": 42,
           "max": 156,
-          "score": 0,
+          "score": 6,
         }
       }
       hoveredField={null}
@@ -18917,7 +19173,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         Object {
           "actual": 0,
           "max": 600,
-          "score": 0,
+          "score": 1,
         }
       }
     >
@@ -19063,14 +19319,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ddd"
                 max={156}
-                progressColor="#dc3232"
-                value={0}
+                progressColor="#ee7c1b"
+                value={42}
               >
                 <progress
                   aria-hidden="true"
-                  className="c33"
+                  className="c36"
                   max={156}
-                  value={0}
+                  value={42}
                 />
               </ProgressBar>
             </div>
@@ -19085,7 +19341,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c36"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -19094,7 +19350,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c36 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -19103,7 +19359,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c36 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -19112,7 +19368,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -19121,13 +19377,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -19228,7 +19484,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   margin-right: 7px;
 }
 
-.c36 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -19422,6 +19678,38 @@ exports[`SnippetEditor passes replacement variables to the title and description
 
 .c33::-ms-fill {
   background-color: #dc3232;
+  border: 0;
+}
+
+.c36 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c36::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c36::-webkit-progress-value {
+  background-color: #ee7c1b;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c36::-moz-progress-bar {
+  background-color: #ee7c1b;
+}
+
+.c36::-ms-fill {
+  background-color: #ee7c1b;
   border: 0;
 }
 
@@ -20503,9 +20791,9 @@ exports[`SnippetEditor passes replacement variables to the title and description
       }
       descriptionLengthProgress={
         Object {
-          "actual": 0,
+          "actual": 42,
           "max": 156,
-          "score": 0,
+          "score": 6,
         }
       }
       hoveredField={null}
@@ -20527,7 +20815,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
         Object {
           "actual": 0,
           "max": 600,
-          "score": 0,
+          "score": 1,
         }
       }
     >
@@ -20695,14 +20983,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ddd"
                 max={156}
-                progressColor="#dc3232"
-                value={0}
+                progressColor="#ee7c1b"
+                value={42}
               >
                 <progress
                   aria-hidden="true"
-                  className="c33"
+                  className="c36"
                   max={156}
-                  value={0}
+                  value={42}
                 />
               </ProgressBar>
             </div>
@@ -20717,7 +21005,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c36"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -20726,7 +21014,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c36 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -20735,7 +21023,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c36 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -20744,7 +21032,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -20753,13 +21041,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -21417,9 +21705,9 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
       }
       descriptionLengthProgress={
         Object {
-          "actual": 0,
+          "actual": 42,
           "max": 156,
-          "score": 0,
+          "score": 6,
         }
       }
       hoveredField={null}
@@ -21430,7 +21718,7 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
         Object {
           "actual": 0,
           "max": 600,
-          "score": 0,
+          "score": 1,
         }
       }
     />


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Make the progress bars for the snippet title and description respond to the content of the input fields.
* Multiple spaces and spaces at the beginning and end of the snippet description are no longer taken into account anymore for the description length progress.
* Newlines in the snippet description are replaced by a space before being displayed in the snippet preview.

## Relevant technical choices:
* Move the measurement of the title and description from `wordpress-seo` to `yoast-components` in order to make the progress bars work without a CMS-specific implementation.
* Remove the test sliders for the progress bars, because the progress bars now respond to the content of the input fields.
* Strip multiple spaces and spaces at the beginning and end of the description.
* I've made a distinction between `mapDataToPreview` and `mapDataToMeasurement`. Most of the mapping is taking place in `mapDataToMeasurement`. In `mapDataToPreview` is decided whether to use the hand-written description or, if that one is empty, the generated description. This distinction exists because the generated description shouldn't be measured because the progress bar should be empty when a generated description is being used.
* Although it is not possible anymore to add newlines to the description and title, the replacement of newlines by spaces is kept in this PR (I've discussed this with @atimmer) because sticking lines together without spaces is never a good idea. 

## Test instructions

This PR can be tested by following these steps:
* Link `stories/add-title-and-description-assessment` to `wordpress-seo`. Test whether the progress bars respond to the content of the input fields.
* Add multiple spaces to the description, both in the middle, at the beginning and the end. Multiple spaces shouldn't be counted for the description length, and spaces from the beginning and end should be stripped as well.
* Play around with changing the title and metadescription, reload the page etc. to make sure everything works as expected with mapping from input field to the preview and from the input field to the progress bars.

Fixes https://github.com/Yoast/wordpress-seo/issues/9777
Fixes https://github.com/Yoast/wordpress-seo/issues/9913
