### PR TITLE
Snippet variable entities and snippet editor styling tweaks

### DIFF
--- a/composites/Plugin/SnippetEditor/components/Mention.js
+++ b/composites/Plugin/SnippetEditor/components/Mention.js
@@ -1,0 +1,31 @@
+import React from "react";
+import styled from "styled-components";
+import colors from "../../../../style-guide/colors";
+import PropTypes from "prop-types";
+
+const StyledMention = styled.span`
+	color: ${ colors.$color_white };
+	background-color: ${ colors.$color_pink_dark };
+	padding: 0px 8px;
+	margin: 0 2px;
+	border-radius: 17px;
+	
+	&:hover {
+		color: ${ colors.$color_white };
+		background-color: ${ colors.$color_pink_dark };
+	}
+`;
+
+export const Mention = ( { children, className } ) => {
+	return <StyledMention
+		className={className}
+		spellCheck={false}
+	>
+		{children}
+	</StyledMention>;
+};
+
+Mention.propTypes = {
+	children: PropTypes.node,
+	className: PropTypes.string,
+};

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -12,6 +12,7 @@ import { __, _n, sprintf } from "@wordpress/i18n";
 
 // Internal dependencies.
 import { replacementVariablesShape } from "../constants";
+import { Mention } from "./Mention";
 import {
 	serializeEditor,
 	unserializeEditor,
@@ -119,6 +120,7 @@ class ReplacementVariableEditor extends React.Component {
 		this.mentionsPlugin = createMentionPlugin( {
 			mentionTrigger: "%",
 			entityMutability: "IMMUTABLE",
+			mentionComponent: Mention,
 		} );
 
 		this.singleLinePlugin = createSingleLinePlugin( {

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -124,7 +124,7 @@ const SimulatedLabel = styled.div`
 	cursor: pointer;
 	font-size: 16px;
 	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
-	margin-bottom: 11px;
+	margin-bottom: 9px;
 `;
 
 const TriggerReplacementVariableSuggestionsButton = Button.extend`

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -62,14 +62,6 @@ const InputContainer = styled.div.attrs( {
 	font-size: 14px;
 	cursor: text;
 
-	.draftJsMentionPlugin__mention__29BEd {
-		color: ${ colors.$color_white };
-		background-color: ${ colors.$color_pink_dark };
-		padding: 0px 8px;
-		margin: 0 2px;
-		border-radius: 17px;
-	}
-
 	&::before {
 		display: block;
 		position: absolute;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -62,6 +62,14 @@ const InputContainer = styled.div.attrs( {
 	font-size: 14px;
 	cursor: text;
 
+	.draftJsMentionPlugin__mention__29BEd {
+		color: ${ colors.$color_white };
+		background-color: ${ colors.$color_pink_dark };
+		padding: 0px 8px;
+		margin: 0 2px;
+		border-radius: 17px;
+	}
+
 	&::before {
 		display: block;
 		position: absolute;
@@ -75,17 +83,8 @@ const InputContainer = styled.div.attrs( {
 	}
 `;
 
-const InputContainerWithStyledEntities = InputContainer.extend`
-	.draftJsMentionPlugin__mention__29BEd {
-		color: ${ colors.$color_white };
-		background-color: ${ colors.$color_pink_dark };
-		padding: 0px 8px;
-		margin: 0 2px;
-		border-radius: 17px;
-	}
-`;
 
-const TitleInputContainer = InputContainerWithStyledEntities.extend`
+const TitleInputContainer = InputContainer.extend`
 	.public-DraftStyleDefault-block {
 		line-height: 24px;
 		height: 24px;
@@ -108,7 +107,7 @@ const SlugInput = styled.input`
 	}
 `;
 
-const DescriptionInputContainer = InputContainerWithStyledEntities.extend`
+const DescriptionInputContainer = InputContainer.extend`
 	min-height: 60px;
 	padding: 2px 6px;
 	line-height: 24px;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -75,7 +75,17 @@ const InputContainer = styled.div.attrs( {
 	}
 `;
 
-const TitleInputContainer = InputContainer.extend`
+const InputContainerWithStyledEntities = InputContainer.extend`
+	.draftJsMentionPlugin__mention__29BEd {
+		color: ${ colors.$color_white };
+		background-color: ${ colors.$color_pink_dark };
+		padding: 0px 8px;
+		margin: 0 2px;
+		border-radius: 17px;
+	}
+`;
+
+const TitleInputContainer = InputContainerWithStyledEntities.extend`
 	.public-DraftStyleDefault-block {
 		line-height: 24px;
 		height: 24px;
@@ -98,25 +108,25 @@ const SlugInput = styled.input`
 	}
 `;
 
-const DescriptionInputContainer = InputContainer.extend`
+const DescriptionInputContainer = InputContainerWithStyledEntities.extend`
 	min-height: 60px;
 	padding: 2px 6px;
-	line-height: 19.6px;
+	line-height: 24px;
 `;
 
 const FormSection = styled.div`
-	margin: 32px 0;
+	margin: 24px 0;
 `;
 
 const StyledEditor = styled.section`
-	padding: 10px 20px 20px 20px;
+	padding: 10px 20px 0px 20px;
 `;
 
 const SimulatedLabel = styled.div`
 	cursor: pointer;
 	font-size: 16px;
 	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
-	margin-bottom: 5px;
+	margin-bottom: 11px;
 `;
 
 const TriggerReplacementVariableSuggestionsButton = Button.extend`
@@ -127,7 +137,7 @@ const TriggerReplacementVariableSuggestionsButton = Button.extend`
 	fill: ${ colors.$color_grey_dark };
 	padding-left: 8px;
 	float: right;
-	margin-top: -35px; // negative height + 2 for spacing
+	margin-top: -33px; // negative height
 
 	${ props => props.isSmallerThanMobileWidth && `
 		float: none;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -83,7 +83,6 @@ const InputContainer = styled.div.attrs( {
 	}
 `;
 
-
 const TitleInputContainer = InputContainer.extend`
 	.public-DraftStyleDefault-block {
 		line-height: 24px;

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -949,14 +949,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   cursor: text;
 }
 
-.c32 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c32::before {
   display: block;
   position: absolute;
@@ -991,14 +983,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   cursor: text;
 }
 
-.c34 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c34::before {
   display: block;
   position: absolute;
@@ -1027,14 +1011,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   min-height: 60px;
   padding: 2px 6px;
   line-height: 24px;
-}
-
-.c36 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
 }
 
 .c36::before {
@@ -2812,14 +2788,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   cursor: text;
 }
 
-.c32 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c32::before {
   display: block;
   position: absolute;
@@ -2854,14 +2822,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   cursor: text;
 }
 
-.c34 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c34::before {
   display: block;
   position: absolute;
@@ -2890,14 +2850,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   min-height: 60px;
   padding: 2px 6px;
   line-height: 24px;
-}
-
-.c36 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
 }
 
 .c36::before {
@@ -4675,14 +4627,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   cursor: text;
 }
 
-.c32 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c32::before {
   display: block;
   position: absolute;
@@ -4717,14 +4661,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   cursor: text;
 }
 
-.c34 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c34::before {
   display: block;
   position: absolute;
@@ -4753,14 +4689,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   min-height: 60px;
   padding: 2px 6px;
   line-height: 24px;
-}
-
-.c36 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
 }
 
 .c36::before {
@@ -6538,14 +6466,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   cursor: text;
 }
 
-.c32 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c32::before {
   display: block;
   position: absolute;
@@ -6580,14 +6500,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   cursor: text;
 }
 
-.c34 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c34::before {
   display: block;
   position: absolute;
@@ -6616,14 +6528,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   min-height: 60px;
   padding: 2px 6px;
   line-height: 24px;
-}
-
-.c36 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
 }
 
 .c36::before {
@@ -9582,14 +9486,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   cursor: text;
 }
 
-.c32 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c32::before {
   display: block;
   position: absolute;
@@ -9624,14 +9520,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   cursor: text;
 }
 
-.c34 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c34::before {
   display: block;
   position: absolute;
@@ -9660,14 +9548,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   min-height: 60px;
   padding: 2px 6px;
   line-height: 24px;
-}
-
-.c36 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
 }
 
 .c36::before {
@@ -11445,14 +11325,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   cursor: text;
 }
 
-.c32 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c32::before {
   display: block;
   position: absolute;
@@ -11487,14 +11359,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   cursor: text;
 }
 
-.c34 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c34::before {
   display: block;
   position: absolute;
@@ -11523,14 +11387,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   min-height: 60px;
   padding: 2px 6px;
   line-height: 24px;
-}
-
-.c36 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
 }
 
 .c36::before {
@@ -14398,14 +14254,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   cursor: text;
 }
 
-.c33 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c33::before {
   display: block;
   position: absolute;
@@ -14440,14 +14288,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   cursor: text;
 }
 
-.c35 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c35::before {
   display: block;
   position: absolute;
@@ -14476,14 +14316,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   min-height: 60px;
   padding: 2px 6px;
   line-height: 24px;
-}
-
-.c37 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
 }
 
 .c37::before {
@@ -16281,14 +16113,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   cursor: text;
 }
 
-.c33 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c33::before {
   display: block;
   position: absolute;
@@ -16323,14 +16147,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   cursor: text;
 }
 
-.c35 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c35::before {
   display: block;
   position: absolute;
@@ -16359,14 +16175,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   min-height: 60px;
   padding: 2px 6px;
   line-height: 24px;
-}
-
-.c37 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
 }
 
 .c37::before {
@@ -18164,14 +17972,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   cursor: text;
 }
 
-.c32 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c32::before {
   display: block;
   position: absolute;
@@ -18206,14 +18006,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   cursor: text;
 }
 
-.c34 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c34::before {
   display: block;
   position: absolute;
@@ -18242,14 +18034,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   min-height: 60px;
   padding: 2px 6px;
   line-height: 24px;
-}
-
-.c36 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
 }
 
 .c36::before {
@@ -20027,14 +19811,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
   cursor: text;
 }
 
-.c32 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c32::before {
   display: block;
   position: absolute;
@@ -20069,14 +19845,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
   cursor: text;
 }
 
-.c34 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c34::before {
   display: block;
   position: absolute;
@@ -20105,14 +19873,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
   min-height: 60px;
   padding: 2px 6px;
   line-height: 24px;
-}
-
-.c36 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
 }
 
 .c36::before {
@@ -22564,14 +22324,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   cursor: text;
 }
 
-.c32 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c32::before {
   display: block;
   position: absolute;
@@ -22606,14 +22358,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   cursor: text;
 }
 
-.c34 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
-}
-
 .c34::before {
   display: block;
   position: absolute;
@@ -22642,14 +22386,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   min-height: 60px;
   padding: 2px 6px;
   line-height: 24px;
-}
-
-.c36 .draftJsMentionPlugin__mention__29BEd {
-  color: #fff;
-  background-color: #a4286a;
-  padding: 0px 8px;
-  margin: 0 2px;
-  border-radius: 17px;
 }
 
 .c36::before {

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -1075,7 +1075,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 11px;
+  margin-bottom: 9px;
 }
 
 .c23 {
@@ -2938,7 +2938,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 11px;
+  margin-bottom: 9px;
 }
 
 .c23 {
@@ -4801,7 +4801,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 11px;
+  margin-bottom: 9px;
 }
 
 .c23 {
@@ -6664,7 +6664,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 11px;
+  margin-bottom: 9px;
 }
 
 .c23 {
@@ -9708,7 +9708,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 11px;
+  margin-bottom: 9px;
 }
 
 .c23 {
@@ -11571,7 +11571,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 11px;
+  margin-bottom: 9px;
 }
 
 .c23 {
@@ -14524,7 +14524,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 11px;
+  margin-bottom: 9px;
 }
 
 .c24 {
@@ -16407,7 +16407,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 11px;
+  margin-bottom: 9px;
 }
 
 .c24 {
@@ -18290,7 +18290,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 11px;
+  margin-bottom: 9px;
 }
 
 .c23 {
@@ -20153,7 +20153,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 11px;
+  margin-bottom: 9px;
 }
 
 .c23 {
@@ -22690,7 +22690,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 11px;
+  margin-bottom: 9px;
 }
 
 .c23 {

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -718,7 +718,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   float: none;
   margin-top: 0;
   margin-bottom: 2px;
@@ -949,6 +949,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   cursor: text;
 }
 
+.c32 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c32::before {
   display: block;
   position: absolute;
@@ -983,6 +991,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   cursor: text;
 }
 
+.c34 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c34::before {
   display: block;
   position: absolute;
@@ -1010,7 +1026,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   cursor: text;
   min-height: 60px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
+}
+
+.c36 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
 }
 
 .c36::before {
@@ -1040,18 +1064,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 11px;
 }
 
 .c23 {
@@ -2557,7 +2581,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   float: none;
   margin-top: 0;
   margin-bottom: 2px;
@@ -2788,6 +2812,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   cursor: text;
 }
 
+.c32 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c32::before {
   display: block;
   position: absolute;
@@ -2822,6 +2854,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   cursor: text;
 }
 
+.c34 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c34::before {
   display: block;
   position: absolute;
@@ -2849,7 +2889,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   cursor: text;
   min-height: 60px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
+}
+
+.c36 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
 }
 
 .c36::before {
@@ -2879,18 +2927,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 11px;
 }
 
 .c23 {
@@ -4396,7 +4444,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   float: none;
   margin-top: 0;
   margin-bottom: 2px;
@@ -4627,6 +4675,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   cursor: text;
 }
 
+.c32 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c32::before {
   display: block;
   position: absolute;
@@ -4661,6 +4717,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   cursor: text;
 }
 
+.c34 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c34::before {
   display: block;
   position: absolute;
@@ -4688,7 +4752,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   cursor: text;
   min-height: 60px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
+}
+
+.c36 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
 }
 
 .c36::before {
@@ -4718,18 +4790,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 11px;
 }
 
 .c23 {
@@ -6235,7 +6307,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   float: none;
   margin-top: 0;
   margin-bottom: 2px;
@@ -6466,6 +6538,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   cursor: text;
 }
 
+.c32 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c32::before {
   display: block;
   position: absolute;
@@ -6500,6 +6580,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   cursor: text;
 }
 
+.c34 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c34::before {
   display: block;
   position: absolute;
@@ -6527,7 +6615,15 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   cursor: text;
   min-height: 60px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
+}
+
+.c36 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
 }
 
 .c36::before {
@@ -6557,18 +6653,18 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 11px;
 }
 
 .c23 {
@@ -9255,7 +9351,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   float: none;
   margin-top: 0;
   margin-bottom: 2px;
@@ -9486,6 +9582,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   cursor: text;
 }
 
+.c32 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c32::before {
   display: block;
   position: absolute;
@@ -9520,6 +9624,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   cursor: text;
 }
 
+.c34 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c34::before {
   display: block;
   position: absolute;
@@ -9547,7 +9659,15 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   cursor: text;
   min-height: 60px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
+}
+
+.c36 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
 }
 
 .c36::before {
@@ -9577,18 +9697,18 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 11px;
 }
 
 .c23 {
@@ -11094,7 +11214,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   float: none;
   margin-top: 0;
   margin-bottom: 2px;
@@ -11325,6 +11445,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   cursor: text;
 }
 
+.c32 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c32::before {
   display: block;
   position: absolute;
@@ -11359,6 +11487,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   cursor: text;
 }
 
+.c34 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c34::before {
   display: block;
   position: absolute;
@@ -11386,7 +11522,15 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   cursor: text;
   min-height: 60px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
+}
+
+.c36 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
 }
 
 .c36::before {
@@ -11416,18 +11560,18 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 11px;
 }
 
 .c23 {
@@ -14023,7 +14167,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   float: none;
   margin-top: 0;
   margin-bottom: 2px;
@@ -14254,6 +14398,14 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   cursor: text;
 }
 
+.c33 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c33::before {
   display: block;
   position: absolute;
@@ -14288,6 +14440,14 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   cursor: text;
 }
 
+.c35 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c35::before {
   display: block;
   position: absolute;
@@ -14315,7 +14475,15 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   cursor: text;
   min-height: 60px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
+}
+
+.c37 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
 }
 
 .c37::before {
@@ -14345,18 +14513,18 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 }
 
 .c30 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c29 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 11px;
 }
 
 .c24 {
@@ -15882,7 +16050,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   float: none;
   margin-top: 0;
   margin-bottom: 2px;
@@ -16113,6 +16281,14 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   cursor: text;
 }
 
+.c33 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c33::before {
   display: block;
   position: absolute;
@@ -16147,6 +16323,14 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   cursor: text;
 }
 
+.c35 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c35::before {
   display: block;
   position: absolute;
@@ -16174,7 +16358,15 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   cursor: text;
   min-height: 60px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
+}
+
+.c37 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
 }
 
 .c37::before {
@@ -16204,18 +16396,18 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 }
 
 .c30 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c29 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 11px;
 }
 
 .c24 {
@@ -17741,7 +17933,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   float: none;
   margin-top: 0;
   margin-bottom: 2px;
@@ -17972,6 +18164,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   cursor: text;
 }
 
+.c32 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c32::before {
   display: block;
   position: absolute;
@@ -18006,6 +18206,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   cursor: text;
 }
 
+.c34 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c34::before {
   display: block;
   position: absolute;
@@ -18033,7 +18241,15 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   cursor: text;
   min-height: 60px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
+}
+
+.c36 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
 }
 
 .c36::before {
@@ -18063,18 +18279,18 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 11px;
 }
 
 .c23 {
@@ -19580,7 +19796,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   float: none;
   margin-top: 0;
   margin-bottom: 2px;
@@ -19811,6 +20027,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
   cursor: text;
 }
 
+.c32 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c32::before {
   display: block;
   position: absolute;
@@ -19845,6 +20069,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
   cursor: text;
 }
 
+.c34 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c34::before {
   display: block;
   position: absolute;
@@ -19872,7 +20104,15 @@ exports[`SnippetEditor passes replacement variables to the title and description
   cursor: text;
   min-height: 60px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
+}
+
+.c36 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
 }
 
 .c36::before {
@@ -19902,18 +20142,18 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 11px;
 }
 
 .c23 {
@@ -22093,7 +22333,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   float: none;
   margin-top: 0;
   margin-bottom: 2px;
@@ -22324,6 +22564,14 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   cursor: text;
 }
 
+.c32 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c32::before {
   display: block;
   position: absolute;
@@ -22358,6 +22606,14 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   cursor: text;
 }
 
+.c34 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
+}
+
 .c34::before {
   display: block;
   position: absolute;
@@ -22385,7 +22641,15 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   cursor: text;
   min-height: 60px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
+}
+
+.c36 .draftJsMentionPlugin__mention__29BEd {
+  color: #fff;
+  background-color: #a4286a;
+  padding: 0px 8px;
+  margin: 0 2px;
+  border-radius: 17px;
 }
 
 .c36::before {
@@ -22415,18 +22679,18 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 11px;
 }
 
 .c23 {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Change styling of Draft.js Mention Plugin entities. They now have a purple background, white letters, rounded corners, and more padding and margin. 

## Relevant technical choices:
* I've made the line height of the meta description input the same as the line height of the title input, to make the entities in both fields look the same.

* I've discussed the following styling changes (which were not in the issue) with @hedgefield:
    - Less padding between the snippet editor input fields.
    - Less padding between the bottom field and the close button.
    - Align the bottom of the input field title with the bottom of the inserter button text
    - Remove the padding between the inserter button and the input field

## Questions/concerns
- I've added padding and margin on the left and right side of the entities. However, the cursor/caret stays directly after/before the last/first letter. Because of this, it feels like it's not possible to put your cursor directly after/before an entity. Is there a way to move the cursor as well based on the padding or margin? I've created a new issue for this: https://github.com/Yoast/yoast-components/issues/595.

## Test instructions

This PR can be tested by following these steps:

* Link this branch to `feature/react-snippet-editor` form wordpress-seo.
* Look at the snippet editor and confirm all the above style changes and the style changes from the issue are implemented.

Fixes Yoast/wordpress-seo/issues/9836 

Needs #567