### PR TITLE
Fix progress bar for empty meta description

### DIFF
--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -74,7 +74,7 @@ function getDescriptionProgress( description, date ) {
 	let descriptionLength = description.length;
 	/* If the meta description is preceded by a date, two spaces and a hyphen (" - ") are added as well. Therefore,
 	three needs to be added to the total length. */
-	if ( date !== "" ) {
+	if ( date !== "" && descriptionLength > 0 ) {
 		descriptionLength += date.length + 3;
 	}
 	const metaDescriptionLengthAssessment = new MetaDescriptionLengthAssessment();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Only add date to the length of the description if the description is set.

## Relevant technical choices:

* Added an additional check so that date is not accounted for in the progress bar in cases of empty descriptions
* This is a bug fix and not directly related to the connected issue 

## Test instructions

This PR can be tested by following these steps:

* In settings, make sure that Date in Snippet Preview is enabled
* Empty the meta description field
* The progress bar should be completely empty
* Typing a single character in the meta description should immediately take the length of the date into account

Fixes https://github.com/Yoast/wordpress-seo/issues/9985
