### PR TITLE
Only suggest replacevars starting with the search value.

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -2,7 +2,7 @@
 import React from "react";
 import { EditorState, convertToRaw, convertFromRaw } from "draft-js";
 import Editor from "draft-js-plugins-editor";
-import createMentionPlugin, { defaultSuggestionsFilter } from "draft-js-mention-plugin";
+import createMentionPlugin from "draft-js-mention-plugin";
 import createSingleLinePlugin from "draft-js-single-line-plugin";
 import flow from "lodash/flow";
 import debounce from "lodash/debounce";

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -137,6 +137,21 @@ class ReplacementVariableEditor extends React.Component {
 	}
 
 	/**
+	 * Filters replacement variables values based on the search term typed by the user.
+	 *
+	 * @param {string} searchValue The search value typed after the mentionTrigger by the user.
+	 * @param {Object[]} replacementVariables The replacement variables to filter.
+	 *
+	 * @returns {Object[]} A filtered set of replacement variables to show as suggestions to the user.
+	 */
+	replacementVariablesFilter( searchValue, replacementVariables ) {
+		const value = searchValue.toLowerCase();
+		return replacementVariables.filter( function( suggestion ) {
+			return ! value || suggestion.name.toLowerCase().indexOf( value ) === 0;
+		} );
+	}
+
+	/**
 	 * Handles a search change in the mentions plugin.
 	 *
 	 * @param {string} value The search value.
@@ -146,7 +161,7 @@ class ReplacementVariableEditor extends React.Component {
 	onSearchChange( { value } ) {
 		this.setState( {
 			searchValue: value,
-			replacementVariables: defaultSuggestionsFilter( value, this.props.replacementVariables ),
+			replacementVariables: this.replacementVariablesFilter( value, this.props.replacementVariables ),
 		} );
 
 		/*
@@ -227,7 +242,7 @@ class ReplacementVariableEditor extends React.Component {
 
 			this.setState( {
 				editorState: createEditorState( unserialized ),
-				replacementVariables: defaultSuggestionsFilter( searchValue, nextProps.replacementVariables ),
+				replacementVariables: this.replacementVariablesFilter( searchValue, nextProps.replacementVariables ),
 			} );
 		}
 	}

--- a/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
@@ -24,10 +24,7 @@ describe( "ReplacementVariableEditor", () => {
 } );
 
 describe( "replacementVariablesFilter", () => {
-	let searchValue;
-	let replacementVariables;
-	let replacementVariablesEditor;
-	let expected;
+	let searchValue, replacementVariables, replacementVariablesEditor, expected;
 
 	beforeEach( () => {
 		searchValue = "cat";
@@ -70,14 +67,13 @@ describe( "replacementVariablesFilter", () => {
 		];
 	} );
 
-	it( "Returns only the replacement variables where the start of the name matches with the search value", () => {
-
+	it( "Returns only the replacement variables where the start of the name matches with the search value.", () => {
 		const actual = replacementVariablesEditor.replacementVariablesFilter( searchValue, replacementVariables );
 
 		expect( actual ).toEqual( expected );
 	} );
 
-	it( "Returns the matching replacement vars, regardless of upper- or lowercase in the search value.", () => {
+	it( "Returns the matching replacement variables, regardless of upper- or lowercase in the search value.", () => {
 		searchValue = "Cat";
 
 		const actual = replacementVariablesEditor.replacementVariablesFilter( searchValue, replacementVariables );

--- a/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
@@ -22,3 +22,66 @@ describe( "ReplacementVariableEditor", () => {
 		expect( editor ).toMatchSnapshot();
 	} );
 } );
+
+describe( "replacementVariablesFilter", () => {
+	let searchValue;
+	let replacementVariables;
+	let replacementVariablesEditor;
+	let expected;
+
+	beforeEach( () => {
+		searchValue = "cat";
+		replacementVariables = [
+			{
+				name: "category",
+				value: "uncategorized",
+			},
+			{
+				name: "primary_category",
+				value: "uncategorized",
+			},
+			{
+				name: "category_description",
+				value: "uncategorized",
+			},
+			{
+				name: "date",
+				value: "May 30, 2018",
+			},
+		];
+
+		const props = {
+			content: "Dummy content",
+			onChange: () => {},
+			ariaLabelledBy: "id",
+		};
+
+		replacementVariablesEditor = new ReplacementVariableEditor( props );
+
+		expected = [
+			{
+				name: "category",
+				value: "uncategorized",
+			},
+			{
+				name: "category_description",
+				value: "uncategorized",
+			},
+		];
+	} );
+
+	it( "Returns only the replacement variables where the start of the name matches with the search value", () => {
+
+		const actual = replacementVariablesEditor.replacementVariablesFilter( searchValue, replacementVariables );
+
+		expect( actual ).toEqual( expected );
+	} );
+
+	it( "Returns the matching replacement vars, regardless of upper- or lowercase in the search value.", () => {
+		searchValue = "Cat";
+
+		const actual = replacementVariablesEditor.replacementVariablesFilter( searchValue, replacementVariables );
+
+		expect( actual ).toEqual( expected );
+	} );
+} );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Stopped using draftjs-mention's own default filter, and started using a self-made filter that has no limit on matches, and that only matches from the start.

## Test instructions

This PR can be tested by following these steps:

* Test if the tests pass.
* Go to a replacevarseditorfield ( the title field of the snippet editor for instance)
* Type a `%` and check if all available replacevars are suggested.
* Type a character, and check if only those replacevars are suggested that start with that character.

Fixes #https://github.com/Yoast/wordpress-seo/issues/9891
