### PR TITLE
SEO title input field should be single line

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -3,6 +3,7 @@ import React from "react";
 import { EditorState, convertToRaw, convertFromRaw } from "draft-js";
 import Editor from "draft-js-plugins-editor";
 import createMentionPlugin, { defaultSuggestionsFilter } from "draft-js-mention-plugin";
+import createSingleLinePlugin from 'draft-js-single-line-plugin'
 import flow from "lodash/flow";
 import debounce from "lodash/debounce";
 import PropTypes from "prop-types";
@@ -95,6 +96,10 @@ class ReplacementVariableEditor extends React.Component {
 		this.mentionsPlugin = createMentionPlugin( {
 			mentionTrigger: "%",
 			entityMutability: "IMMUTABLE",
+		} );
+
+		this.singleLinePlugin = createSingleLinePlugin( {
+			stripEntities: false,
 		} );
 	}
 
@@ -254,7 +259,7 @@ class ReplacementVariableEditor extends React.Component {
 					onChange={ this.onChange }
 					onFocus={ onFocus }
 					onBlur={ onBlur }
-					plugins={ [ this.mentionsPlugin ] }
+					plugins={ [ this.mentionsPlugin, this.singleLinePlugin ] }
 					ref={ this.setEditorRef }
 					stripPastedStyles={ true }
 					ariaLabelledBy={ ariaLabelledBy }

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -3,7 +3,7 @@ import React from "react";
 import { EditorState, convertToRaw, convertFromRaw } from "draft-js";
 import Editor from "draft-js-plugins-editor";
 import createMentionPlugin, { defaultSuggestionsFilter } from "draft-js-mention-plugin";
-import createSingleLinePlugin from 'draft-js-single-line-plugin'
+import createSingleLinePlugin from "draft-js-single-line-plugin";
 import flow from "lodash/flow";
 import debounce from "lodash/debounce";
 import PropTypes from "prop-types";

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -73,6 +73,15 @@ const InputContainer = styled.div.attrs( {
 	}
 `;
 
+const InputContainerTitle = InputContainer.extend`
+	.public-DraftStyleDefault-block {
+		line-height: 24px;
+		height: 24px;
+		overflow: hidden;
+		white-space: nowrap;
+	}
+`;
+
 const SlugInput = styled.input`
 	border: none;
 	width: 100%;
@@ -224,7 +233,7 @@ class SnippetEditorFields extends React.Component {
 						onClick={ () => onFocus( "title" ) } >
 						{ __( "SEO title", "yoast-components" ) }
 					</SimulatedLabel>
-					<InputContainer
+					<InputContainerTitle
 						onClick={ () => this.elements.title.focus() }
 						isActive={ activeField === "title" }
 						isHovered={ hoveredField === "title" }>
@@ -237,7 +246,7 @@ class SnippetEditorFields extends React.Component {
 							ref={ ( ref ) => this.setRef( "title", ref ) }
 							ariaLabelledBy={ titleLabelId }
 						/>
-					</InputContainer>
+					</InputContainerTitle>
 					<ProgressBar
 						max={ titleLengthProgress.max }
 						value={ titleLengthProgress.actual }

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -73,7 +73,7 @@ const InputContainer = styled.div.attrs( {
 	}
 `;
 
-const InputContainerTitle = InputContainer.extend`
+const TitleInputContainer = InputContainer.extend`
 	.public-DraftStyleDefault-block {
 		line-height: 24px;
 		height: 24px;
@@ -96,7 +96,7 @@ const SlugInput = styled.input`
 	}
 `;
 
-const InputContainerDescription = InputContainer.extend`
+const DescriptionInputContainer = InputContainer.extend`
 	min-height: 60px;
 	padding: 2px 6px;
 	line-height: 19.6px;
@@ -233,7 +233,7 @@ class SnippetEditorFields extends React.Component {
 						onClick={ () => onFocus( "title" ) } >
 						{ __( "SEO title", "yoast-components" ) }
 					</SimulatedLabel>
-					<InputContainerTitle
+					<TitleInputContainer
 						onClick={ () => this.elements.title.focus() }
 						isActive={ activeField === "title" }
 						isHovered={ hoveredField === "title" }>
@@ -246,7 +246,7 @@ class SnippetEditorFields extends React.Component {
 							ref={ ( ref ) => this.setRef( "title", ref ) }
 							ariaLabelledBy={ titleLabelId }
 						/>
-					</InputContainerTitle>
+					</TitleInputContainer>
 					<ProgressBar
 						max={ titleLengthProgress.max }
 						value={ titleLengthProgress.actual }
@@ -279,7 +279,7 @@ class SnippetEditorFields extends React.Component {
 						onClick={ () => onFocus( "description" ) } >
 						{ __( "Meta description", "yoast-components" ) }
 					</SimulatedLabel>
-					<InputContainerDescription
+					<DescriptionInputContainer
 						onClick={ () => this.elements.description.focus() }
 						isActive={ activeField === "description" }
 						isHovered={ hoveredField === "description" }>
@@ -292,7 +292,7 @@ class SnippetEditorFields extends React.Component {
 							ref={ ( ref ) => this.setRef( "description", ref ) }
 							ariaLabelledBy={ descriptionLabelId }
 						/>
-					</InputContainerDescription>
+					</DescriptionInputContainer>
 					<ProgressBar
 						max={ descriptionLengthProgress.max }
 						value={ descriptionLengthProgress.actual }

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
@@ -157,6 +157,15 @@ exports[`ReplacementVariableEditor wraps a Draft.js editor instance 1`] = `
           "onTab": [Function],
           "onUpArrow": [Function],
         },
+        Object {
+          "blockRenderMap": Immutable.Map {
+            "unstyled": Object {
+              "element": "div",
+            },
+          },
+          "handleReturn": [Function],
+          "onChange": [Function],
+        },
       ]
     }
     stripPastedStyles={true}

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -738,7 +738,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   margin-right: 7px;
 }
 
