### PR TITLE
Account for the date when calculating meta description length

### DIFF
--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -65,11 +65,17 @@ function getTitleProgress( title ) {
  * Gets the description progress.
  *
  * @param {string} description The description.
+ * @param {string} date        The meta description date
  *
  * @returns {Object} The description progress.
  */
-function getDescriptionProgress( description ) {
-	const descriptionLength = description.length;
+function getDescriptionProgress( description, date ) {
+	let descriptionLength = description.length;
+	/* If the meta description is preceded by a date, two spaces and a hyphen (" - ") are added as well. Therefore,
+	three needs to be added to the total length. */
+	if ( date !== "" ) {
+		descriptionLength += date.length + 3;
+	}
 	const metaDescriptionLengthAssessment = new MetaDescriptionLengthAssessment();
 	const score = metaDescriptionLengthAssessment.calculateScore( descriptionLength );
 	const maximumLength = metaDescriptionLengthAssessment.getMaximumLength();
@@ -123,7 +129,7 @@ class SnippetEditor extends React.Component {
 			hoveredField: null,
 			mappedData: previewData,
 			titleLengthProgress: getTitleProgress( measurementData.title ),
-			descriptionLengthProgress: getDescriptionProgress( measurementData.description ),
+			descriptionLengthProgress: getDescriptionProgress( measurementData.description, this.props.date ),
 		};
 
 		this.setFieldFocus = this.setFieldFocus.bind( this );
@@ -168,7 +174,7 @@ class SnippetEditor extends React.Component {
 			this.setState(
 				{
 					titleLengthProgress: getTitleProgress( data.title ),
-					descriptionLengthProgress: getDescriptionProgress( data.description ),
+					descriptionLengthProgress: getDescriptionProgress( data.description, nextProps.date ),
 				}
 			);
 		}

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
@@ -186,7 +186,6 @@ exports[`ReplacementVariableEditor wraps a Draft.js editor instance 1`] = `
   />
   <Decorated(MentionSuggestions)
     onSearchChange={[Function]}
-    suggestions={Array []}
   />
 </React.Fragment>
 `;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Uses the meta description date in the props to calculate actual length of the meta description
* Adds an additional 3 to the length if date is present, since two spaces and a hyphen (" - ") are automatically appended to the description date in that case

## Test instructions

This PR can be tested by following these steps:

* Make sure that "date in snippet preview" is enabled for posts and pages (under "SEO" -> "Search Appearance" -> "Content types")
* In a post/page, edit the snippet and write a meta description that exactly fills the progress bar (i.e. the color is still green)
* Copy the description as it appears in the snippet preview (i.e. should include the date)
* Counting the characters (using appropriate program or website) should show the full description to be 156 characters if the progress bar was exactly full
* Disable "date in snippet preview" for posts and pages
* As before, write a meta description that entirely fills the progress bar (i.e. color still green)
* Counting the characters in the full description as it appears in the snippet preview should show it to be 156 (and should be very similar to the description you just wrote, accounting for multiple and trailing spaces etc.)
* Make sure this works for both posts and pages

Fixes #563 
