### PR TITLE
Use replacevar labels (nicenames) in suggestions

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -331,6 +331,13 @@ class ReplacementVariableEditor extends React.Component {
 		const { MentionSuggestions } = this.mentionsPlugin;
 		const { onFocus, onBlur, ariaLabelledBy, descriptionEditorFieldPlaceholder } = this.props;
 		const { editorState, replacementVariables } = this.state;
+		const replaceVarSuggestions = replacementVariables.map( ( variable ) => {
+			return {
+				...variable,
+				name: variable.label,
+				replaceName: variable.name,
+			};
+		} );
 
 		return (
 			<React.Fragment>
@@ -347,8 +354,7 @@ class ReplacementVariableEditor extends React.Component {
 				/>
 				<MentionSuggestions
 					onSearchChange={ this.onSearchChange }
-					suggestions={ replacementVariables }
-					onAddMention={ this.onAddMention }
+					suggestions={ replaceVarSuggestions }
 				/>
 			</React.Fragment>
 		);

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
@@ -182,8 +182,12 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	}
 
 	/**
+	 * In order to have the replaceVariable labels rather than the names in the Mention suggestions,
+	 * we map the replaceVar label as the name, and save the original name in replaceName.
 	 *
-	 * @param replacementVariables
+	 * @param {array} replacementVariables The list of replacementVariables.
+	 *
+	 * @returns {array} The suggestions, a mapped version of the replacementVariables.
 	 */
 	mapReplacementVariablesToSuggestions( replacementVariables ) {
 		return replacementVariables.map( ( variable ) => {

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
@@ -192,7 +192,7 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	replacementVariablesFilter( searchValue, replacementVariables ) {
 		const value = searchValue.toLowerCase();
 		return replacementVariables.filter( function( suggestion ) {
-			return ! value || suggestion.name.toLowerCase().indexOf( value ) === 0;
+			return ! value || suggestion.label.toLowerCase().indexOf( value ) === 0;
 		} );
 	}
 

--- a/composites/Plugin/SnippetEditor/serialization.js
+++ b/composites/Plugin/SnippetEditor/serialization.js
@@ -38,7 +38,9 @@ export function serializeBlock( entityMap, block ) {
 		const beforeEntityLength = offset - previousEntityEnd;
 
 		const beforeEntity = text.substr( previousEntityEnd, beforeEntityLength );
-		const serializedEntity = serializeVariable( entityMap[ key ].data.mention.name );
+
+		// The entity should be serialized using the replaceName, which is the "not-nice" name.
+		const serializedEntity = serializeVariable( entityMap[ key ].data.mention.replaceName );
 
 		previousEntityEnd = offset + length;
 
@@ -191,7 +193,7 @@ export function moveSelectionAfterReplacement( selection, blockKey, variable ) {
 export function createEntityInContent( contentState, variable ) {
 	const entityData = {
 		mention: {
-			name: variable.name,
+			replaceName: variable.name,
 		},
 	};
 

--- a/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
@@ -39,18 +39,22 @@ describe( "replacementVariablesFilter", () => {
 		replacementVariables = [
 			{
 				name: "category",
+				label: "Category",
 				value: "uncategorized",
 			},
 			{
 				name: "primary_category",
+				label: "Primary category",
 				value: "uncategorized",
 			},
 			{
 				name: "category_description",
+				label: "Category description",
 				value: "uncategorized",
 			},
 			{
 				name: "date",
+				label: "Date",
 				value: "May 30, 2018",
 			},
 		];
@@ -66,10 +70,12 @@ describe( "replacementVariablesFilter", () => {
 		expected = [
 			{
 				name: "category",
+				label: "Category",
 				value: "uncategorized",
 			},
 			{
 				name: "category_description",
+				label: "Category description",
 				value: "uncategorized",
 			},
 		];

--- a/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
@@ -17,7 +17,14 @@ jest.mock( "draft-js/lib/generateRandomKey", () => () => {
 
 describe( "ReplacementVariableEditor", () => {
 	it( "wraps a Draft.js editor instance", () => {
-		const editor = shallow( <ReplacementVariableEditor content="Dummy content" onChange={ () => {} } ariaLabelledBy="id" /> );
+		const editor = shallow(
+			<ReplacementVariableEditor
+				replacementVariables={ [] }
+				content="Dummy content"
+				onChange={ () => {} }
+				ariaLabelledBy="id"
+			/>
+		);
 
 		expect( editor ).toMatchSnapshot();
 	} );

--- a/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
@@ -31,8 +31,8 @@ describe( "ReplacementVariableEditor", () => {
 	} );
 } );
 
-describe( "replacementVariablesFilter", () => {
-	let searchValue, replacementVariables, replacementVariablesEditor, expected;
+describe( "suggestionsFilter", () => {
+	let searchValue, replacementVariables, suggestions, replacementVariablesEditor, expected;
 
 	beforeEach( () => {
 		searchValue = "cat";
@@ -60,6 +60,7 @@ describe( "replacementVariablesFilter", () => {
 		];
 
 		const props = {
+			replacementVariables,
 			content: "Dummy content",
 			onChange: () => {},
 			ariaLabelledBy: "id",
@@ -67,22 +68,59 @@ describe( "replacementVariablesFilter", () => {
 
 		replacementVariablesEditor = new ReplacementVariableEditorStandalone( props );
 
+		suggestions = replacementVariablesEditor.mapReplacementVariablesToSuggestions( props.replacementVariables );
+
 		expected = [
 			{
-				name: "category",
+				replaceName: "category",
 				label: "Category",
+				name: "Category",
 				value: "uncategorized",
 			},
 			{
-				name: "category_description",
+				replaceName: "category_description",
 				label: "Category description",
+				name: "Category description",
 				value: "uncategorized",
 			},
 		];
 	} );
 
+	it( "Replacement variables are correctly mapped to suggestions by mapReplacementVariablesToSuggestions.", () => {
+		let expected = [
+			{
+				replaceName: "category",
+				label: "Category",
+				name: "Category",
+				value: "uncategorized",
+			},
+			{
+				replaceName: "primary_category",
+				label: "Primary category",
+				name: "Primary category",
+				value: "uncategorized",
+			},
+			{
+				replaceName: "category_description",
+				label: "Category description",
+				name: "Category description",
+				value: "uncategorized",
+			},
+			{
+				replaceName: "date",
+				label: "Date",
+				name: "Date",
+				value: "May 30, 2018",
+			},
+		];
+
+		const actual = replacementVariablesEditor.mapReplacementVariablesToSuggestions( replacementVariables );
+
+		expect( actual ).toEqual( expected );
+	} );
+
 	it( "Returns only the replacement variables where the start of the name matches with the search value.", () => {
-		const actual = replacementVariablesEditor.replacementVariablesFilter( searchValue, replacementVariables );
+		const actual = replacementVariablesEditor.suggestionsFilter( searchValue, suggestions );
 
 		expect( actual ).toEqual( expected );
 	} );
@@ -90,7 +128,7 @@ describe( "replacementVariablesFilter", () => {
 	it( "Returns the matching replacement variables, regardless of upper- or lowercase in the search value.", () => {
 		searchValue = "Cat";
 
-		const actual = replacementVariablesEditor.replacementVariablesFilter( searchValue, replacementVariables );
+		const actual = replacementVariablesEditor.suggestionsFilter( searchValue, suggestions );
 
 		expect( actual ).toEqual( expected );
 	} );

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
@@ -186,6 +186,7 @@ exports[`ReplacementVariableEditor wraps a Draft.js editor instance 1`] = `
   />
   <Decorated(MentionSuggestions)
     onSearchChange={[Function]}
+    suggestions={Array []}
   />
 </React.Fragment>
 `;

--- a/composites/Plugin/SnippetEditor/tests/serializationTest.js
+++ b/composites/Plugin/SnippetEditor/tests/serializationTest.js
@@ -47,12 +47,12 @@ describe( "editor serialization", () => {
 				0: {
 					type: "%mention",
 					mutability: "IMMUTABLE",
-					data: { mention: { name: "post_type" } },
+					data: { mention: { replaceName: "post_type" } },
 				},
 				1: {
 					type: "%mention",
 					mutability: "IMMUTABLE",
-					data: { mention: { name: "title" } },
+					data: { mention: { replaceName: "title" } },
 				},
 			},
 		};
@@ -89,12 +89,12 @@ describe( "editor unserialization", () => {
 				0: {
 					type: "%mention",
 					mutability: "IMMUTABLE",
-					data: { mention: { name: "title" } },
+					data: { mention: { replaceName: "title" } },
 				},
 				1: {
 					type: "%mention",
 					mutability: "IMMUTABLE",
-					data: { mention: { name: "post_type" } },
+					data: { mention: { replaceName: "post_type" } },
 				},
 			},
 		};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Replacevar suggestions now use nicenames rather than raw replacevariable names.

## Test instructions

This PR can be tested by following these steps:

* Test whether the dropdown suggestion list (after typing `%`) uses nicenames, and will fill the nicename into the editor field.
* Verify that the preview still replaces the variable with the correct value.
* Save and load posts, and enter replacevars by just typing `%%title%%` etc., and see that that functionality also still works (so without using the mention/suggestions).

Fixes #577 
Requires https://github.com/Yoast/wordpress-seo/pull/10065 (for custom field replacevars)