### PR TITLE
9892 remove prefixing hyphens

### DIFF
--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -273,15 +273,17 @@ class SnippetEditor extends React.Component {
 	mapDataToPreview( originalData, generatedDescription ) {
 		const { baseUrl, mapDataToPreview } = this.props;
 
-		const mappedData = {
+		let mappedData = {
 			title: this.processReplacementVariables( originalData.title ),
-			url: baseUrl.replace( "https://", "" ) + originalData.slug,
+			url: originalData.slug,
 			description: this.processReplacementVariables( originalData.description || generatedDescription ),
 		};
 
 		if ( mapDataToPreview ) {
-			return mapDataToPreview( mappedData, originalData );
+			mappedData =  mapDataToPreview( mappedData, originalData );
 		}
+
+		mappedData.url = baseUrl.replace( "https://", "" ) + mappedData.url;
 
 		return mappedData;
 	}

--- a/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
@@ -70,13 +70,13 @@ describe( "SnippetEditor", () => {
 		const mapper = jest.fn( () => {
 			return {
 				title: "Totally different title",
-				url: "http://example.org/totally-different-url",
+				url: "totally-different-url",
 				description: "Totally different description",
 			};
 		} );
 		const defaultMappedData = {
 			title: "Test title",
-			url: "example.org/test-slug",
+			url: "test-slug",
 			description: "Test description, replacement value",
 		};
 		const replacementVariables = [


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Used if statement to filter the dashes. Changed what is sent to the function to only be the slug. This way, It's easier to check for the start of what the user has typed. Otherwise, the baseurl also needed to be passed, which would've been inconvenient.

## Test instructions

This PR can be tested by following these steps:

* Check if the unit tests pass on wordpress-seo.
* Checkout this branch and it's sibling branch: https://github.com/Yoast/wordpress-seo/pull/9937
* Visit a post page, add a url with a prefix space and a trailing space, verify no dashes are shown in the snippet preview.

Hyphens typed by the user will unfortunately also be filtered, this has been discussed, and is not considered a big enough problem to stop this pull.

Fixes #https://github.com/Yoast/wordpress-seo/issues/9892
