### PR TITLE
Improve the snippet editor placeholder color contrast

### DIFF
--- a/composites/Plugin/SnippetEditor/components/Shared.js
+++ b/composites/Plugin/SnippetEditor/components/Shared.js
@@ -81,6 +81,14 @@ export const DescriptionInputContainer = InputContainer.extend`
 	min-height: 72px;
 	padding: 2px 6px;
 	line-height: 24px;
+
+	.public-DraftEditorPlaceholder-root {
+		color: ${ colors.$color_grey_text };
+	}
+
+	.public-DraftEditorPlaceholder-hasFocus {
+		color: ${ colors.$color_grey_text };
+	}
 `;
 
 export const FormSection = styled.div`

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -927,6 +927,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   line-height: 24px;
 }
 
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
 .c36::before {
   display: block;
   position: absolute;
@@ -2740,6 +2748,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   min-height: 72px;
   padding: 2px 6px;
   line-height: 24px;
+}
+
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
 }
 
 .c36::before {
@@ -4557,6 +4573,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   line-height: 24px;
 }
 
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
 .c36::before {
   display: block;
   position: absolute;
@@ -6370,6 +6394,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   min-height: 72px;
   padding: 2px 6px;
   line-height: 24px;
+}
+
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
 }
 
 .c36::before {
@@ -9307,6 +9339,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   line-height: 24px;
 }
 
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
 .c36::before {
   display: block;
   position: absolute;
@@ -11120,6 +11160,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   min-height: 72px;
   padding: 2px 6px;
   line-height: 24px;
+}
+
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
 }
 
 .c36::before {
@@ -14027,6 +14075,14 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   line-height: 24px;
 }
 
+.c37 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c37 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
 .c37::before {
   display: block;
   position: absolute;
@@ -15860,6 +15916,14 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   min-height: 72px;
   padding: 2px 6px;
   line-height: 24px;
+}
+
+.c37 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c37 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
 }
 
 .c37::before {
@@ -17697,6 +17761,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   line-height: 24px;
 }
 
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
 .c36::before {
   display: block;
   position: absolute;
@@ -19510,6 +19582,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
   min-height: 72px;
   padding: 2px 6px;
   line-height: 24px;
+}
+
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
 }
 
 .c36::before {
@@ -22021,6 +22101,14 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   min-height: 72px;
   padding: 2px 6px;
   line-height: 24px;
+}
+
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
 }
 
 .c36::before {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improve the snippet editor placeholder color contrast

## Relevant technical choices:

* Uses the same gray color we use on MyYoast

## Test instructions

- currently, the placeholder text in the description field has a light gray color that becomes even lighter when the field is focused:

<img width="495" alt="screen shot 2018-06-18 at 10 31 55" src="https://user-images.githubusercontent.com/1682452/41530677-40085276-72f1-11e8-8ab4-31530529d107.png">
<img width="490" alt="screen shot 2018-06-18 at 10 32 03" src="https://user-images.githubusercontent.com/1682452/41530678-402def40-72f1-11e8-9990-81c8bb059512.png">

This PR changes the color to `#646464` in both states (normal and focused). 
- test the standalone version: `yarn-start` and go to localhost:3333
- open the snippet editor
- empty the description field to make the placeholder text appear
- check the placeholder color is always `#646464` also when the field is focused
- optionally, yarn-link to the  plugin `release-7.7` branch and test also in the plugin


Fixes #602 
Fixes https://github.com/Yoast/wordpress-seo/issues/9874
