### PR TITLE
Higher z-index for the mention plugin suggestions

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
@@ -42,12 +42,16 @@ const serializeEditorState = flow( [
 ] );
 
 /**
- * Needed to avoid styling issues on the settings pages iwth the suggestions dropdown,
- * because the button labels have a z-index of 3.
+ * Needed to avoid styling issues on the settings pages with the
+ * suggestions dropdown, because the button labels have a z-index of 3.
+ * Added an extra 1000 because with a lot of replacement variables it should
+ * stay on top of the #wp-content-editor-tools element, which has a z-index
+ * of 1000.
+ *
  */
 const ZIndexOverride = styled.div`
 	div {
-		z-index: 5;
+		z-index: 1005;
 	}
 `;
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where in cases with a lot of snippet variables it would sometimes be partially hidden behind the WordPress toolbar.

## Relevant technical choices:

* Increased the z-index by 1000, because this is the value of the element it was behind has as z-index.

## Test instructions

This PR can be tested by following these steps:

* See issue.

Fixes https://github.com/Yoast/wordpress-seo/issues/10045
