### PR TITLE
Serialize replacement variables on the fly

### DIFF
--- a/app/SnippetEditorExample.js
+++ b/app/SnippetEditorExample.js
@@ -15,19 +15,21 @@ const Container = styled.div`
 const replacementVariables = [
 	{
 		name: "title",
+		title: "Title",
 		value: "Title",
+		description: "This is the title of your post",
 	},
 	{
 		name: "post_type",
+		title: "Post type",
 		value: "Gallery",
+		description: "This is the post type of your post",
 	},
 	{
-		name: "snippet",
-		value: "The snippet of your post.",
-	},
-	{
-		name: "snippet_manual",
-		value: "The manual snippet of your post.",
+		name: "sep",
+		title: "Separator",
+		value: " - ",
+		description: "A separator that clarifies your search result snippet",
 	},
 ];
 

--- a/app/SnippetEditorExample.js
+++ b/app/SnippetEditorExample.js
@@ -15,19 +15,19 @@ const Container = styled.div`
 const replacementVariables = [
 	{
 		name: "title",
-		title: "Title",
+		label: "Title",
 		value: "Title",
 		description: "This is the title of your post",
 	},
 	{
 		name: "post_type",
-		title: "Post type",
+		label: "Post type",
 		value: "Gallery",
 		description: "This is the post type of your post",
 	},
 	{
 		name: "sep",
-		title: "Separator",
+		label: "Separator",
 		value: " - ",
 		description: "A separator that clarifies your search result snippet",
 	},

--- a/app/SnippetEditorExample.js
+++ b/app/SnippetEditorExample.js
@@ -31,6 +31,12 @@ const replacementVariables = [
 		value: " - ",
 		description: "A separator that clarifies your search result snippet",
 	},
+	{
+		name: "term404",
+		label: "Error 404 slug",
+		value: "Error 404 slug",
+		description: "The slug which caused the error 404",
+	},
 ];
 
 export default class SnippetEditorExample extends Component {

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -1,6 +1,6 @@
 // External dependencies.
 import React from "react";
-import { EditorState, convertToRaw, convertFromRaw } from "draft-js";
+import { convertToRaw } from "draft-js";
 import Editor from "draft-js-plugins-editor";
 import createMentionPlugin, { defaultSuggestionsFilter } from "draft-js-mention-plugin";
 import flow from "lodash/flow";
@@ -11,19 +11,11 @@ import { __, _n, sprintf } from "@wordpress/i18n";
 
 // Internal dependencies.
 import { replacementVariablesShape } from "../constants";
-import { serializeEditor, unserializeEditor } from "../serialization";
-
-/**
- * Creates a Draft.js editor state from a string.
- *
- * @param {string} content The content to turn into editor state.
- *
- * @returns {EditorState} The editor state.
- */
-const createEditorState = flow( [
-	convertFromRaw,
-	EditorState.createWithContent,
-] );
+import {
+	serializeEditor,
+	unserializeEditor,
+	replaceReplacementVariables,
+} from "../serialization";
 
 /**
  * Serializes the Draft.js editor state into a string.
@@ -67,10 +59,10 @@ class ReplacementVariableEditor extends React.Component {
 		super( props );
 
 		const { content: rawContent, replacementVariables } = this.props;
-		const unserialized = unserializeEditor( rawContent, replacementVariables );
+		const editorState = unserializeEditor( rawContent, replacementVariables );
 
 		this.state = {
-			editorState: createEditorState( unserialized ),
+			editorState,
 			searchValue: "",
 			replacementVariables,
 		};
@@ -124,8 +116,10 @@ class ReplacementVariableEditor extends React.Component {
 	 * @returns {void}
 	 */
 	onChange( editorState ) {
+		editorState = replaceReplacementVariables( editorState, this.props.replacementVariables );
+
 		this.setState( {
-			editorState,
+			editorState: editorState,
 		}, () => {
 			this.serializeContent( editorState );
 		} );
@@ -218,10 +212,10 @@ class ReplacementVariableEditor extends React.Component {
 			nextProps.replacementVariables !== replacementVariables
 		) {
 			this._serializedContent = nextProps.content;
-			const unserialized = unserializeEditor( nextProps.content, nextProps.replacementVariables );
+			const editorState = unserializeEditor( nextProps.content, nextProps.replacementVariables );
 
 			this.setState( {
-				editorState: createEditorState( unserialized ),
+				editorState,
 				replacementVariables: defaultSuggestionsFilter( searchValue, nextProps.replacementVariables ),
 			} );
 		}
@@ -282,6 +276,7 @@ ReplacementVariableEditor.defaultProps = {
 	onFocus: () => {},
 	onBlur: () => {},
 	className: "",
+	replacementVariables: [],
 };
 
 export default ReplacementVariableEditor;

--- a/composites/Plugin/SnippetEditor/constants.js
+++ b/composites/Plugin/SnippetEditor/constants.js
@@ -7,6 +7,8 @@ export const lengthProgressShape = PropTypes.shape( {
 } );
 
 export const replacementVariablesShape = PropTypes.arrayOf( PropTypes.shape( {
-	name: PropTypes.string,
-	value: PropTypes.string,
+	name: PropTypes.string.isRequired,
+	value: PropTypes.string.isRequired,
+	title: PropTypes.string,
+	description: PropTypes.string,
 } ) );

--- a/composites/Plugin/SnippetEditor/constants.js
+++ b/composites/Plugin/SnippetEditor/constants.js
@@ -9,6 +9,6 @@ export const lengthProgressShape = PropTypes.shape( {
 export const replacementVariablesShape = PropTypes.arrayOf( PropTypes.shape( {
 	name: PropTypes.string.isRequired,
 	value: PropTypes.string.isRequired,
-	title: PropTypes.string,
+	label: PropTypes.string,
 	description: PropTypes.string,
 } ) );

--- a/composites/Plugin/SnippetEditor/serialization.js
+++ b/composites/Plugin/SnippetEditor/serialization.js
@@ -4,7 +4,7 @@ import { EditorState, Modifier, SelectionState, ContentState } from "draft-js";
 
 const CIRCUMFIX = "%%";
 
-const ENTITY_FORMAT = /%%(\w+)%%/g;
+const ENTITY_FORMAT = /%%([A-Za-z0-9_]+)%%/g;
 const ENTITY_TYPE = "%mention";
 const ENTITY_MUTABILITY = "IMMUTABLE";
 

--- a/composites/Plugin/SnippetEditor/serialization.js
+++ b/composites/Plugin/SnippetEditor/serialization.js
@@ -1,10 +1,12 @@
-import forEach from "lodash/forEach";
 import reduce from "lodash/reduce";
 import sortBy from "lodash/sortBy";
-import sortedIndexBy from "lodash/sortedIndexBy";
-import trim from "lodash/trim";
+import { EditorState, Modifier, SelectionState, ContentState } from "draft-js";
 
 const CIRCUMFIX = "%%";
+
+const ENTITY_FORMAT = /%%([a-zA-Z_]+)%%/g;
+const ENTITY_TYPE = "%mention";
+const ENTITY_MUTABILITY = "IMMUTABLE";
 
 /**
  * Serializes a tag into a string.
@@ -64,69 +66,229 @@ export function serializeEditor( rawContent ) {
 }
 
 /**
- * Unserializes a tag into a string.
+ * Determines the title for a given name.
  *
- * @param {string} serializedTag The serialized tag.
+ * @param {Array} replacementVariables All the available replacment variables.
+ * @param {string} name The name to find the title for.
  *
- * @returns {string} Unserialized tag.
+ * @returns {string} The title for this replacement variable.
  */
-export function unserializeTag( serializedTag ) {
-	return trim( serializedTag, CIRCUMFIX );
+export function getReplacementVariableTitle( replacementVariables, name ) {
+	let title = name;
+
+	replacementVariables.forEach( ( replacementVariable ) => {
+		if ( replacementVariable.name === name && replacementVariable.title ) {
+			title = replacementVariable.title;
+		}
+	} );
+
+	return title;
 }
 
 /**
- * Unserializes an entity to Draft.js data.
+ * Finds replacement variables in a piece of content.
  *
- * @param {number} key The key the new entity should use.
- * @param {string} name The name of this entity.
- * @param {number} offset The offset where this entity starts in the text.
+ * Returns an array with all strings that match `%%[tag]%%`.
  *
- * @returns {Object} The serialized entity.
+ * @param {string} content The content to find replacement variables in.
+ *
+ * @returns {Array} The found variables and their positions.
  */
-export function unserializeEntity( key, name, offset ) {
-	const entityRange = {
-		key,
-		offset,
-		length: name.length,
-	};
+export function findReplacementVariables( content ) {
+	const variables = [];
+	let replacementVariable;
 
-	const mappedEntity = {
-		data: {
-			mention: {
-				name,
-			},
+	while ( ( replacementVariable = ENTITY_FORMAT.exec( content ) ) ) {
+		const [ match, name ] = replacementVariable;
+
+		variables.push( {
+			name,
+			start: replacementVariable.index,
+			length: match.length,
+		} );
+	}
+
+	return variables;
+}
+
+/**
+ * Adds title to a variable.
+ *
+ * @param {Object} variable Details about the variable we are replacing.
+ * @param {Array} replacementVariables All the available replacement variables.
+ *
+ * @returns {Object} The variable with its title.
+ */
+export function addTitle( variable, replacementVariables ) {
+	return {
+		...variable,
+		title: getReplacementVariableTitle( replacementVariables, variable.name ),
+	};
+}
+
+/**
+ * Adds position information about a variable inside a block.
+ *
+ * @param {Object} variable Details about the variable we are replacing.
+ * @param {number} offset The offset we need to add because of other replacements.
+ *
+ * @returns {Object} The variable with position information.
+ */
+export function addPositionInformation( variable, offset ) {
+	return {
+		...variable,
+		start: variable.start + offset,
+		end: variable.start + variable.length + offset,
+		delta: variable.title.length - variable.length,
+	};
+}
+
+/**
+ * Changes a selection object to represent the selection after replacement.
+ *
+ * @param {SelectionState} selection The previous selection state.
+ * @param {string} blockKey The key of the block we are working in.
+ * @param {Object} variable Details about the variable we are replacing.
+ *
+ * @returns {SelectionState} The new selection state.
+ */
+export function moveSelectionAfterReplacement( selection, blockKey, variable ) {
+	const { start, end, delta } = variable;
+
+	/*
+	 * If the selection touches the replacement we are doing we always move the
+	 * cursor to the end of the entity once it is replaced.
+	 *
+	 * This is probably not always correct, but it works easy and it feels right
+	 * when using the editor.
+	 */
+	if ( selection.hasEdgeWithin( blockKey, start, end ) ) {
+		const newEnd = end + delta;
+
+		selection = selection.merge( {
+			anchorOffset: newEnd,
+			focusOffset: newEnd,
+		} );
+
+		/*
+		 * If the selection is after the thing we are replacing, we need to move the
+		 * selection the same amount
+		 */
+	} else if ( selection.focusOffset > end ) {
+		selection = selection.merge( {
+			anchorOffset: selection.anchorOffset + delta,
+			focusOffset: selection.focusOffset + delta,
+		} );
+	}
+
+	return selection;
+}
+
+/**
+ * Creates a DraftJS entity in a content state.
+ *
+ * @param {ContentState} contentState The previous content state.
+ * @param {Object} variable Details about the variable we are replacing.
+ *
+ * @returns {ContentState} The new content state.
+ */
+export function createEntityInContent( contentState, variable ) {
+	const entityData = {
+		mention: {
+			name: variable.name,
 		},
-		mutability: "IMMUTABLE",
-		type: "%mention",
 	};
 
-	return { entityRange, mappedEntity };
+	return contentState.createEntity( ENTITY_TYPE, ENTITY_MUTABILITY, entityData );
 }
 
 /**
- * Find all indices of a search term in a string.
+ * Replaces a replacement variable in the editor with an entity representing it.
  *
- * @param {string} searchTerm The term to search for.
- * @param {string} text       The text to search in.
+ * @param {EditorState} editorState The previous editor state.
+ * @param {Object} variable Details about the variable we are replacing.
+ * @param {string} blockKey The key of the block we are working in.
  *
- * @returns {Array} Array of found indices.
+ * @returns {EditorState} The new editor state.
  */
-const getIndicesOf = ( searchTerm, text ) => {
-	if ( searchTerm.length === 0 ) {
-		return [];
-	}
+export function replaceVariableWithEntity( editorState, variable, blockKey ) {
+	let contentState = editorState.getCurrentContent();
 
-	let startIndex = 0;
-	let index;
-	const indices = [];
+	// Create a selection that spans the `%%replacement_variable%%` in the text.
+	const variableTextSelection = SelectionState.createEmpty( blockKey )
+		.merge( {
+			anchorOffset: variable.start,
+			focusOffset: variable.end,
+		} );
 
-	while ( ( index = text.indexOf( searchTerm, startIndex ) ) > -1 ) {
-		indices.push( index );
-		startIndex = index + searchTerm.length;
-	}
+	// We need to create the entity before replacing text with it.
+	contentState = createEntityInContent( contentState, variable );
 
-	return indices;
-};
+	/*
+	 * Do the actual replacement.
+	 *
+	 * We replace `%%replacement_variable%%` with an entity. The entity is already
+	 * created in the content state. So we can refer to it by using
+	 * `contentState.getLastCreatedEntityKey`.
+	 */
+	const newContentState = Modifier.replaceText(
+		contentState,
+		variableTextSelection,
+		variable.title,
+		// No inline style needed.
+		null,
+		contentState.getLastCreatedEntityKey(),
+	);
+
+	// We need to apply the new content state to the editor state.
+	return EditorState.push( editorState, newContentState, "apply-entity" );
+}
+
+/**
+ * Replaces replacement variables (%%tags%%) in an editor state with entities.
+ *
+ * @param {EditorState} editorState          The editor state to find the variables in.
+ * @param {Array}       replacementVariables The available replacement variables, used
+ *                                           to determine the title in the entities.
+ *
+ * @returns {EditorState} The new editor state with entities.
+ */
+export function replaceReplacementVariables( editorState, replacementVariables ) {
+	const contentState = editorState.getCurrentContent();
+	const blockMap = contentState.getBlockMap();
+	let newEditorState = editorState;
+
+	/*
+	 * Because we do this for each block our code will work for multiple blocks even if
+	 * we currently usually only have one block.
+	 */
+	blockMap.forEach( ( block ) => {
+		const { text, key: blockKey } = block;
+		const foundReplacementVariables = findReplacementVariables( text );
+
+		/*
+		 * Offset keeps track of the amount of shifting that occured by replacing
+		 * replacement variables with entities. This makes sure multiple replacement
+		 * variables are replaced correctly.
+		 */
+		let offset = 0;
+
+		foundReplacementVariables.forEach( ( variable ) => {
+			variable = addTitle( variable, replacementVariables );
+			variable = addPositionInformation( variable, offset );
+
+			let selection = newEditorState.getSelection();
+			selection = moveSelectionAfterReplacement( selection, blockKey, variable );
+
+			newEditorState = replaceVariableWithEntity( newEditorState, variable, blockKey );
+			newEditorState = EditorState.acceptSelection( newEditorState, selection );
+
+			offset = offset + variable.delta;
+		} );
+	} );
+
+	return newEditorState;
+}
 
 /**
  * Unserializes a piece of content into Draft.js data.
@@ -134,58 +296,10 @@ const getIndicesOf = ( searchTerm, text ) => {
  * @param {string} content The content to unserialize.
  * @param {Array} tags The tags for the Draft.js mention plugin.
  *
- * @returns {Object} The raw data ready for convertFromRaw.
+ * @returns {EditorState} The raw data ready for convertFromRaw.
  */
 export function unserializeEditor( content, tags ) {
-	const entityRanges = [];
-	const entityMap = {};
-	const replaceIndices = [];
+	const editorState = EditorState.createWithContent( ContentState.createFromText( content ) );
 
-	// Collect the replace indices for each tag.
-	forEach( tags, tag => {
-		const tagValue = serializeTag( tag.name );
-		const indices = getIndicesOf( tagValue, content );
-
-		forEach( indices, index => {
-			const replaceIndex = {
-				index,
-				tag,
-				tagValue,
-			};
-
-			// Add the replace index in order.
-			const insertAt = sortedIndexBy( replaceIndices, replaceIndex, "index" );
-			replaceIndices.splice( insertAt, 0, replaceIndex );
-		} );
-	} );
-
-	// Loop from high to low to ensure the index is still correct.
-	for( let i = replaceIndices.length - 1; i >= 0; i-- ) {
-		const { index, tag, tagValue } = replaceIndices[ i ];
-
-		// Replace the serialized tag with the unserialized tag.
-		const before = content.substr( 0, index );
-		const between = unserializeTag( content.substr( index, tagValue.length ) );
-		const after = content.substr( index + tagValue.length );
-		content = before + between + after;
-
-		// Decrease the offset by twice the length of the circumfix for every index we replace.
-		const offset = index - i * CIRCUMFIX.length * 2;
-		const key = entityRanges.length;
-
-		// Create the DraftJS data.
-		const { entityRange, mappedEntity } = unserializeEntity( key, tag.name, offset );
-		entityRanges.push( entityRange );
-		entityMap[ key ] = mappedEntity;
-	}
-
-	const blocks = [ {
-		entityRanges,
-		text: content,
-	} ];
-
-	return {
-		blocks,
-		entityMap,
-	};
+	return replaceReplacementVariables( editorState, tags );
 }

--- a/composites/Plugin/SnippetEditor/serialization.js
+++ b/composites/Plugin/SnippetEditor/serialization.js
@@ -4,7 +4,7 @@ import { EditorState, Modifier, SelectionState, ContentState } from "draft-js";
 
 const CIRCUMFIX = "%%";
 
-const ENTITY_FORMAT = /%%([a-z0-9_]+)%%/gi;
+const ENTITY_FORMAT = /%%(\w+)%%/g;
 const ENTITY_TYPE = "%mention";
 const ENTITY_MUTABILITY = "IMMUTABLE";
 

--- a/composites/Plugin/SnippetEditor/serialization.js
+++ b/composites/Plugin/SnippetEditor/serialization.js
@@ -4,7 +4,7 @@ import { EditorState, Modifier, SelectionState, ContentState } from "draft-js";
 
 const CIRCUMFIX = "%%";
 
-const ENTITY_FORMAT = /%%([a-zA-Z_]+)%%/g;
+const ENTITY_FORMAT = /%%([a-z0-9_]+)%%/gi;
 const ENTITY_TYPE = "%mention";
 const ENTITY_MUTABILITY = "IMMUTABLE";
 

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
@@ -13,7 +13,20 @@ exports[`ReplacementVariableEditor wraps a Draft.js editor instance 1`] = `
         "_immutable": Immutable.Record {
           "allowUndo": true,
           "currentContent": Immutable.Record {
-            "entityMap": Object {},
+            "entityMap": Object {
+              "__add": [Function],
+              "__create": [Function],
+              "__get": [Function],
+              "__getLastCreatedEntityKey": [Function],
+              "__mergeData": [Function],
+              "__replaceData": [Function],
+              "add": [Function],
+              "create": [Function],
+              "get": [Function],
+              "getLastCreatedEntityKey": [Function],
+              "mergeData": [Function],
+              "replaceData": [Function],
+            },
             "blockMap": Immutable.OrderedMap {
               "1": Immutable.Record {
                 "key": "1",
@@ -163,6 +176,7 @@ exports[`ReplacementVariableEditor wraps a Draft.js editor instance 1`] = `
   />
   <Decorated(MentionSuggestions)
     onSearchChange={[Function]}
+    suggestions={Array []}
   />
 </React.Fragment>
 `;

--- a/composites/Plugin/SnippetEditor/tests/serializationTest.js
+++ b/composites/Plugin/SnippetEditor/tests/serializationTest.js
@@ -1,10 +1,27 @@
-import { serializeEditor, unserializeEditor } from "../serialization";
+import {
+	findReplacementVariables,
+	serializeEditor,
+	unserializeEditor,
+} from "../serialization";
+import { convertToRaw } from "draft-js";
+
+jest.mock( "draft-js/lib/generateRandomKey", () => () => {
+	let randomKey = global._testDraftJSRandomNumber;
+
+	if ( ! randomKey ) {
+		randomKey = 0;
+	}
+
+	randomKey++;
+	global._testDraftJSRandomNumber = randomKey;
+
+	return randomKey + "";
+} );
 
 const TAGS = [
 	{ name: "title", value: "Title" },
 	{ name: "post_type", value: "Gallery" },
 ];
-
 
 describe( "editor serialization", () => {
 	it( "transforms the deep structure to a plain string", () => {
@@ -52,14 +69,19 @@ describe( "editor unserialization", () => {
 		const input = "%%title%% %%post_type%% test test123";
 		const expected = {
 			blocks: [ {
+				data: {},
+				key: "1",
+				inlineStyleRanges: [],
+				type: "unstyled",
+				depth: 0,
 				text: "title post_type test test123",
 				entityRanges: [ {
-					offset: 6,
-					length: 9,
-					key: 0,
-				}, {
 					offset: 0,
 					length: 5,
+					key: 0,
+				}, {
+					offset: 6,
+					length: 9,
 					key: 1,
 				} ],
 			} ],
@@ -67,17 +89,17 @@ describe( "editor unserialization", () => {
 				0: {
 					type: "%mention",
 					mutability: "IMMUTABLE",
-					data: { mention: { name: "post_type" } },
+					data: { mention: { name: "title" } },
 				},
 				1: {
 					type: "%mention",
 					mutability: "IMMUTABLE",
-					data: { mention: { name: "title" } },
+					data: { mention: { name: "post_type" } },
 				},
 			},
 		};
 
-		const actual = unserializeEditor( input, TAGS );
+		const actual = convertToRaw( unserializeEditor( input, TAGS ).getCurrentContent() );
 
 		expect( actual ).toEqual( expected );
 	} );
@@ -86,8 +108,80 @@ describe( "editor unserialization", () => {
 		const input = "The first thing, %%title%%, %%post_type%% type.";
 		const expected = input;
 
-		const actual = serializeEditor( unserializeEditor( input, TAGS ) );
+		const actual = serializeEditor( convertToRaw( unserializeEditor( input, TAGS ).getCurrentContent() ) );
 
 		expect( actual ).toBe( expected );
+	} );
+} );
+
+describe( "findReplacementVariables", () => {
+	it( "determines the list of replacement variables in the text", () => {
+		const content = "Hallo %%title%%, meer spul. %%abcdefghijklmnopqrstuvwxyz%%. Hoi! %%post_type%%.";
+		const expected = [
+			{
+				name: "title",
+				start: 6,
+				length: 9,
+			},
+			{
+				name: "abcdefghijklmnopqrstuvwxyz",
+				start: 28,
+				length: 30,
+			},
+			{
+				name: "post_type",
+				start: 65,
+				length: 13,
+			},
+		];
+
+		const actual = findReplacementVariables( content );
+
+		expect( actual ).toEqual( expected );
+	} );
+
+	it( "recognizes edge cases", () => {
+		const content = "%%title%% !";
+		const expected = [
+			{
+				name: "title",
+				start: 0,
+				length: 9,
+			},
+		];
+
+		const actual = findReplacementVariables( content );
+
+		expect( actual ).toEqual( expected );
+	} );
+
+	it( "recognizes variables at the end of the string", () => {
+		const content = "Hoi %%title%%";
+		const expected = [
+			{
+				name: "title",
+				start: 4,
+				length: 9,
+			},
+		];
+
+		const actual = findReplacementVariables( content );
+
+		expect( actual ).toEqual( expected );
+	} );
+
+	it( "recognizes malformed replacement variables correctly", () => {
+		const content = "%%gibberish%%title%%";
+		const expected = [
+			{
+				name: "gibberish",
+				start: 0,
+				length: 13,
+			},
+		];
+
+		const actual = findReplacementVariables( content );
+
+		expect( actual ).toEqual( expected );
 	} );
 } );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes replacement variable editor to automatically replace replacement variables with entities.

## Relevant technical choices:

* This makes it possible to type or paste `%%title%%` and have it automatically be replaced by an entity. This makes for a much better user experience.

## Test instructions

This PR can be tested by following these steps:

* Open the snippet editor in the yoast components examples.
* See that you can type %%title%% and it turns into an entity.
* See that you can paste `%%title%% %%post_type%% %%sep%%` and they all turn into entities.

Fixes Yoast/wordpress-seo#9820
Fixes Yoast/wordpress-seo#9778