-.c36 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -960,7 +960,42 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   content: "";
 }
 
-.c35 {
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+  height: 24px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c34 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -979,7 +1014,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   line-height: 19.6px;
 }
 
-.c35::before {
+.c36::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -991,7 +1026,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   content: "";
 }
 
-.c34 {
+.c35 {
   border: none;
   width: 100%;
   height: inherit;
@@ -1001,7 +1036,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   color: inherit;
 }
 
-.c34:focus {
+.c35:focus {
   outline: 0;
 }
 
@@ -2092,7 +2127,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c34"
                   onClick={[Function]}
                 >
                   <SnippetEditorFields__SlugInput
@@ -2105,7 +2140,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   >
                     <input
                       aria-labelledby="snippet-editor-field-6-slug"
-                      className="c34"
+                      className="c35"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -2138,7 +2173,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 onClick={[Function]}
               >
                 <div
-                  className="c35"
+                  className="c36"
                   onClick={[Function]}
                 >
                   <ReplacementVariableEditor
@@ -2180,7 +2215,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c36"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -2189,7 +2224,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c36 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -2198,7 +2233,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c36 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -2207,7 +2242,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -2216,13 +2251,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -2323,7 +2358,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   margin-right: 7px;
 }
 
-.c36 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -2545,7 +2580,42 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   content: "";
 }
 
-.c35 {
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+  height: 24px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c34 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -2564,7 +2634,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   line-height: 19.6px;
 }
 
-.c35::before {
+.c36::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -2576,7 +2646,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   content: "";
 }
 
-.c34 {
+.c35 {
   border: none;
   width: 100%;
   height: inherit;
@@ -2586,7 +2656,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   color: inherit;
 }
 
-.c34:focus {
+.c35:focus {
   outline: 0;
 }
 
@@ -3677,7 +3747,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c34"
                   onClick={[Function]}
                 >
                   <SnippetEditorFields__SlugInput
@@ -3690,7 +3760,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   >
                     <input
                       aria-labelledby="snippet-editor-field-6-slug"
-                      className="c34"
+                      className="c35"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -3723,7 +3793,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 onClick={[Function]}
               >
                 <div
-                  className="c35"
+                  className="c36"
                   onClick={[Function]}
                 >
                   <ReplacementVariableEditor
@@ -3765,7 +3835,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c36"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -3774,7 +3844,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c36 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -3783,7 +3853,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c36 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -3792,7 +3862,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -3801,13 +3871,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -3908,7 +3978,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   margin-right: 7px;
 }
 
-.c36 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -4130,7 +4200,42 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   content: "";
 }
 
