### PR TITLE
Stories/9834 ditch snippet variables

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -67,8 +67,8 @@ class ReplacementVariableEditor extends React.Component {
 	constructor( props ) {
 		super( props );
 
-		const { content: rawContent, excludeReplaceVars } = this.props;
-		const replacementVariables = this.excludeReplaceVars( this.props.replacementVariables, excludeReplaceVars );
+		const { content: rawContent } = this.props;
+		const replacementVariables = this.excludeReplaceVars( this.props.replacementVariables, this.props.excludeReplaceVars );
 		const unserialized = unserializeEditor( rawContent, replacementVariables );
 
 		this.state = {

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -67,7 +67,8 @@ class ReplacementVariableEditor extends React.Component {
 	constructor( props ) {
 		super( props );
 
-		const { content: rawContent, replacementVariables } = this.props;
+		const { content: rawContent, excludeReplaceVars } = this.props;
+		const replacementVariables = this.modifyReplaceVars( this.props.replacementVariables, excludeReplaceVars );
 		const unserialized = unserializeEditor( rawContent, replacementVariables );
 
 		this.state = {
@@ -119,6 +120,17 @@ class ReplacementVariableEditor extends React.Component {
 
 			this.props.onChange( this._serializedContent );
 		}
+	}
+
+	modifyReplaceVars( replaceVars, excludeReplaceVars ) {
+		let defaultSuggestions = replaceVars;
+		for ( let removeVar of excludeReplaceVars ) {
+			let currentIndex = replaceVars.findIndex( x => x.name === removeVar );
+			if ( currentIndex !== -1 ) {
+				defaultSuggestions = replaceVars.splice( currentIndex, 1 );
+			}
+		}
+		return defaultSuggestions;
 	}
 
 	/**
@@ -283,6 +295,7 @@ ReplacementVariableEditor.propTypes = {
 	onFocus: PropTypes.func,
 	onBlur: PropTypes.func,
 	descriptionEditorFieldPlaceholder: PropTypes.string,
+	excludeReplaceVars: PropTypes.array,
 };
 
 ReplacementVariableEditor.defaultProps = {

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -131,14 +131,14 @@ class ReplacementVariableEditor extends React.Component {
 	 * @returns {array} The new array of replacement variables.
 	 */
 	excludeReplaceVars( replaceVars, excludeReplaceVars ) {
-		let defaultSuggestions = replaceVars;
+		let suggestions = replaceVars;
 		for ( let removeVar of excludeReplaceVars ) {
 			let currentIndex = replaceVars.findIndex( x => x.name === removeVar );
 			if ( currentIndex !== -1 ) {
-				defaultSuggestions = replaceVars.splice( currentIndex, 1 );
+				suggestions = replaceVars.splice( currentIndex, 1 );
 			}
 		}
-		return defaultSuggestions;
+		return suggestions;
 	}
 
 	/**

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -68,7 +68,7 @@ class ReplacementVariableEditor extends React.Component {
 		super( props );
 
 		const { content: rawContent, excludeReplaceVars } = this.props;
-		const replacementVariables = this.modifyReplaceVars( this.props.replacementVariables, excludeReplaceVars );
+		const replacementVariables = this.excludeReplaceVars( this.props.replacementVariables, excludeReplaceVars );
 		const unserialized = unserializeEditor( rawContent, replacementVariables );
 
 		this.state = {
@@ -122,7 +122,15 @@ class ReplacementVariableEditor extends React.Component {
 		}
 	}
 
-	modifyReplaceVars( replaceVars, excludeReplaceVars ) {
+	/**
+	 * Excludes entries from the replacement variables used in the suggestions menu.
+	 *
+	 * @param {array} replaceVars        The array of replacement variable objects.
+	 * @param {array} excludeReplaceVars The array of variables to exclude.
+	 *
+	 * @returns {array} The new array of replacement variables.
+	 */
+	excludeReplaceVars( replaceVars, excludeReplaceVars ) {
 		let defaultSuggestions = replaceVars;
 		for ( let removeVar of excludeReplaceVars ) {
 			let currentIndex = replaceVars.findIndex( x => x.name === removeVar );
@@ -303,6 +311,7 @@ ReplacementVariableEditor.defaultProps = {
 	onBlur: () => {},
 	className: "",
 	descriptionEditorFieldPlaceholder: "",
+	excludeReplaceVars: [],
 };
 
 export default ReplacementVariableEditor;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -114,6 +114,7 @@ class SnippetEditor extends React.Component {
 			descriptionLengthProgress,
 			replacementVariables,
 			descriptionEditorFieldPlaceholder,
+			excludeReplaceVars,
 		} = this.props;
 		const { activeField, hoveredField, isOpen } = this.state;
 
@@ -134,6 +135,7 @@ class SnippetEditor extends React.Component {
 					titleLengthProgress={ titleLengthProgress }
 					descriptionLengthProgress={ descriptionLengthProgress }
 					descriptionEditorFieldPlaceholder={ descriptionEditorFieldPlaceholder }
+					excludeReplaceVars={ excludeReplaceVars }
 				/>
 				<CloseEditorButton onClick={ this.close }>
 					{ __( "Close snippet editor", "yoast-components" ) }
@@ -398,6 +400,7 @@ SnippetEditor.propTypes = {
 	} ).isRequired,
 	descriptionPlaceholder: PropTypes.string,
 	descriptionEditorFieldPlaceholder: PropTypes.string,
+	excludeReplaceVars: PropTypes.array,
 	generatedDescription: PropTypes.string,
 	baseUrl: PropTypes.string.isRequired,
 	mode: PropTypes.oneOf( MODES ),
@@ -427,6 +430,10 @@ SnippetEditor.defaultProps = {
 	mapDataToPreview: null,
 	generatedDescription: "",
 	locale: "en",
+	excludeReplaceVars: [
+		"currentyear", "currentmonth", "currentday", "currenttime",
+		"currentdate", "userid", "searchphrase", "archivetitle"
+	],
 	descriptionEditorFieldPlaceholder: "Modify your meta description by editing it right here",
 };
 

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -432,7 +432,7 @@ SnippetEditor.defaultProps = {
 	locale: "en",
 	excludeReplaceVars: [
 		"currentyear", "currentmonth", "currentday", "currenttime",
-		"currentdate", "userid", "searchphrase", "archivetitle"
+		"currentdate", "userid", "searchphrase", "archivetitle",
 	],
 	descriptionEditorFieldPlaceholder: "Modify your meta description by editing it right here",
 };

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -215,6 +215,7 @@ class SnippetEditorFields extends React.Component {
 			onBlur,
 			onChange,
 			descriptionEditorFieldPlaceholder,
+			excludeReplaceVars,
 			data: {
 				title,
 				slug,
@@ -246,6 +247,7 @@ class SnippetEditorFields extends React.Component {
 							replacementVariables={ replacementVariables }
 							ref={ ( ref ) => this.setRef( "title", ref ) }
 							ariaLabelledBy={ titleLabelId }
+							excludeReplaceVars={ excludeReplaceVars }
 						/>
 					</TitleInputContainer>
 					<ProgressBar
@@ -293,6 +295,7 @@ class SnippetEditorFields extends React.Component {
 							ref={ ( ref ) => this.setRef( "description", ref ) }
 							ariaLabelledBy={ descriptionLabelId }
 							descriptionEditorFieldPlaceholder={ descriptionEditorFieldPlaceholder }
+							excludeReplaceVars={ excludeReplaceVars }
 						/>
 					</DescriptionInputContainer>
 					<ProgressBar
@@ -340,6 +343,7 @@ SnippetEditorFields.propTypes = {
 	titleLengthProgress: lengthProgressShape,
 	descriptionLengthProgress: lengthProgressShape,
 	descriptionEditorFieldPlaceholder: PropTypes.string,
+	excludeReplaceVars: PropTypes.array,
 };
 
 SnippetEditorFields.defaultProps = {

--- a/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
@@ -83,7 +83,7 @@ describe( "replacementVariablesFilter", () => {
 	} );
 } );
 
-describe( "replacementVariablesFilter", () => {
+describe( "excludeReplaceVars", () => {
 	let searchValue, replacementVariables, replacementVariablesEditor, expected;
 
 	beforeEach( () => {
@@ -117,7 +117,7 @@ describe( "replacementVariablesFilter", () => {
 		];
 	} );
 
-	it( "Returns only the replacement variables where the start of the name matches with the search value.", () => {
+	it( "Returns the replacement variable that is still present in the suggestions.", () => {
 		const actual = replacementVariablesEditor.replacementVariablesFilter( searchValue, replacementVariables );
 
 		expect( actual ).toEqual( expected );

--- a/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
@@ -51,6 +51,7 @@ describe( "replacementVariablesFilter", () => {
 			content: "Dummy content",
 			onChange: () => {},
 			ariaLabelledBy: "id",
+			excludeReplaceVars: [],
 		};
 
 		replacementVariablesEditor = new ReplacementVariableEditor( props );
@@ -76,6 +77,47 @@ describe( "replacementVariablesFilter", () => {
 	it( "Returns the matching replacement variables, regardless of upper- or lowercase in the search value.", () => {
 		searchValue = "Cat";
 
+		const actual = replacementVariablesEditor.replacementVariablesFilter( searchValue, replacementVariables );
+
+		expect( actual ).toEqual( expected );
+	} );
+} );
+
+describe( "replacementVariablesFilter", () => {
+	let searchValue, replacementVariables, replacementVariablesEditor, expected;
+
+	beforeEach( () => {
+		searchValue = "cat";
+		replacementVariables = [
+			{
+				name: "category",
+				value: "uncategorized",
+			},
+			{
+				name: "category_description",
+				value: "uncategorized",
+			},
+		];
+
+		const props = {
+			replacementVariables: replacementVariables,
+			content: "Dummy content",
+			onChange: () => {},
+			ariaLabelledBy: "id",
+			excludeReplaceVars: [ "category" ],
+		};
+
+		replacementVariablesEditor = new ReplacementVariableEditor( props );
+
+		expected = [
+			{
+				name: "category_description",
+				value: "uncategorized",
+			},
+		];
+	} );
+
+	it( "Returns only the replacement variables where the start of the name matches with the search value.", () => {
 		const actual = replacementVariablesEditor.replacementVariablesFilter( searchValue, replacementVariables );
 
 		expect( actual ).toEqual( expected );

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -632,6 +632,18 @@ exports[`SnippetEditor activates a field on onMouseUp() and opens the editor 1`]
           "score": 0,
         }
       }
+      excludeReplaceVars={
+        Array [
+          "currentyear",
+          "currentmonth",
+          "currentday",
+          "currenttime",
+          "currentdate",
+          "userid",
+          "searchphrase",
+          "archivetitle",
+        ]
+      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[Function]}
@@ -1162,6 +1174,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
       "max": 156,
       "score": 0,
     }
+  }
+  excludeReplaceVars={
+    Array [
+      "currentyear",
+      "currentmonth",
+      "currentday",
+      "currenttime",
+      "currentdate",
+      "userid",
+      "searchphrase",
+      "archivetitle",
+    ]
   }
   generatedDescription=""
   intl={
@@ -2037,6 +2061,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           "score": 0,
         }
       }
+      excludeReplaceVars={
+        Array [
+          "currentyear",
+          "currentmonth",
+          "currentday",
+          "currenttime",
+          "currentdate",
+          "userid",
+          "searchphrase",
+          "archivetitle",
+        ]
+      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[Function]}
@@ -2082,6 +2118,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-6-title"
                     content="Test title"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -2183,6 +2231,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     ariaLabelledBy="snippet-editor-field-6-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -2786,6 +2846,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
       "score": 0,
     }
   }
+  excludeReplaceVars={
+    Array [
+      "currentyear",
+      "currentmonth",
+      "currentday",
+      "currenttime",
+      "currentdate",
+      "userid",
+      "searchphrase",
+      "archivetitle",
+    ]
+  }
   generatedDescription=""
   intl={
     Object {
@@ -3660,6 +3732,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           "score": 0,
         }
       }
+      excludeReplaceVars={
+        Array [
+          "currentyear",
+          "currentmonth",
+          "currentday",
+          "currenttime",
+          "currentdate",
+          "userid",
+          "searchphrase",
+          "archivetitle",
+        ]
+      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[Function]}
@@ -3705,6 +3789,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-6-title"
                     content="Test title"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -3806,6 +3902,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     ariaLabelledBy="snippet-editor-field-6-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -4409,6 +4517,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
       "score": 0,
     }
   }
+  excludeReplaceVars={
+    Array [
+      "currentyear",
+      "currentmonth",
+      "currentday",
+      "currenttime",
+      "currentdate",
+      "userid",
+      "searchphrase",
+      "archivetitle",
+    ]
+  }
   generatedDescription=""
   intl={
     Object {
@@ -5283,6 +5403,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           "score": 0,
         }
       }
+      excludeReplaceVars={
+        Array [
+          "currentyear",
+          "currentmonth",
+          "currentday",
+          "currenttime",
+          "currentdate",
+          "userid",
+          "searchphrase",
+          "archivetitle",
+        ]
+      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[Function]}
@@ -5328,6 +5460,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-6-title"
                     content="Test title"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -5429,6 +5573,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     ariaLabelledBy="snippet-editor-field-6-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -6031,6 +6187,18 @@ exports[`SnippetEditor closes when calling close() 1`] = `
       "max": 156,
       "score": 0,
     }
+  }
+  excludeReplaceVars={
+    Array [
+      "currentyear",
+      "currentmonth",
+      "currentday",
+      "currenttime",
+      "currentdate",
+      "userid",
+      "searchphrase",
+      "archivetitle",
+    ]
   }
   generatedDescription=""
   intl={
@@ -6906,6 +7074,18 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           "score": 0,
         }
       }
+      excludeReplaceVars={
+        Array [
+          "currentyear",
+          "currentmonth",
+          "currentday",
+          "currenttime",
+          "currentdate",
+          "userid",
+          "searchphrase",
+          "archivetitle",
+        ]
+      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[Function]}
@@ -6951,6 +7131,18 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-2-title"
                     content="Test title"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -7052,6 +7244,18 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     ariaLabelledBy="snippet-editor-field-2-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -7491,6 +7695,18 @@ exports[`SnippetEditor closes when calling close() 2`] = `
       "max": 156,
       "score": 0,
     }
+  }
+  excludeReplaceVars={
+    Array [
+      "currentyear",
+      "currentmonth",
+      "currentday",
+      "currenttime",
+      "currentdate",
+      "userid",
+      "searchphrase",
+      "archivetitle",
+    ]
   }
   generatedDescription=""
   intl={
@@ -8894,6 +9110,18 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
       "score": 0,
     }
   }
+  excludeReplaceVars={
+    Array [
+      "currentyear",
+      "currentmonth",
+      "currentday",
+      "currenttime",
+      "currentdate",
+      "userid",
+      "searchphrase",
+      "archivetitle",
+    ]
+  }
   generatedDescription=""
   intl={
     Object {
@@ -9768,6 +9996,18 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           "score": 0,
         }
       }
+      excludeReplaceVars={
+        Array [
+          "currentyear",
+          "currentmonth",
+          "currentday",
+          "currenttime",
+          "currentdate",
+          "userid",
+          "searchphrase",
+          "archivetitle",
+        ]
+      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[Function]}
@@ -9813,6 +10053,18 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-9-title"
                     content="Test title"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -9914,6 +10166,18 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     ariaLabelledBy="snippet-editor-field-9-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -10548,6 +10812,18 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
       "max": 650,
       "score": 9,
     }
+  }
+  excludeReplaceVars={
+    Array [
+      "currentyear",
+      "currentmonth",
+      "currentday",
+      "currenttime",
+      "currentdate",
+      "userid",
+      "searchphrase",
+      "archivetitle",
+    ]
   }
   generatedDescription=""
   intl={
@@ -11423,6 +11699,18 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           "score": 9,
         }
       }
+      excludeReplaceVars={
+        Array [
+          "currentyear",
+          "currentmonth",
+          "currentday",
+          "currenttime",
+          "currentdate",
+          "userid",
+          "searchphrase",
+          "archivetitle",
+        ]
+      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[Function]}
@@ -11468,6 +11756,18 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-8-title"
                     content="Test title"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -11569,6 +11869,18 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     ariaLabelledBy="snippet-editor-field-8-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -13344,6 +13656,18 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
       "score": 0,
     }
   }
+  excludeReplaceVars={
+    Array [
+      "currentyear",
+      "currentmonth",
+      "currentday",
+      "currenttime",
+      "currentdate",
+      "userid",
+      "searchphrase",
+      "archivetitle",
+    ]
+  }
   generatedDescription=""
   intl={
     Object {
@@ -14226,6 +14550,18 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           "score": 0,
         }
       }
+      excludeReplaceVars={
+        Array [
+          "currentyear",
+          "currentmonth",
+          "currentday",
+          "currenttime",
+          "currentdate",
+          "userid",
+          "searchphrase",
+          "archivetitle",
+        ]
+      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[Function]}
@@ -14271,6 +14607,18 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-4-title"
                     content="Test title"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -14372,6 +14720,18 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     ariaLabelledBy="snippet-editor-field-4-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -14987,6 +15347,18 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
       "score": 0,
     }
   }
+  excludeReplaceVars={
+    Array [
+      "currentyear",
+      "currentmonth",
+      "currentday",
+      "currenttime",
+      "currentdate",
+      "userid",
+      "searchphrase",
+      "archivetitle",
+    ]
+  }
   generatedDescription=""
   intl={
     Object {
@@ -15869,6 +16241,18 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
           "score": 0,
         }
       }
+      excludeReplaceVars={
+        Array [
+          "currentyear",
+          "currentmonth",
+          "currentday",
+          "currenttime",
+          "currentdate",
+          "userid",
+          "searchphrase",
+          "archivetitle",
+        ]
+      }
       hoveredField="description"
       onBlur={[Function]}
       onChange={[Function]}
@@ -15914,6 +16298,18 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-3-title"
                     content="Test title"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -16015,6 +16411,18 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     ariaLabelledBy="snippet-editor-field-3-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -16617,6 +17025,18 @@ exports[`SnippetEditor opens when calling open() 1`] = `
       "max": 156,
       "score": 0,
     }
+  }
+  excludeReplaceVars={
+    Array [
+      "currentyear",
+      "currentmonth",
+      "currentday",
+      "currenttime",
+      "currentdate",
+      "userid",
+      "searchphrase",
+      "archivetitle",
+    ]
   }
   generatedDescription=""
   intl={
@@ -17492,6 +17912,18 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           "score": 0,
         }
       }
