### PR TITLE
Fix single line browser compatibility

### DIFF
--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -78,7 +78,6 @@ const TitleInputContainer = InputContainer.extend`
 		line-height: 24px;
 		height: 24px;
 		overflow: hidden;
-		white-space: nowrap;
 	}
 `;
 

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -75,9 +75,8 @@ const InputContainer = styled.div.attrs( {
 
 const TitleInputContainer = InputContainer.extend`
 	.public-DraftStyleDefault-block {
+		// Don't use properties that trigger hasLayout in IE11.
 		line-height: 24px;
-		height: 24px;
-		overflow: hidden;
 	}
 `;
 

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -995,8 +995,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 
 .c32 .public-DraftStyleDefault-block {
   line-height: 24px;
-  height: 24px;
-  overflow: hidden;
 }
 
 .c34 {
@@ -2649,8 +2647,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 
 .c32 .public-DraftStyleDefault-block {
   line-height: 24px;
-  height: 24px;
-  overflow: hidden;
 }
 
 .c34 {
@@ -4303,8 +4299,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 
 .c32 .public-DraftStyleDefault-block {
   line-height: 24px;
-  height: 24px;
-  overflow: hidden;
 }
 
 .c34 {
@@ -5957,8 +5951,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 
 .c32 .public-DraftStyleDefault-block {
   line-height: 24px;
-  height: 24px;
-  overflow: hidden;
 }
 
 .c34 {
@@ -8818,8 +8810,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 
 .c32 .public-DraftStyleDefault-block {
   line-height: 24px;
-  height: 24px;
-  overflow: hidden;
 }
 
 .c34 {
@@ -10472,8 +10462,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 
 .c32 .public-DraftStyleDefault-block {
   line-height: 24px;
-  height: 24px;
-  overflow: hidden;
 }
 
 .c34 {
@@ -13286,8 +13274,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 
 .c33 .public-DraftStyleDefault-block {
   line-height: 24px;
-  height: 24px;
-  overflow: hidden;
 }
 
 .c35 {
@@ -14960,8 +14946,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 
 .c33 .public-DraftStyleDefault-block {
   line-height: 24px;
-  height: 24px;
-  overflow: hidden;
 }
 
 .c35 {
@@ -16634,8 +16618,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 
 .c32 .public-DraftStyleDefault-block {
   line-height: 24px;
-  height: 24px;
-  overflow: hidden;
 }
 
 .c34 {
@@ -18288,8 +18270,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
 
 .c32 .public-DraftStyleDefault-block {
   line-height: 24px;
-  height: 24px;
-  overflow: hidden;
 }
 
 .c34 {
@@ -20650,8 +20630,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 
 .c32 .public-DraftStyleDefault-block {
   line-height: 24px;
-  height: 24px;
-  overflow: hidden;
 }
 
 .c34 {

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -997,7 +997,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   line-height: 24px;
   height: 24px;
   overflow: hidden;
-  white-space: nowrap;
 }
 
 .c34 {
@@ -2652,7 +2651,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   line-height: 24px;
   height: 24px;
   overflow: hidden;
-  white-space: nowrap;
 }
 
 .c34 {
@@ -4307,7 +4305,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   line-height: 24px;
   height: 24px;
   overflow: hidden;
-  white-space: nowrap;
 }
 
 .c34 {
@@ -5962,7 +5959,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   line-height: 24px;
   height: 24px;
   overflow: hidden;
-  white-space: nowrap;
 }
 
 .c34 {
@@ -8824,7 +8820,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   line-height: 24px;
   height: 24px;
   overflow: hidden;
-  white-space: nowrap;
 }
 
 .c34 {
@@ -10479,7 +10474,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   line-height: 24px;
   height: 24px;
   overflow: hidden;
-  white-space: nowrap;
 }
 
 .c34 {
@@ -13294,7 +13288,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   line-height: 24px;
   height: 24px;
   overflow: hidden;
-  white-space: nowrap;
 }
 
 .c35 {
@@ -14969,7 +14962,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   line-height: 24px;
   height: 24px;
   overflow: hidden;
-  white-space: nowrap;
 }
 
 .c35 {
@@ -16644,7 +16636,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   line-height: 24px;
   height: 24px;
   overflow: hidden;
-  white-space: nowrap;
 }
 
 .c34 {
@@ -18299,7 +18290,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
   line-height: 24px;
   height: 24px;
   overflow: hidden;
-  white-space: nowrap;
 }
 
 .c34 {
@@ -20662,7 +20652,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   line-height: 24px;
   height: 24px;
   overflow: hidden;
-  white-space: nowrap;
 }
 
 .c34 {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Remove white-space nowrap style on the TitleInputContainer in the SnippetEditorFields. This was creating problems in other browsers than Chrome.

## Test instructions

This PR can be tested by following these steps:

* https://github.com/Yoast/yoast-components/pull/568#issuecomment-395423015
* https://github.com/Yoast/yoast-components/pull/568#issuecomment-395426406
* https://github.com/Yoast/yoast-components/pull/568#issuecomment-395450196
* https://github.com/Yoast/yoast-components/pull/568#issuecomment-395452346

## Note

I did not test in IE and Edge to see if this fixes those yet.