-.c35 {
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+  height: 24px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c34 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -4149,7 +4254,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   line-height: 19.6px;
 }
 
-.c35::before {
+.c36::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -4161,7 +4266,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   content: "";
 }
 
-.c34 {
+.c35 {
   border: none;
   width: 100%;
   height: inherit;
@@ -4171,7 +4276,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   color: inherit;
 }
 
-.c34:focus {
+.c35:focus {
   outline: 0;
 }
 
@@ -5262,7 +5367,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c34"
                   onClick={[Function]}
                 >
                   <SnippetEditorFields__SlugInput
@@ -5275,7 +5380,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   >
                     <input
                       aria-labelledby="snippet-editor-field-6-slug"
-                      className="c34"
+                      className="c35"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -5308,7 +5413,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 onClick={[Function]}
               >
                 <div
-                  className="c35"
+                  className="c36"
                   onClick={[Function]}
                 >
                   <ReplacementVariableEditor
@@ -5350,7 +5455,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c36"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -5359,7 +5464,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c36 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -5368,7 +5473,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c36 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -5377,7 +5482,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -5386,13 +5491,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -5493,7 +5598,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   margin-right: 7px;
 }
 
-.c36 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -5715,7 +5820,42 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   content: "";
 }
 
-.c35 {
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+  height: 24px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c34 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -5734,7 +5874,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   line-height: 19.6px;
 }
 
-.c35::before {
+.c36::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -5746,7 +5886,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   content: "";
 }
 
-.c34 {
+.c35 {
   border: none;
   width: 100%;
   height: inherit;
@@ -5756,7 +5896,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   color: inherit;
 }
 
-.c34:focus {
+.c35:focus {
   outline: 0;
 }
 
@@ -6847,7 +6987,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c34"
                   onClick={[Function]}
                 >
                   <SnippetEditorFields__SlugInput
@@ -6860,7 +7000,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   >
                     <input
                       aria-labelledby="snippet-editor-field-2-slug"
-                      className="c34"
+                      className="c35"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -6893,7 +7033,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 onClick={[Function]}
               >
                 <div
-                  className="c35"
+                  className="c36"
                   onClick={[Function]}
                 >
                   <ReplacementVariableEditor
@@ -6935,7 +7075,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c36"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -6944,7 +7084,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c36 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -6953,7 +7093,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c36 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -6962,7 +7102,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -6971,13 +7111,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -8284,7 +8424,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   margin-right: 7px;
 }
 
-.c37 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -8446,7 +8586,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   margin: 0;
 }
 
-.c36 {
+.c37 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -8459,21 +8599,21 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border: 1px solid #ddd;
 }
 