+      excludeReplaceVars={
+        Array [
+          "currentyear",
+          "currentmonth",
+          "currentday",
+          "currenttime",
+          "currentdate",
+          "userid",
+          "searchphrase",
+          "archivetitle",
+        ]
+      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[Function]}
@@ -17537,6 +17969,18 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-1-title"
                     content="Test title"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -17638,6 +18082,18 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     ariaLabelledBy="snippet-editor-field-1-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -18240,6 +18696,18 @@ exports[`SnippetEditor passes replacement variables to the title and description
       "max": 156,
       "score": 0,
     }
+  }
+  excludeReplaceVars={
+    Array [
+      "currentyear",
+      "currentmonth",
+      "currentday",
+      "currenttime",
+      "currentdate",
+      "userid",
+      "searchphrase",
+      "archivetitle",
+    ]
   }
   generatedDescription=""
   intl={
@@ -19126,6 +19594,18 @@ exports[`SnippetEditor passes replacement variables to the title and description
           "score": 0,
         }
       }
+      excludeReplaceVars={
+        Array [
+          "currentyear",
+          "currentmonth",
+          "currentday",
+          "currenttime",
+          "currentdate",
+          "userid",
+          "searchphrase",
+          "archivetitle",
+        ]
+      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[Function]}
@@ -19182,6 +19662,18 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-7-title"
                     content="Test title"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -19294,6 +19786,18 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     ariaLabelledBy="snippet-editor-field-7-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -20041,6 +20545,18 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
           "score": 0,
         }
       }
+      excludeReplaceVars={
+        Array [
+          "currentyear",
+          "currentmonth",
+          "currentday",
+          "currenttime",
+          "currentdate",
+          "userid",
+          "searchphrase",
+          "archivetitle",
+        ]
+      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[Function]}
@@ -20571,6 +21087,18 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
       "max": 156,
       "score": 0,
     }
+  }
+  excludeReplaceVars={
+    Array [
+      "currentyear",
+      "currentmonth",
+      "currentday",
+      "currenttime",
+      "currentdate",
+      "userid",
+      "searchphrase",
+      "archivetitle",
+    ]
   }
   generatedDescription=""
   intl={
@@ -21446,6 +21974,18 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
           "score": 0,
         }
       }
+      excludeReplaceVars={
+        Array [
+          "currentyear",
+          "currentmonth",
+          "currentday",
+          "currenttime",
+          "currentdate",
+          "userid",
+          "searchphrase",
+          "archivetitle",
+        ]
+      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[Function]}
@@ -21491,6 +22031,18 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-5-title"
                     content="Test title"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -21592,6 +22144,18 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     ariaLabelledBy="snippet-editor-field-5-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+                    excludeReplaceVars={
+                      Array [
+                        "currentyear",
+                        "currentmonth",
+                        "currentday",
+                        "currenttime",
+                        "currentdate",
+                        "userid",
+                        "searchphrase",
+                        "archivetitle",
+                      ]
+                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes certain replacement variables from appearing in the suggestions in the snippet editor (`currentdate`, `currenttime`, `currentyear`, `currentmonth`, `currentday`, `userid`, `searchphrase`, and `archive_title`)

## Relevant technical choices:

* Introduced a new prop which can contain the names of any replacement variables that should be removed from the suggestions
* This allows specific inclusion/exclusion of replacement variables depending on the instance of the replacement variable editor (the upcoming implementation for the settings page can include `searchphrase` for example)
* This also allows the replacement variables to be used as normal regardless of whether or not they appear in the suggestions menu

## Test instructions

This PR can be tested by following these steps:

* Link wordpress-seo to yoast-components and build
* When editing a snippet, bring up the replacement variable suggestions in the title or meta description fields
* Make sure that the above mentioned replacement variables are not listed in the suggestions 
* Make sure that's the case for both pages and posts
* Typing any of the above replacement variables in their full form (e.g. %%currentdate%%) will correctly display the value (but not bring it up in the suggestions) 

Fixes https://github.com/Yoast/wordpress-seo/issues/9834
