### PR TITLE
Revert "Stories/9834 ditch snippet variables"

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -67,8 +67,7 @@ class ReplacementVariableEditor extends React.Component {
 	constructor( props ) {
 		super( props );
 
-		const { content: rawContent } = this.props;
-		const replacementVariables = this.excludeReplaceVars( this.props.replacementVariables, this.props.excludeReplaceVars );
+		const { content: rawContent, replacementVariables } = this.props;
 		const unserialized = unserializeEditor( rawContent, replacementVariables );
 
 		this.state = {
@@ -120,25 +119,6 @@ class ReplacementVariableEditor extends React.Component {
 
 			this.props.onChange( this._serializedContent );
 		}
-	}
-
-	/**
-	 * Excludes entries from the replacement variables used in the suggestions menu.
-	 *
-	 * @param {array} replaceVars        The array of replacement variable objects.
-	 * @param {array} excludeReplaceVars The array of variables to exclude.
-	 *
-	 * @returns {array} The new array of replacement variables.
-	 */
-	excludeReplaceVars( replaceVars, excludeReplaceVars ) {
-		let suggestions = replaceVars;
-		for ( let removeVar of excludeReplaceVars ) {
-			let currentIndex = replaceVars.findIndex( x => x.name === removeVar );
-			if ( currentIndex !== -1 ) {
-				suggestions = replaceVars.splice( currentIndex, 1 );
-			}
-		}
-		return suggestions;
 	}
 
 	/**
@@ -318,7 +298,6 @@ ReplacementVariableEditor.propTypes = {
 	onFocus: PropTypes.func,
 	onBlur: PropTypes.func,
 	descriptionEditorFieldPlaceholder: PropTypes.string,
-	excludeReplaceVars: PropTypes.array,
 };
 
 ReplacementVariableEditor.defaultProps = {
@@ -326,7 +305,6 @@ ReplacementVariableEditor.defaultProps = {
 	onBlur: () => {},
 	className: "",
 	descriptionEditorFieldPlaceholder: "",
-	excludeReplaceVars: [],
 };
 
 export default ReplacementVariableEditor;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -184,7 +184,6 @@ class SnippetEditor extends React.Component {
 			data,
 			replacementVariables,
 			descriptionEditorFieldPlaceholder,
-			excludeReplaceVars,
 			onChange,
 		} = this.props;
 		const { activeField, hoveredField, isOpen, titleLengthProgress, descriptionLengthProgress } = this.state;
@@ -206,7 +205,6 @@ class SnippetEditor extends React.Component {
 					titleLengthProgress={ titleLengthProgress }
 					descriptionLengthProgress={ descriptionLengthProgress }
 					descriptionEditorFieldPlaceholder={ descriptionEditorFieldPlaceholder }
-					excludeReplaceVars={ excludeReplaceVars }
 				/>
 				<CloseEditorButton onClick={ this.close }>
 					{ __( "Close snippet editor", "yoast-components" ) }
@@ -501,7 +499,6 @@ SnippetEditor.propTypes = {
 	} ).isRequired,
 	descriptionPlaceholder: PropTypes.string,
 	descriptionEditorFieldPlaceholder: PropTypes.string,
-	excludeReplaceVars: PropTypes.array,
 	generatedDescription: PropTypes.string,
 	baseUrl: PropTypes.string.isRequired,
 	mode: PropTypes.oneOf( MODES ),
@@ -531,10 +528,6 @@ SnippetEditor.defaultProps = {
 	mapDataToPreview: null,
 	generatedDescription: "",
 	locale: "en",
-	excludeReplaceVars: [
-		"currentyear", "currentmonth", "currentday", "currenttime",
-		"currentdate", "userid", "searchphrase", "archivetitle",
-	],
 	descriptionEditorFieldPlaceholder: "Modify your meta description by editing it right here",
 };
 

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -215,7 +215,6 @@ class SnippetEditorFields extends React.Component {
 			onBlur,
 			onChange,
 			descriptionEditorFieldPlaceholder,
-			excludeReplaceVars,
 			data: {
 				title,
 				slug,
@@ -247,7 +246,6 @@ class SnippetEditorFields extends React.Component {
 							replacementVariables={ replacementVariables }
 							ref={ ( ref ) => this.setRef( "title", ref ) }
 							ariaLabelledBy={ titleLabelId }
-							excludeReplaceVars={ excludeReplaceVars }
 						/>
 					</TitleInputContainer>
 					<ProgressBar
@@ -295,7 +293,6 @@ class SnippetEditorFields extends React.Component {
 							ref={ ( ref ) => this.setRef( "description", ref ) }
 							ariaLabelledBy={ descriptionLabelId }
 							descriptionEditorFieldPlaceholder={ descriptionEditorFieldPlaceholder }
-							excludeReplaceVars={ excludeReplaceVars }
 						/>
 					</DescriptionInputContainer>
 					<ProgressBar
@@ -343,7 +340,6 @@ SnippetEditorFields.propTypes = {
 	titleLengthProgress: lengthProgressShape,
 	descriptionLengthProgress: lengthProgressShape,
 	descriptionEditorFieldPlaceholder: PropTypes.string,
-	excludeReplaceVars: PropTypes.array,
 };
 
 SnippetEditorFields.defaultProps = {

--- a/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
@@ -51,7 +51,6 @@ describe( "replacementVariablesFilter", () => {
 			content: "Dummy content",
 			onChange: () => {},
 			ariaLabelledBy: "id",
-			excludeReplaceVars: [],
 		};
 
 		replacementVariablesEditor = new ReplacementVariableEditor( props );
@@ -77,47 +76,6 @@ describe( "replacementVariablesFilter", () => {
 	it( "Returns the matching replacement variables, regardless of upper- or lowercase in the search value.", () => {
 		searchValue = "Cat";
 
-		const actual = replacementVariablesEditor.replacementVariablesFilter( searchValue, replacementVariables );
-
-		expect( actual ).toEqual( expected );
-	} );
-} );
-
-describe( "excludeReplaceVars", () => {
-	let searchValue, replacementVariables, replacementVariablesEditor, expected;
-
-	beforeEach( () => {
-		searchValue = "cat";
-		replacementVariables = [
-			{
-				name: "category",
-				value: "uncategorized",
-			},
-			{
-				name: "category_description",
-				value: "uncategorized",
-			},
-		];
-
-		const props = {
-			replacementVariables: replacementVariables,
-			content: "Dummy content",
-			onChange: () => {},
-			ariaLabelledBy: "id",
-			excludeReplaceVars: [ "category" ],
-		};
-
-		replacementVariablesEditor = new ReplacementVariableEditor( props );
-
-		expected = [
-			{
-				name: "category_description",
-				value: "uncategorized",
-			},
-		];
-	} );
-
-	it( "Returns the replacement variable that is still present in the suggestions.", () => {
 		const actual = replacementVariablesEditor.replacementVariablesFilter( searchValue, replacementVariables );
 
 		expect( actual ).toEqual( expected );

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -632,18 +632,6 @@ exports[`SnippetEditor activates a field on onMouseUp() and opens the editor 1`]
           "score": 6,
         }
       }
-      excludeReplaceVars={
-        Array [
-          "currentyear",
-          "currentmonth",
-          "currentday",
-          "currenttime",
-          "currentdate",
-          "userid",
-          "searchphrase",
-          "archivetitle",
-        ]
-      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[MockFunction]}
@@ -1206,18 +1194,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
       "max": 156,
       "score": 0,
     }
-  }
-  excludeReplaceVars={
-    Array [
-      "currentyear",
-      "currentmonth",
-      "currentday",
-      "currenttime",
-      "currentdate",
-      "userid",
-      "searchphrase",
-      "archivetitle",
-    ]
   }
   generatedDescription=""
   intl={
@@ -2093,18 +2069,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           "score": 6,
         }
       }
-      excludeReplaceVars={
-        Array [
-          "currentyear",
-          "currentmonth",
-          "currentday",
-          "currenttime",
-          "currentdate",
-          "userid",
-          "searchphrase",
-          "archivetitle",
-        ]
-      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[MockFunction]}
@@ -2150,18 +2114,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-6-title"
                     content="Test title"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -2263,18 +2215,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     ariaLabelledBy="snippet-editor-field-6-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -2910,18 +2850,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
       "score": 0,
     }
   }
-  excludeReplaceVars={
-    Array [
-      "currentyear",
-      "currentmonth",
-      "currentday",
-      "currenttime",
-      "currentdate",
-      "userid",
-      "searchphrase",
-      "archivetitle",
-    ]
-  }
   generatedDescription=""
   intl={
     Object {
@@ -3796,18 +3724,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           "score": 6,
         }
       }
-      excludeReplaceVars={
-        Array [
-          "currentyear",
-          "currentmonth",
-          "currentday",
-          "currenttime",
-          "currentdate",
-          "userid",
-          "searchphrase",
-          "archivetitle",
-        ]
-      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[MockFunction]}
@@ -3853,18 +3769,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-6-title"
                     content="Test title"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -3966,18 +3870,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     ariaLabelledBy="snippet-editor-field-6-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -4613,18 +4505,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
       "score": 0,
     }
   }
-  excludeReplaceVars={
-    Array [
-      "currentyear",
-      "currentmonth",
-      "currentday",
-      "currenttime",
-      "currentdate",
-      "userid",
-      "searchphrase",
-      "archivetitle",
-    ]
-  }
   generatedDescription=""
   intl={
     Object {
@@ -5499,18 +5379,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           "score": 6,
         }
       }
-      excludeReplaceVars={
-        Array [
-          "currentyear",
-          "currentmonth",
-          "currentday",
-          "currenttime",
-          "currentdate",
-          "userid",
-          "searchphrase",
-          "archivetitle",
-        ]
-      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[MockFunction]}
@@ -5556,18 +5424,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-6-title"
                     content="Test title"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -5669,18 +5525,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     ariaLabelledBy="snippet-editor-field-6-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -6316,18 +6160,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
       "score": 0,
     }
   }
-  excludeReplaceVars={
-    Array [
-      "currentyear",
-      "currentmonth",
-      "currentday",
-      "currenttime",
-      "currentdate",
-      "userid",
-      "searchphrase",
-      "archivetitle",
-    ]
-  }
   generatedDescription=""
   intl={
     Object {
@@ -7202,18 +7034,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           "score": 6,
         }
       }
-      excludeReplaceVars={
-        Array [
-          "currentyear",
-          "currentmonth",
-          "currentday",
-          "currenttime",
-          "currentdate",
-          "userid",
-          "searchphrase",
-          "archivetitle",
-        ]
-      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[MockFunction]}
@@ -7259,18 +7079,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-2-title"
                     content="Test title"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -7372,18 +7180,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     ariaLabelledBy="snippet-editor-field-2-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -7823,18 +7619,6 @@ exports[`SnippetEditor closes when calling close() 2`] = `
       "max": 156,
       "score": 0,
     }
-  }
-  excludeReplaceVars={
-    Array [
-      "currentyear",
-      "currentmonth",
-      "currentday",
-      "currenttime",
-      "currentdate",
-      "userid",
-      "searchphrase",
-      "archivetitle",
-    ]
   }
   generatedDescription=""
   intl={
@@ -9238,18 +9022,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
       "score": 0,
     }
   }
-  excludeReplaceVars={
-    Array [
-      "currentyear",
-      "currentmonth",
-      "currentday",
-      "currenttime",
-      "currentdate",
-      "userid",
-      "searchphrase",
-      "archivetitle",
-    ]
-  }
   generatedDescription=""
   intl={
     Object {
@@ -10124,18 +9896,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           "score": 6,
         }
       }
-      excludeReplaceVars={
-        Array [
-          "currentyear",
-          "currentmonth",
-          "currentday",
-          "currenttime",
-          "currentdate",
-          "userid",
-          "searchphrase",
-          "archivetitle",
-        ]
-      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[MockFunction]}
@@ -10181,18 +9941,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-9-title"
                     content="Test title"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -10294,18 +10042,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     ariaLabelledBy="snippet-editor-field-9-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -10940,18 +10676,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
       "max": 650,
       "score": 9,
     }
-  }
-  excludeReplaceVars={
-    Array [
-      "currentyear",
-      "currentmonth",
-      "currentday",
-      "currenttime",
-      "currentdate",
-      "userid",
-      "searchphrase",
-      "archivetitle",
-    ]
   }
   generatedDescription=""
   intl={
@@ -11827,18 +11551,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           "score": 6,
         }
       }
-      excludeReplaceVars={
-        Array [
-          "currentyear",
-          "currentmonth",
-          "currentday",
-          "currenttime",
-          "currentdate",
-          "userid",
-          "searchphrase",
-          "archivetitle",
-        ]
-      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[MockFunction]}
@@ -11884,18 +11596,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-8-title"
                     content="Test title"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -11997,18 +11697,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     ariaLabelledBy="snippet-editor-field-8-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -13816,18 +13504,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
       "score": 0,
     }
   }
-  excludeReplaceVars={
-    Array [
-      "currentyear",
-      "currentmonth",
-      "currentday",
-      "currenttime",
-      "currentdate",
-      "userid",
-      "searchphrase",
-      "archivetitle",
-    ]
-  }
   generatedDescription=""
   intl={
     Object {
@@ -14710,18 +14386,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           "score": 6,
         }
       }
-      excludeReplaceVars={
-        Array [
-          "currentyear",
-          "currentmonth",
-          "currentday",
-          "currenttime",
-          "currentdate",
-          "userid",
-          "searchphrase",
-          "archivetitle",
-        ]
-      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[MockFunction]}
@@ -14767,18 +14431,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-4-title"
                     content="Test title"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -14880,18 +14532,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     ariaLabelledBy="snippet-editor-field-4-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -15539,18 +15179,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
       "score": 0,
     }
   }
-  excludeReplaceVars={
-    Array [
-      "currentyear",
-      "currentmonth",
-      "currentday",
-      "currenttime",
-      "currentdate",
-      "userid",
-      "searchphrase",
-      "archivetitle",
-    ]
-  }
   generatedDescription=""
   intl={
     Object {
@@ -16433,18 +16061,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
           "score": 6,
         }
       }
-      excludeReplaceVars={
-        Array [
-          "currentyear",
-          "currentmonth",
-          "currentday",
-          "currenttime",
-          "currentdate",
-          "userid",
-          "searchphrase",
-          "archivetitle",
-        ]
-      }
       hoveredField="description"
       onBlur={[Function]}
       onChange={[MockFunction]}
@@ -16490,18 +16106,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-3-title"
                     content="Test title"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -16603,18 +16207,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     ariaLabelledBy="snippet-editor-field-3-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -17249,18 +16841,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
       "max": 156,
       "score": 0,
     }
-  }
-  excludeReplaceVars={
-    Array [
-      "currentyear",
-      "currentmonth",
-      "currentday",
-      "currenttime",
-      "currentdate",
-      "userid",
-      "searchphrase",
-      "archivetitle",
-    ]
   }
   generatedDescription=""
   intl={
@@ -18136,18 +17716,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           "score": 6,
         }
       }
-      excludeReplaceVars={
-        Array [
-          "currentyear",
-          "currentmonth",
-          "currentday",
-          "currenttime",
-          "currentdate",
-          "userid",
-          "searchphrase",
-          "archivetitle",
-        ]
-      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[MockFunction]}
@@ -18193,18 +17761,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-1-title"
                     content="Test title"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -18306,18 +17862,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     ariaLabelledBy="snippet-editor-field-1-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -18952,18 +18496,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
       "max": 156,
       "score": 0,
     }
-  }
-  excludeReplaceVars={
-    Array [
-      "currentyear",
-      "currentmonth",
-      "currentday",
-      "currenttime",
-      "currentdate",
-      "userid",
-      "searchphrase",
-      "archivetitle",
-    ]
   }
   generatedDescription=""
   intl={
@@ -19850,18 +19382,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
           "score": 6,
         }
       }
-      excludeReplaceVars={
-        Array [
-          "currentyear",
-          "currentmonth",
-          "currentday",
-          "currenttime",
-          "currentdate",
-          "userid",
-          "searchphrase",
-          "archivetitle",
-        ]
-      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[MockFunction]}
@@ -19918,18 +19438,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-7-title"
                     content="Test title"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -20042,18 +19550,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     ariaLabelledBy="snippet-editor-field-7-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -20801,18 +20297,6 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
           "score": 6,
         }
       }
-      excludeReplaceVars={
-        Array [
-          "currentyear",
-          "currentmonth",
-          "currentday",
-          "currenttime",
-          "currentdate",
-          "userid",
-          "searchphrase",
-          "archivetitle",
-        ]
-      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[MockFunction]}
@@ -21375,18 +20859,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
       "max": 156,
       "score": 0,
     }
-  }
-  excludeReplaceVars={
-    Array [
-      "currentyear",
-      "currentmonth",
-      "currentday",
-      "currenttime",
-      "currentdate",
-      "userid",
-      "searchphrase",
-      "archivetitle",
-    ]
   }
   generatedDescription=""
   intl={
@@ -22262,18 +21734,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
           "score": 6,
         }
       }
-      excludeReplaceVars={
-        Array [
-          "currentyear",
-          "currentmonth",
-          "currentday",
-          "currenttime",
-          "currentdate",
-          "userid",
-          "searchphrase",
-          "archivetitle",
-        ]
-      }
       hoveredField={null}
       onBlur={[Function]}
       onChange={[MockFunction]}
@@ -22319,18 +21779,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   <ReplacementVariableEditor
                     ariaLabelledBy="snippet-editor-field-5-title"
                     content="Test title"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -22432,18 +21880,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     ariaLabelledBy="snippet-editor-field-5-description"
                     content="Test description, %%replacement_variable%%"
                     descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-                    excludeReplaceVars={
-                      Array [
-                        "currentyear",
-                        "currentmonth",
-                        "currentday",
-                        "currenttime",
-                        "currentdate",
-                        "userid",
-                        "searchphrase",
-                        "archivetitle",
-                      ]
-                    }
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}


### PR DESCRIPTION
Reverts Yoast/yoast-components#572

Based on feedback, this approach will no longer be used (will remove the relevant replace vars in wordpress-seo instead), and these changes are therefore reverted. 