### PR TITLE
Snippet editor and entities styling tweaks

### DIFF
--- a/composites/Plugin/SnippetEditor/components/Mention.js
+++ b/composites/Plugin/SnippetEditor/components/Mention.js
@@ -1,0 +1,31 @@
+import React from "react";
+import styled from "styled-components";
+import colors from "../../../../style-guide/colors";
+import PropTypes from "prop-types";
+
+const StyledMention = styled.span`
+	color: ${ colors.$color_white };
+	background-color: ${ colors.$color_pink_dark };
+	padding: 0px 8px;
+	margin: 0 2px;
+	border-radius: 17px;
+	
+	&:hover {
+		color: ${ colors.$color_white };
+		background-color: ${ colors.$color_pink_dark };
+	}
+`;
+
+export const Mention = ( { children, className } ) => {
+	return <StyledMention
+		className={className}
+		spellCheck={false}
+	>
+		{children}
+	</StyledMention>;
+};
+
+Mention.propTypes = {
+	children: PropTypes.node,
+	className: PropTypes.string,
+};

--- a/composites/Plugin/SnippetEditor/components/Mention.js
+++ b/composites/Plugin/SnippetEditor/components/Mention.js
@@ -7,7 +7,7 @@ const StyledMention = styled.span`
 	color: ${ colors.$color_white };
 	background-color: ${ colors.$color_pink_dark };
 	padding: 0px 8px;
-	margin: 0 2px;
+	margin: 2px 2px;
 	border-radius: 17px;
 	
 	&:hover {

--- a/composites/Plugin/SnippetEditor/components/Mention.js
+++ b/composites/Plugin/SnippetEditor/components/Mention.js
@@ -9,6 +9,7 @@ const StyledMention = styled.span`
 	padding: 0px 8px;
 	margin: 2px 2px;
 	border-radius: 17px;