-.c36::-webkit-progress-bar {
+.c37::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c36::-webkit-progress-value {
+.c37::-webkit-progress-value {
   background-color: #dc3232;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c36::-moz-progress-bar {
+.c37::-moz-progress-bar {
   background-color: #dc3232;
 }
 
-.c36::-ms-fill {
+.c37::-ms-fill {
   background-color: #dc3232;
   border: 0;
 }
@@ -8538,7 +8678,42 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   content: "";
 }
 
-.c35 {
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+  height: 24px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c34 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -8557,7 +8732,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   line-height: 19.6px;
 }
 
-.c35::before {
+.c36::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -8569,7 +8744,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   content: "";
 }
 
-.c34 {
+.c35 {
   border: none;
   width: 100%;
   height: inherit;
@@ -8579,7 +8754,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   color: inherit;
 }
 
-.c34:focus {
+.c35:focus {
   outline: 0;
 }
 
@@ -9670,7 +9845,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c34"
                   onClick={[Function]}
                 >
                   <SnippetEditorFields__SlugInput
@@ -9683,7 +9858,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   >
                     <input
                       aria-labelledby="snippet-editor-field-9-slug"
-                      className="c34"
+                      className="c35"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -9716,7 +9891,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 onClick={[Function]}
               >
                 <div
-                  className="c35"
+                  className="c36"
                   onClick={[Function]}
                 >
                   <ReplacementVariableEditor
@@ -9741,7 +9916,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               >
                 <progress
                   aria-hidden="true"
-                  className="c36"
+                  className="c37"
                   max={156}
                   value={0}
                 />
@@ -9758,7 +9933,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c37"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -9767,7 +9942,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c37 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -9776,7 +9951,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -9785,7 +9960,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -9794,13 +9969,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -9901,7 +10076,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   margin-right: 7px;
 }
 
-.c37 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -10095,7 +10270,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border: 0;
 }
 
-.c36 {
+.c37 {
   box-sizing: border-box;
   width: 100%;
   height: 8px;
@@ -10108,21 +10283,21 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border: 1px solid #ddd;
 }
 
-.c36::-webkit-progress-bar {
+.c37::-webkit-progress-bar {
   background-color: #f7f7f7;
 }
 
-.c36::-webkit-progress-value {
+.c37::-webkit-progress-value {
   background-color: #7ad03a;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
-.c36::-moz-progress-bar {
+.c37::-moz-progress-bar {
   background-color: #7ad03a;
 }
 
-.c36::-ms-fill {
+.c37::-ms-fill {
   background-color: #7ad03a;
   border: 0;
 }
@@ -10155,7 +10330,42 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   content: "";
 }
 
-.c35 {
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+  height: 24px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c34 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -10174,7 +10384,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   line-height: 19.6px;
 }
 
-.c35::before {
+.c36::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -10186,7 +10396,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   content: "";
 }
 
-.c34 {
+.c35 {
   border: none;
   width: 100%;
   height: inherit;
@@ -10196,7 +10406,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   color: inherit;
 }
 
-.c34:focus {
+.c35:focus {
   outline: 0;
 }
 
@@ -11287,7 +11497,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c34"
                   onClick={[Function]}
                 >
                   <SnippetEditorFields__SlugInput
@@ -11300,7 +11510,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   >
                     <input
                       aria-labelledby="snippet-editor-field-8-slug"
-                      className="c34"
+                      className="c35"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -11333,7 +11543,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 onClick={[Function]}
               >
                 <div
-                  className="c35"
+                  className="c36"
                   onClick={[Function]}
                 >
                   <ReplacementVariableEditor
@@ -11358,7 +11568,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               >
                 <progress
                   aria-hidden="true"
-                  className="c36"
+                  className="c37"
                   max={650}
                   value={330}
                 />
@@ -11375,7 +11585,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c37"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -11384,7 +11594,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c37 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -11393,7 +11603,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -11402,7 +11612,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -11411,13 +11621,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -12678,7 +12888,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   margin-right: 7px;
 }
 
-.c37 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -12900,7 +13110,42 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   content: "";
 }
 
-.c36 {
+.c33 .public-DraftStyleDefault-block {
+  line-height: 24px;
+  height: 24px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c35 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  cursor: text;
+}
+
+.c35::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c37 {
   padding: 3px 5px;
   border: 1px solid #5b9dd9;
   box-shadow: 0 0 2px rgba(30,140,190,.8);
@@ -12919,7 +13164,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   line-height: 19.6px;
 }
 
-.c36::before {
+.c37::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -12931,7 +13176,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   content: "";
 }
 
-.c35 {
+.c36 {
   border: none;
   width: 100%;
   height: inherit;
@@ -12941,7 +13186,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   color: inherit;
 }
 
-.c35:focus {
+.c36:focus {
   outline: 0;
 }
 
@@ -14052,7 +14297,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 onClick={[Function]}
               >
                 <div
-                  className="c33"
+                  className="c35"
                   onClick={[Function]}
                 >
                   <SnippetEditorFields__SlugInput
@@ -14065,7 +14310,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   >
                     <input
                       aria-labelledby="snippet-editor-field-4-slug"
-                      className="c35"
+                      className="c36"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -14098,7 +14343,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 onClick={[Function]}
               >
                 <div
-                  className="c36"
+                  className="c37"
                   onClick={[Function]}
                 >
                   <ReplacementVariableEditor
@@ -14140,7 +14385,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c37"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -14149,7 +14394,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c37 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -14158,7 +14403,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -14167,7 +14412,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -14176,13 +14421,13 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -14283,7 +14528,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   margin-right: 7px;
 }
 
-.c37 {
+.c38 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -14505,7 +14750,42 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   content: "";
 }
 
-.c36 {
+.c33 .public-DraftStyleDefault-block {
+  line-height: 24px;
+  height: 24px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c35 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  cursor: text;
+}
+
+.c35::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c37 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -14524,7 +14804,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   line-height: 19.6px;
 }
 
-.c36::before {
+.c37::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -14536,7 +14816,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   content: "";
 }
 
-.c35 {
+.c36 {
   border: none;
   width: 100%;
   height: inherit;
@@ -14546,7 +14826,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   color: inherit;
 }
 
-.c35:focus {
+.c36:focus {
   outline: 0;
 }
 
@@ -15657,7 +15937,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                 onClick={[Function]}
               >
                 <div
-                  className="c33"
+                  className="c35"
                   onClick={[Function]}
                 >
                   <SnippetEditorFields__SlugInput
@@ -15670,7 +15950,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   >
                     <input
                       aria-labelledby="snippet-editor-field-3-slug"
-                      className="c35"
+                      className="c36"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -15703,7 +15983,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                 onClick={[Function]}
               >
                 <div
-                  className="c36"
+                  className="c37"
                   onClick={[Function]}
                 >
                   <ReplacementVariableEditor
@@ -15745,7 +16025,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c37"
+        className="c38"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -15754,7 +16034,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c37 Button-kDSBcD c3"
+          className="c38 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -15763,7 +16043,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -15772,7 +16052,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -15781,13 +16061,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -15888,7 +16168,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   margin-right: 7px;
 }
 
-.c36 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -16110,7 +16390,42 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   content: "";
 }
 
-.c35 {
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+  height: 24px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c34 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -16129,7 +16444,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   line-height: 19.6px;
 }
 
-.c35::before {
+.c36::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -16141,7 +16456,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   content: "";
 }
 
-.c34 {
+.c35 {
   border: none;
   width: 100%;
   height: inherit;
@@ -16151,7 +16466,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   color: inherit;
 }
 
-.c34:focus {
+.c35:focus {
   outline: 0;
 }
 
@@ -17242,7 +17557,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c34"
                   onClick={[Function]}
                 >
                   <SnippetEditorFields__SlugInput
@@ -17255,7 +17570,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   >
                     <input
                       aria-labelledby="snippet-editor-field-1-slug"
-                      className="c34"
+                      className="c35"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -17288,7 +17603,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 onClick={[Function]}
               >
                 <div
-                  className="c35"
+                  className="c36"
                   onClick={[Function]}
                 >
                   <ReplacementVariableEditor
@@ -17330,7 +17645,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c36"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -17339,7 +17654,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c36 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -17348,7 +17663,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c36 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -17357,7 +17672,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -17366,13 +17681,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -17473,7 +17788,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   margin-right: 7px;
 }
 
-.c36 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -17695,7 +18010,42 @@ exports[`SnippetEditor passes replacement variables to the title and description
   content: "";
 }
 
-.c35 {
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+  height: 24px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c34 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -17714,7 +18064,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   line-height: 19.6px;
 }
 
-.c35::before {
+.c36::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -17726,7 +18076,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   content: "";
 }
 
-.c34 {
+.c35 {
   border: none;
   width: 100%;
   height: inherit;
@@ -17736,7 +18086,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   color: inherit;
 }
 
-.c34:focus {
+.c35:focus {
   outline: 0;
 }
 
@@ -18860,7 +19210,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c34"
                   onClick={[Function]}
                 >
                   <SnippetEditorFields__SlugInput
@@ -18873,7 +19223,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   >
                     <input
                       aria-labelledby="snippet-editor-field-7-slug"
-                      className="c34"
+                      className="c35"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -18906,7 +19256,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 onClick={[Function]}
               >
                 <div
-                  className="c35"
+                  className="c36"
                   onClick={[Function]}
                 >
                   <ReplacementVariableEditor
@@ -18959,7 +19309,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c36"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -18968,7 +19318,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c36 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -18977,7 +19327,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c36 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -18986,7 +19336,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -18995,13 +19345,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >
@@ -19765,7 +20115,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   margin-right: 7px;
 }
 
-.c36 {
+.c37 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -19987,7 +20337,42 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   content: "";
 }
 
-.c35 {
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+  height: 24px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.c34 {
+  padding: 3px 5px;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  margin-top: 5px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
   padding: 3px 5px;
   border: 1px solid #ddd;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -20006,7 +20391,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   line-height: 19.6px;
 }
 
-.c35::before {
+.c36::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -20018,7 +20403,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   content: "";
 }
 
-.c34 {
+.c35 {
   border: none;
   width: 100%;
   height: inherit;
@@ -20028,7 +20413,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   color: inherit;
 }
 
-.c34:focus {
+.c35:focus {
   outline: 0;
 }
 
@@ -21119,7 +21504,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                 onClick={[Function]}
               >
                 <div
-                  className="c32"
+                  className="c34"
                   onClick={[Function]}
                 >
                   <SnippetEditorFields__SlugInput
@@ -21132,7 +21517,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   >
                     <input
                       aria-labelledby="snippet-editor-field-5-slug"
-                      className="c34"
+                      className="c35"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -21165,7 +21550,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                 onClick={[Function]}
               >
                 <div
-                  className="c35"
+                  className="c36"
                   onClick={[Function]}
                 >
                   <ReplacementVariableEditor
@@ -21207,7 +21592,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
         backgroundColor="#f7f7f7"
         borderColor="#ccc"
         boxShadowColor="#ccc"
-        className="c36"
+        className="c37"
         onClick={[Function]}
         textColor="#555"
         type="button"
@@ -21216,7 +21601,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c36 Button-kDSBcD c3"
+          className="c37 Button-kDSBcD c3"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -21225,7 +21610,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c36 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c37 Button-kDSBcD c3 Button-kDSBcD c4"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -21234,7 +21619,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
               onClick={[Function]}
               textColor="#555"
               type="button"
@@ -21243,13 +21628,13 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
                 <button
-                  className="c36 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  className="c37 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
                   onClick={[Function]}
                   type="button"
                 >

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "draft-js": "^0.10.5",
     "draft-js-mention-plugin": "^3.0.4",
     "draft-js-plugins-editor": "^2.0.4",
+    "draft-js-single-line-plugin": "^2.0.1",
     "grunt-scss-to-json": "^1.0.1",
     "interpolate-components": "^1.1.0",
     "jed": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2481,6 +2481,12 @@ draft-js-plugins-editor@^2.0.4:
     prop-types "^15.5.8"
     union-class-names "^1.0.0"
 
+draft-js-single-line-plugin@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/draft-js-single-line-plugin/-/draft-js-single-line-plugin-2.0.1.tgz#3aea1b100b1562d7ef3d5d02e73190da12953857"
+  dependencies:
+    immutable "^3.8.1"
+
 draft-js@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.10.5.tgz#bfa9beb018fe0533dbb08d6675c371a6b08fa742"
@@ -4028,6 +4034,10 @@ ignore-walk@^3.0.1:
 ignore@^3.3.3, ignore@^3.3.5:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
+
+immutable@^3.8.1:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
 
 immutable@~3.7.4:
   version "3.7.6"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Implemented [draft-js-single-line-plugin](https://github.com/icelab/draft-js-single-line-plugin) in order to keep the Draft-js Editor from creating new blocks on enter presses. This results in a single-line editor. This now affects both the `SEO title` input field, and the `Meta description` input field.

## Relevant technical choices:

* Used [draft-js-single-line-plugin](https://github.com/icelab/draft-js-single-line-plugin) because preventing the default for Enter keydowns did not work.

## Test instructions

This PR can be tested by following these steps:

* Run `yarn install` and start yoast components.
* Type a sentence in the input field, and make it very long. The editor should remain one line high.
* Try to press `Enter` in the input fields, this should not create new lines.
* Try copy pasting text with linebreaks, `<br />`, etc, into the input fields. Never should you be able to create a new line.
* **NOTE**: there was an issue with the mention plugin entitities being stripped, which was fixed by passing an option to the single-line plugin. So please test that the auto-completing for replacevars still works.

Fixes https://github.com/Yoast/wordpress-seo/issues/9842