+	cursor: default;
 	
 	&:hover {
 		color: ${ colors.$color_white };

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
@@ -14,6 +14,7 @@ import styled from "styled-components";
 // Internal dependencies.
 import { replacementVariablesShape } from "../constants";
 import { positionSuggestions } from "../positionSuggestions";
+import { Mention } from "./Mention";
 import {
 	serializeEditor,
 	unserializeEditor,
@@ -134,6 +135,7 @@ class ReplacementVariableEditorStandalone extends React.Component {
 			mentionTrigger: "%",
 			entityMutability: "IMMUTABLE",
 			positionSuggestions,
+			mentionComponent: Mention,
 		} );
 
 		this.singleLinePlugin = createSingleLinePlugin( {

--- a/composites/Plugin/SnippetEditor/components/SettingsSnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SettingsSnippetEditorFields.js
@@ -12,6 +12,9 @@ import { replacementVariablesShape } from "../constants";
 
 const FormSection = styled.div`
 	margin: 10px 0;
+	&:not(:first-child) {
+		margin-top: 32px; 
+	}
 `;
 
 const StyledEditor = styled.div`

--- a/composites/Plugin/SnippetEditor/components/Shared.js
+++ b/composites/Plugin/SnippetEditor/components/Shared.js
@@ -78,17 +78,17 @@ export const TitleInputContainer = InputContainer.extend`
 `;
 
 export const DescriptionInputContainer = InputContainer.extend`
-	min-height: 60px;
+	min-height: 72px;
 	padding: 2px 6px;
-	line-height: 19.6px;
+	line-height: 24px;
 `;
 
 export const FormSection = styled.div`
-	margin: 32px 0;
+	margin: 24px 0;
 `;
 
 export const StyledEditor = styled.section`
-	padding: 10px 20px 20px 20px;
+	padding: 10px 20px 0px 20px;
 `;
 
 /**
@@ -98,7 +98,7 @@ export const SimulatedLabel = styled.div`
 	cursor: pointer;
 	font-size: 16px;
 	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
-	margin-bottom: 5px;
+	margin-bottom: 9px;
 `;
 
 export const TriggerReplacementVariableSuggestionsButton = styled( Button )`
@@ -107,7 +107,7 @@ export const TriggerReplacementVariableSuggestionsButton = styled( Button )`
 	fill: ${ colors.$color_grey_dark };
 	padding-left: 8px;
 	float: right;
-	margin-top: -35px; // negative height + 2 for spacing
+	margin-top: -33px; // negative height
 	height: 33px;
 	border: 1px solid #dbdbdb;
 	font-size: 13px;

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -922,9 +922,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   font-size: 14px;
   cursor: text;
-  min-height: 60px;
+  min-height: 72px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
 }
 
 .c36::before {
@@ -940,18 +940,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 9px;
 }
 
 .c31 {
@@ -960,7 +960,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
@@ -2737,9 +2737,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   font-size: 14px;
   cursor: text;
-  min-height: 60px;
+  min-height: 72px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
 }
 
 .c36::before {
@@ -2755,18 +2755,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 9px;
 }
 
 .c31 {
@@ -2775,7 +2775,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
@@ -4552,9 +4552,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   font-size: 14px;
   cursor: text;
-  min-height: 60px;
+  min-height: 72px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
 }
 
 .c36::before {
@@ -4570,18 +4570,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 9px;
 }
 
 .c31 {
@@ -4590,7 +4590,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
@@ -6367,9 +6367,9 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   font-size: 14px;
   cursor: text;
-  min-height: 60px;
+  min-height: 72px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
 }
 
 .c36::before {
@@ -6385,18 +6385,18 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 9px;
 }
 
 .c31 {
@@ -6405,7 +6405,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
@@ -9302,9 +9302,9 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   font-size: 14px;
   cursor: text;
-  min-height: 60px;
+  min-height: 72px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
 }
 
 .c36::before {
@@ -9320,18 +9320,18 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 9px;
 }
 
 .c31 {
@@ -9340,7 +9340,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
@@ -11117,9 +11117,9 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   font-size: 14px;
   cursor: text;
-  min-height: 60px;
+  min-height: 72px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
 }
 
 .c36::before {
@@ -11135,18 +11135,18 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 9px;
 }
 
 .c31 {
@@ -11155,7 +11155,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
@@ -14022,9 +14022,9 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   font-size: 14px;
   cursor: text;
-  min-height: 60px;
+  min-height: 72px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
 }
 
 .c37::before {
@@ -14040,18 +14040,18 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 }
 
 .c30 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c29 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 9px;
 }
 
 .c32 {
@@ -14060,7 +14060,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
@@ -15857,9 +15857,9 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   font-size: 14px;
   cursor: text;
-  min-height: 60px;
+  min-height: 72px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
 }
 
 .c37::before {
@@ -15875,18 +15875,18 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 }
 
 .c30 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c29 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c31 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 9px;
 }
 
 .c32 {
@@ -15895,7 +15895,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
@@ -17692,9 +17692,9 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   font-size: 14px;
   cursor: text;
-  min-height: 60px;
+  min-height: 72px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
 }
 
 .c36::before {
@@ -17710,18 +17710,18 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 9px;
 }
 
 .c31 {
@@ -17730,7 +17730,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
@@ -19507,9 +19507,9 @@ exports[`SnippetEditor passes replacement variables to the title and description
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   font-size: 14px;
   cursor: text;
-  min-height: 60px;
+  min-height: 72px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
 }
 
 .c36::before {
@@ -19525,18 +19525,18 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 9px;
 }
 
 .c31 {
@@ -19545,7 +19545,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
@@ -22018,9 +22018,9 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   font-size: 14px;
   cursor: text;
-  min-height: 60px;
+  min-height: 72px;
   padding: 2px 6px;
-  line-height: 19.6px;
+  line-height: 24px;
 }
 
 .c36::before {
@@ -22036,18 +22036,18 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 }
 
 .c29 {
-  margin: 32px 0;
+  margin: 24px 0;
 }
 
 .c28 {
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 0px 20px;
 }
 
 .c30 {
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 5px;
+  margin-bottom: 9px;
 }
 
 .c31 {
@@ -22056,7 +22056,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   fill: #555;
   padding-left: 8px;
   float: right;
-  margin-top: -35px;
+  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Change styling of Draft.js Mention Plugin entities. They now have a purple background, white letters, rounded corners, and more padding and margin. 

## Relevant technical choices:
* I'm overwriting the mention component from the mention plugin to add styling to the mentions/entities.
* I've made the line height of the meta description input the same as the line height of the title input, to make the entities in both fields look the same.
* I've discussed the following styling changes (which were not in the issue) with @hedgefield:
    - Less padding between the snippet editor input fields.
    - Less padding between the bottom field and the close button.
    - Align the bottom of the input field title with the bottom of the inserter button text.
    - Remove the padding between the inserter button and the input field.
    - Add padding between the title and description input field in the settings pages snippet editors.

## Questions/concerns
- I've added padding and margin on the left and right side of the entities. However, the cursor/caret stays directly after/before the last/first letter. Because of this, it feels like it's not possible to put your cursor directly after/before an entity. Is there a way to move the cursor as well based on the padding or margin? I've created a new issue for this: https://github.com/Yoast/yoast-components/issues/595.

## Test instructions

This PR can be tested by following these steps:

* Link this branch to `feature/react-snippet-editor` form wordpress-seo.
* Look at the snippet editor in the editor and on the settings pages and confirm all the above style changes and the style changes from the issue are implemented.

Fixes Yoast/wordpress-seo/issues/9836 
