### PR TITLE
Introduce an ErrorBoundary component and use it around the SnippetEditorFields

### DIFF
--- a/composites/Plugin/SnippetEditor/components/SettingsSnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SettingsSnippetEditor.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 // Internal dependencies.
 import SettingsSnippetEditorFields from "./SettingsSnippetEditorFields";
 import { replacementVariablesShape } from "../constants";
+import ErrorBoundary from "../../../basic/ErrorBoundary";
 
 class SnippetEditor extends React.Component {
 	/**
@@ -103,14 +104,17 @@ class SnippetEditor extends React.Component {
 		const { activeField, hoveredField } = this.state;
 
 		return (
-			<SettingsSnippetEditorFields
-				descriptionEditorFieldPlaceholder={ descriptionEditorFieldPlaceholder }
-				data={ data }
-				activeField={ activeField }
-				hoveredField={ hoveredField }
-				onChange={ this.handleChange }
-				onFocus={ this.setFieldFocus }
-				replacementVariables={ replacementVariables } />
+			<ErrorBoundary>
+				<SettingsSnippetEditorFields
+					descriptionEditorFieldPlaceholder={ descriptionEditorFieldPlaceholder }
+					data={ data }
+					activeField={ activeField }
+					hoveredField={ hoveredField }
+					onChange={ this.handleChange }
+					onFocus={ this.setFieldFocus }
+					replacementVariables={ replacementVariables }
+				/>
+			</ErrorBoundary>
 		);
 	}
 }

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -20,6 +20,7 @@ import SvgIcon from "../../Shared/components/SvgIcon";
 import { lengthProgressShape, replacementVariablesShape } from "../constants";
 import ModeSwitcher from "./ModeSwitcher";
 import colors from "../../../../style-guide/colors";
+import ErrorBoundary from "../../../basic/ErrorBoundary";
 
 const SnippetEditorButton = Button.extend`
 	height: 33px;
@@ -502,33 +503,35 @@ class SnippetEditor extends React.Component {
 		 */
 		/* eslint-disable jsx-a11y/mouse-events-have-key-events */
 		return (
-			<div>
-				<SnippetPreview
-					keyword={ keyword }
-					mode={ mode }
-					date={ date }
-					activeField={ this.mapFieldToPreview( activeField ) }
-					hoveredField={ this.mapFieldToPreview( hoveredField ) }
-					onMouseEnter={ this.onMouseEnter }
-					onMouseLeave={ this.onMouseLeave }
-					onMouseUp={ this.onMouseUp }
-					locale={ locale }
-					{ ...mappedData }
-				/>
+			<ErrorBoundary>
+				<div>
+					<SnippetPreview
+						keyword={ keyword }
+						mode={ mode }
+						date={ date }
+						activeField={ this.mapFieldToPreview( activeField ) }
+						hoveredField={ this.mapFieldToPreview( hoveredField ) }
+						onMouseEnter={ this.onMouseEnter }
+						onMouseLeave={ this.onMouseLeave }
+						onMouseUp={ this.onMouseUp }
+						locale={ locale }
+						{ ...mappedData }
+					/>
 
-				<ModeSwitcher onChange={ ( mode ) => onChange( "mode", mode ) } active={ mode } />
+					<ModeSwitcher onChange={ ( mode ) => onChange( "mode", mode ) } active={ mode } />
 
-				<EditSnippetButton
-					onClick={ isOpen ? this.close : this.open }
-					aria-expanded={ isOpen }
-					innerRef={ this.setEditButtonRef }
-				>
-					<SvgIcon icon="edit" />
-					{ __( "Edit snippet", "yoast-components" ) }
-				</EditSnippetButton>
+					<EditSnippetButton
+						onClick={ isOpen ? this.close : this.open }
+						aria-expanded={ isOpen }
+						innerRef={ this.setEditButtonRef }
+					>
+						<SvgIcon icon="edit" />
+						{ __( "Edit snippet", "yoast-components" ) }
+					</EditSnippetButton>
 
-				{ this.renderEditor() }
-			</div>
+					{ this.renderEditor() }
+				</div>
+			</ErrorBoundary>
 		);
 		/* eslint-enable jsx-a11y/mouse-events-have-key-events */
 	}

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -18,7 +18,6 @@ import {
 import ProgressBar from "../../SnippetPreview/components/ProgressBar";
 import { lengthProgressShape, replacementVariablesShape } from "../constants";
 import colors from "../../../../style-guide/colors";
-import ErrorBoundary from "../../../basic/ErrorBoundary";
 
 const SlugInput = styled.input`
 	border: none;
@@ -151,8 +150,12 @@ class SnippetEditorFields extends React.Component {
 	 */
 	focusOnActiveFieldChange() {
 		const { activeField } = this.props;
-		if ( activeField ) {
-			const activeElement = this.elements[ activeField ];
+		const activeElement = activeField ? this.elements[ activeField ] : null;
+		/*
+		 * The editor might not render if any previous error occurs, so better
+		 * to check for the existence of the DOM node before trying to use it.
+		 */
+		if ( activeElement ) {
 			activeElement.focus();
 		}
 	}
@@ -216,76 +219,74 @@ class SnippetEditorFields extends React.Component {
 		const slugLabelId = `${ this.uniqueId }-slug`;
 
 		return (
-			<ErrorBoundary>
-				<StyledEditor
-					innerRef={ this.setEditorRef }
-				>
-					<FormSection>
-						<ReplacementVariableEditor
-							withCaret={ true }
-							label={ __( "SEO title", "yoast-components" ) }
-							onFocus={ () => onFocus( "title" ) }
+			<StyledEditor
+				innerRef={ this.setEditorRef }
+			>
+				<FormSection>
+					<ReplacementVariableEditor
+						withCaret={ true }
+						label={ __( "SEO title", "yoast-components" ) }
+						onFocus={ () => onFocus( "title" ) }
+						onBlur={ () => onBlur() }
+						isActive={ activeField === "title" }
+						isHovered={ hoveredField === "title" }
+						editorRef={ ref => this.setRef( "title", ref ) }
+						replacementVariables={ replacementVariables }
+						content={ title }
+						onChange={ content => onChange( "title", content ) }
+						styleForMobile={ isSmallerThanMobileWidth }
+					/>
+					<ProgressBar
+						max={ titleLengthProgress.max }
+						value={ titleLengthProgress.actual }
+						progressColor={ this.getProgressColor( titleLengthProgress.score ) }
+					/>
+				</FormSection>
+				<FormSection>
+					<SimulatedLabel
+						id={ slugLabelId }
+						onClick={ () => onFocus( "slug" ) }
+					>
+						{ __( "Slug", "yoast-components" ) }
+					</SimulatedLabel>
+					<InputContainerWithCaretStyles
+						onClick={ () => this.elements.slug.focus() }
+						isActive={ activeField === "slug" }
+						isHovered={ hoveredField === "slug" }
+					>
+						<SlugInput
+							value={ slug }
+							onChange={ event => onChange( "slug", event.target.value ) }
+							onFocus={ () => onFocus( "slug" ) }
 							onBlur={ () => onBlur() }
-							isActive={ activeField === "title" }
-							isHovered={ hoveredField === "title" }
-							editorRef={ ref => this.setRef( "title", ref ) }
-							replacementVariables={ replacementVariables }
-							content={ title }
-							onChange={ content => onChange( "title", content ) }
-							styleForMobile={ isSmallerThanMobileWidth }
+							innerRef={ ref => this.setRef( "slug", ref ) }
+							aria-labelledby={ this.uniqueId + "-slug" }
 						/>
-						<ProgressBar
-							max={ titleLengthProgress.max }
-							value={ titleLengthProgress.actual }
-							progressColor={ this.getProgressColor( titleLengthProgress.score ) }
-						/>
-					</FormSection>
-					<FormSection>
-						<SimulatedLabel
-							id={ slugLabelId }
-							onClick={ () => onFocus( "slug" ) }
-						>
-							{ __( "Slug", "yoast-components" ) }
-						</SimulatedLabel>
-						<InputContainerWithCaretStyles
-							onClick={ () => this.elements.slug.focus() }
-							isActive={ activeField === "slug" }
-							isHovered={ hoveredField === "slug" }
-						>
-							<SlugInput
-								value={ slug }
-								onChange={ event => onChange( "slug", event.target.value ) }
-								onFocus={ () => onFocus( "slug" ) }
-								onBlur={ () => onBlur() }
-								innerRef={ ref => this.setRef( "slug", ref ) }
-								aria-labelledby={ this.uniqueId + "-slug" }
-							/>
-						</InputContainerWithCaretStyles>
-					</FormSection>
-					<FormSection>
-						<ReplacementVariableEditor
-							withCaret={ true }
-							type="description"
-							placeholder={ descriptionEditorFieldPlaceholder }
-							label={ __( "Meta description", "yoast-components" ) }
-							onFocus={ () => onFocus( "description" ) }
-							onBlur={ () => onBlur() }
-							isActive={ activeField === "description" }
-							isHovered={ hoveredField === "description" }
-							editorRef={ ref => this.setRef( "description", ref ) }
-							replacementVariables={ replacementVariables }
-							content={ description }
-							onChange={ content => onChange( "description", content ) }
-							styleForMobile={ isSmallerThanMobileWidth }
-						/>
-						<ProgressBar
-							max={ descriptionLengthProgress.max }
-							value={ descriptionLengthProgress.actual }
-							progressColor={ this.getProgressColor( descriptionLengthProgress.score ) }
-						/>
-					</FormSection>
-				</StyledEditor>
-			</ErrorBoundary>
+					</InputContainerWithCaretStyles>
+				</FormSection>
+				<FormSection>
+					<ReplacementVariableEditor
+						withCaret={ true }
+						type="description"
+						placeholder={ descriptionEditorFieldPlaceholder }
+						label={ __( "Meta description", "yoast-components" ) }
+						onFocus={ () => onFocus( "description" ) }
+						onBlur={ () => onBlur() }
+						isActive={ activeField === "description" }
+						isHovered={ hoveredField === "description" }
+						editorRef={ ref => this.setRef( "description", ref ) }
+						replacementVariables={ replacementVariables }
+						content={ description }
+						onChange={ content => onChange( "description", content ) }
+						styleForMobile={ isSmallerThanMobileWidth }
+					/>
+					<ProgressBar
+						max={ descriptionLengthProgress.max }
+						value={ descriptionLengthProgress.actual }
+						progressColor={ this.getProgressColor( descriptionLengthProgress.score ) }
+					/>
+				</FormSection>
+			</StyledEditor>
 		);
 	}
 

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -18,6 +18,7 @@ import {
 import ProgressBar from "../../SnippetPreview/components/ProgressBar";
 import { lengthProgressShape, replacementVariablesShape } from "../constants";
 import colors from "../../../../style-guide/colors";
+import ErrorBoundary from "../../../basic/ErrorBoundary";
 
 const SlugInput = styled.input`
 	border: none;
@@ -177,6 +178,11 @@ class SnippetEditorFields extends React.Component {
 	 * @returns {void}
 	 */
 	updateIsSmallerThanMobileWidth() {
+		if ( ! this.editor ) {
+			// The editor might not render if any previous error occurs.
+			return;
+		}
+
 		const isSmallerThanMobileWidth = this.editor.clientWidth < this.props.mobileWidth;
 		if ( this.state.isSmallerThanMobileWidth !== isSmallerThanMobileWidth ) {
 			this.setState( { isSmallerThanMobileWidth } );
@@ -210,74 +216,76 @@ class SnippetEditorFields extends React.Component {
 		const slugLabelId = `${ this.uniqueId }-slug`;
 
 		return (
-			<StyledEditor
-				innerRef={ this.setEditorRef }
-			>
-				<FormSection>
-					<ReplacementVariableEditor
-						withCaret={ true }
-						label={ __( "SEO title", "yoast-components" ) }
-						onFocus={ () => onFocus( "title" ) }
-						onBlur={ () => onBlur() }
-						isActive={ activeField === "title" }
-						isHovered={ hoveredField === "title" }
-						editorRef={ ref => this.setRef( "title", ref ) }
-						replacementVariables={ replacementVariables }
-						content={ title }
-						onChange={ content => onChange( "title", content ) }
-						styleForMobile={ isSmallerThanMobileWidth }
-					/>
-					<ProgressBar
-						max={ titleLengthProgress.max }
-						value={ titleLengthProgress.actual }
-						progressColor={ this.getProgressColor( titleLengthProgress.score ) }
-					/>
-				</FormSection>
-				<FormSection>
-					<SimulatedLabel
-						id={ slugLabelId }
-						onClick={ () => onFocus( "slug" ) }
-					>
-						{ __( "Slug", "yoast-components" ) }
-					</SimulatedLabel>
-					<InputContainerWithCaretStyles
-						onClick={ () => this.elements.slug.focus() }
-						isActive={ activeField === "slug" }
-						isHovered={ hoveredField === "slug" }
-					>
-						<SlugInput
-							value={ slug }
-							onChange={ event => onChange( "slug", event.target.value ) }
-							onFocus={ () => onFocus( "slug" ) }
+			<ErrorBoundary>
+				<StyledEditor
+					innerRef={ this.setEditorRef }
+				>
+					<FormSection>
+						<ReplacementVariableEditor
+							withCaret={ true }
+							label={ __( "SEO title", "yoast-components" ) }
+							onFocus={ () => onFocus( "title" ) }
 							onBlur={ () => onBlur() }
-							innerRef={ ref => this.setRef( "slug", ref ) }
-							aria-labelledby={ this.uniqueId + "-slug" }
+							isActive={ activeField === "title" }
+							isHovered={ hoveredField === "title" }
+							editorRef={ ref => this.setRef( "title", ref ) }
+							replacementVariables={ replacementVariables }
+							content={ title }
+							onChange={ content => onChange( "title", content ) }
+							styleForMobile={ isSmallerThanMobileWidth }
 						/>
-					</InputContainerWithCaretStyles>
-				</FormSection>
-				<FormSection>
-					<ReplacementVariableEditor
-						withCaret={ true }
-						type="description"
-						placeholder={ descriptionEditorFieldPlaceholder }
-						label={ __( "Meta description", "yoast-components" ) }
-						onFocus={ () => onFocus( "description" ) }
-						onBlur={ () => onBlur() }
-						isActive={ activeField === "description" }
-						isHovered={ hoveredField === "description" }
-						editorRef={ ref => this.setRef( "description", ref ) }
-						replacementVariables={ replacementVariables }
-						content={ description }
-						onChange={ content => onChange( "description", content ) }
-						styleForMobile={ isSmallerThanMobileWidth }
-					/>
-					<ProgressBar
-						max={ descriptionLengthProgress.max }
-						value={ descriptionLengthProgress.actual }
-						progressColor={ this.getProgressColor( descriptionLengthProgress.score ) }
-					/>
-				</FormSection>
-			</StyledEditor>
+						<ProgressBar
+							max={ titleLengthProgress.max }
+							value={ titleLengthProgress.actual }
+							progressColor={ this.getProgressColor( titleLengthProgress.score ) }
+						/>
+					</FormSection>
+					<FormSection>
+						<SimulatedLabel
+							id={ slugLabelId }
+							onClick={ () => onFocus( "slug" ) }
+						>
+							{ __( "Slug", "yoast-components" ) }
+						</SimulatedLabel>
+						<InputContainerWithCaretStyles
+							onClick={ () => this.elements.slug.focus() }
+							isActive={ activeField === "slug" }
+							isHovered={ hoveredField === "slug" }
+						>
+							<SlugInput
+								value={ slug }
+								onChange={ event => onChange( "slug", event.target.value ) }
+								onFocus={ () => onFocus( "slug" ) }
+								onBlur={ () => onBlur() }
+								innerRef={ ref => this.setRef( "slug", ref ) }
+								aria-labelledby={ this.uniqueId + "-slug" }
+							/>
+						</InputContainerWithCaretStyles>
+					</FormSection>
+					<FormSection>
+						<ReplacementVariableEditor
+							withCaret={ true }
+							type="description"
+							placeholder={ descriptionEditorFieldPlaceholder }
+							label={ __( "Meta description", "yoast-components" ) }
+							onFocus={ () => onFocus( "description" ) }
+							onBlur={ () => onBlur() }
+							isActive={ activeField === "description" }
+							isHovered={ hoveredField === "description" }
+							editorRef={ ref => this.setRef( "description", ref ) }
+							replacementVariables={ replacementVariables }
+							content={ description }
+							onChange={ content => onChange( "description", content ) }
+							styleForMobile={ isSmallerThanMobileWidth }
+						/>
+						<ProgressBar
+							max={ descriptionLengthProgress.max }
+							value={ descriptionLengthProgress.actual }
+							progressColor={ this.getProgressColor( descriptionLengthProgress.score ) }
+						/>
+					</FormSection>
+				</StyledEditor>
+			</ErrorBoundary>
 		);
 	}
 

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -546,78 +546,80 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
 `;
 
 exports[`SnippetEditor activates a field on onMouseUp() and opens the editor 1`] = `
-<div>
-  <SnippetPreview
-    activeField={null}
-    breadcrumbs={null}
-    date=""
-    description="Test description, %%replacement_variable%%"
-    hoveredField={null}
-    isAmp={false}
-    keyword=""
-    locale="en"
-    mode="mobile"
-    onHover={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    title="Test title"
-    url="example.org/test-slug"
-  />
-  <ModeSwitcher
-    active="mobile"
-    onChange={[Function]}
-  />
-  <Button
-    aria-expanded={true}
-    innerRef={[Function]}
-    onClick={[Function]}
-  >
-    <SvgIcon
-      icon="edit"
-      size="16px"
-    />
-    Edit snippet
-  </Button>
-  <React.Fragment>
-    <SnippetEditorFields
+<ErrorBoundary>
+  <div>
+    <SnippetPreview
       activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
-        }
-      }
-      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-      descriptionLengthProgress={
-        Object {
-          "actual": 42,
-          "max": 156,
-          "score": 6,
-        }
-      }
+      breadcrumbs={null}
+      date=""
+      description="Test description, %%replacement_variable%%"
       hoveredField={null}
-      mobileWidth={356}
-      onBlur={[Function]}
+      isAmp={false}
+      keyword=""
+      locale="en"
+      mode="mobile"
+      onHover={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      title="Test title"
+      url="example.org/test-slug"
+    />
+    <ModeSwitcher
+      active="mobile"
       onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthProgress={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 1,
-        }
-      }
     />
     <Button
+      aria-expanded={true}
+      innerRef={[Function]}
       onClick={[Function]}
     >
-      Close snippet editor
+      <SvgIcon
+        icon="edit"
+        size="16px"
+      />
+      Edit snippet
     </Button>
-  </React.Fragment>
-</div>
+    <React.Fragment>
+      <SnippetEditorFields
+        activeField={null}
+        data={
+          Object {
+            "description": "Test description, %%replacement_variable%%",
+            "slug": "test-slug",
+            "title": "Test title",
+          }
+        }
+        descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+        descriptionLengthProgress={
+          Object {
+            "actual": 42,
+            "max": 156,
+            "score": 6,
+          }
+        }
+        hoveredField={null}
+        mobileWidth={356}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        replacementVariables={Array []}
+        titleLengthProgress={
+          Object {
+            "actual": 0,
+            "max": 600,
+            "score": 1,
+          }
+        }
+      />
+      <Button
+        onClick={[Function]}
+      >
+        Close snippet editor
+      </Button>
+    </React.Fragment>
+  </div>
+</ErrorBoundary>
 `;
 
 exports[`SnippetEditor calls callbacks when the editors are focused or changed 1`] = `
@@ -1206,72 +1208,61 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
     }
   }
 >
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      keyword=""
-      locale="en"
-      mode="mobile"
-      onHover={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <div>
-          <HelpTextWrapper
-            className="yoast-help"
-            helpText={
-              Array [
-                "This is a rendering of what this post might look like in Google's search results. ",
-                <OutboundLink
-                  href="https://yoa.st/snippet-preview"
-                >
-                  Learn more about the Snippet Preview.
-                </OutboundLink>,
-              ]
-            }
-            helpTextButtonLabel="Help on the Snippet Preview"
-            panelMaxWidth="400px"
-          >
-            <HelpTextWrapper__HelpTextContainer
+  <ErrorBoundary>
+    <div>
+      <SnippetPreview
+        activeField={null}
+        breadcrumbs={null}
+        date=""
+        description="Test description, %%replacement_variable%%"
+        hoveredField={null}
+        isAmp={false}
+        keyword=""
+        locale="en"
+        mode="mobile"
+        onHover={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        title="Test title"
+        url="example.org/test-slug"
+      >
+        <section>
+          <div>
+            <HelpTextWrapper
               className="yoast-help"
+              helpText={
+                Array [
+                  "This is a rendering of what this post might look like in Google's search results. ",
+                  <OutboundLink
+                    href="https://yoa.st/snippet-preview"
+                  >
+                    Learn more about the Snippet Preview.
+                  </OutboundLink>,
+                ]
+              }
+              helpTextButtonLabel="Help on the Snippet Preview"
+              panelMaxWidth="400px"
             >
-              <div
-                className="yoast-help c0"
+              <HelpTextWrapper__HelpTextContainer
+                className="yoast-help"
               >
-                <HelpTextWrapper__HelpTextButton
-                  aria-controls={null}
-                  aria-expanded={false}
-                  aria-label="Help on the Snippet Preview"
-                  className="yoast-help__button"
-                  onClick={[Function]}
+                <div
+                  className="yoast-help c0"
                 >
-                  <Button
+                  <HelpTextWrapper__HelpTextButton
                     aria-controls={null}
                     aria-expanded={false}
                     aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button c1"
+                    className="yoast-help__button"
                     onClick={[Function]}
                   >
                     <Button
                       aria-controls={null}
                       aria-expanded={false}
                       aria-label="Help on the Snippet Preview"
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="yoast-help__button c1 c2"
+                      className="yoast-help__button c1"
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         aria-controls={null}
@@ -1280,7 +1271,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2 Button-kDSBcD c3"
+                        className="yoast-help__button c1 c2"
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -1292,7 +1283,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -1304,55 +1295,57 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               aria-controls={null}
                               aria-expanded={false}
                               aria-label="Help on the Snippet Preview"
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
+                              <Button__BaseButton
                                 aria-controls={null}
                                 aria-expanded={false}
                                 aria-label="Help on the Snippet Preview"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <HelpTextWrapper__StyledSvg
-                                  color="#646464"
-                                  icon="question-circle"
-                                  size="16px"
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-label="Help on the Snippet Preview"
+                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon
-                                    className="c8"
+                                  <HelpTextWrapper__StyledSvg
                                     color="#646464"
                                     icon="question-circle"
                                     size="16px"
                                   >
-                                    <SvgIcon__StyledSvg
-                                      aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                      fill="#646464"
-                                      focusable="false"
-                                      role="img"
+                                    <SvgIcon
+                                      className="c8"
+                                      color="#646464"
+                                      icon="question-circle"
                                       size="16px"
-                                      viewBox="0 0 1792 1792"
-                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <svg
+                                      <SvgIcon__StyledSvg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
                                         fill="#646464"
                                         focusable="false"
                                         role="img"
@@ -1360,268 +1353,267 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                         viewBox="0 0 1792 1792"
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                        />
-                                      </svg>
-                                    </SvgIcon__StyledSvg>
-                                  </SvgIcon>
-                                </HelpTextWrapper__StyledSvg>
-                              </button>
-                            </Button__BaseButton>
+                                        <svg
+                                          aria-hidden={true}
+                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                          fill="#646464"
+                                          focusable="false"
+                                          role="img"
+                                          size="16px"
+                                          viewBox="0 0 1792 1792"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                          />
+                                        </svg>
+                                      </SvgIcon__StyledSvg>
+                                    </SvgIcon>
+                                  </HelpTextWrapper__StyledSvg>
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </HelpTextWrapper__HelpTextButton>
-                <YoastSlideToggle
-                  duration={300}
-                  isOpen={false}
-                >
-                  <animations__YoastSlideToggleContainer
+                  </HelpTextWrapper__HelpTextButton>
+                  <YoastSlideToggle
                     duration={300}
+                    isOpen={false}
                   >
-                    <div
-                      className="c10"
+                    <animations__YoastSlideToggleContainer
+                      duration={300}
                     >
-                      <CSSTransition
-                        classNames="slide"
-                        in={false}
-                        onEnter={[Function]}
-                        onEntered={[Function]}
-                        onEntering={[Function]}
-                        onExit={[Function]}
-                        onExiting={[Function]}
-                        timeout={300}
-                        unmountOnExit={true}
+                      <div
+                        className="c10"
                       >
-                        <Transition
-                          appear={false}
-                          enter={true}
-                          exit={true}
+                        <CSSTransition
+                          classNames="slide"
                           in={false}
-                          mountOnEnter={false}
                           onEnter={[Function]}
                           onEntered={[Function]}
                           onEntering={[Function]}
                           onExit={[Function]}
-                          onExited={[Function]}
                           onExiting={[Function]}
                           timeout={300}
                           unmountOnExit={true}
-                        />
-                      </CSSTransition>
-                    </div>
-                  </animations__YoastSlideToggleContainer>
-                </YoastSlideToggle>
-              </div>
-            </HelpTextWrapper__HelpTextContainer>
-          </HelpTextWrapper>
-        </div>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c11"
+                        >
+                          <Transition
+                            appear={false}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            timeout={300}
+                            unmountOnExit={true}
+                          />
+                        </CSSTransition>
+                      </div>
+                    </animations__YoastSlideToggleContainer>
+                  </YoastSlideToggle>
+                </div>
+              </HelpTextWrapper__HelpTextContainer>
+            </HelpTextWrapper>
+          </div>
+          <SnippetPreview__MobileContainer
+            padding={20}
             width={640}
           >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    SEO title preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseTitle
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+            <div
+              className="c11"
+              width={640}
+            >
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <div
-                    className="c13"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      SEO title preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseTitle
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c14"
-                      >
-                        <div
-                          className="c14 c15"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c16"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Url preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseUrl>
-                  <div
-                    className="c17"
-                  >
-                    <SnippetPreview__BaseUrlOverflowContainer
+                    <div
+                      className="c13"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <div
-                        className="c18"
+                      <SnippetPreview__TitleBounded>
+                        <SnippetPreview__Title
+                          className="c14"
+                        >
+                          <div
+                            className="c14 c15"
+                          >
+                            <SnippetPreview__TitleUnboundedMobile
+                              innerRef={[Function]}
+                            >
+                              <span
+                                className="c16"
+                              >
+                                Test title
+                              </span>
+                            </SnippetPreview__TitleUnboundedMobile>
+                          </div>
+                        </SnippetPreview__Title>
+                      </SnippetPreview__TitleBounded>
+                    </div>
+                  </SnippetPreview__BaseTitle>
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Url preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseUrl>
+                    <div
+                      className="c17"
+                    >
+                      <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
-                        example.org › test-slug
-                      </div>
-                    </SnippetPreview__BaseUrlOverflowContainer>
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c19"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Meta description preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__MobileDescription
-                  isDescriptionPlaceholder={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+                        <div
+                          className="c18"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrlOverflowContainer>
+                    </div>
+                  </SnippetPreview__BaseUrl>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+              <SnippetPreview__Separator>
+                <hr
+                  className="c19"
+                />
+              </SnippetPreview__Separator>
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <SnippetPreview__DesktopDescription
-                    className="c20"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Meta description preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__MobileDescription
                     isDescriptionPlaceholder={false}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <div
-                      className="c20 c21"
+                    <SnippetPreview__DesktopDescription
+                      className="c20"
+                      isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <SnippetPreview__MobileDescription
-                        innerRef={[Function]}
-                        isDescriptionPlaceholder={false}
+                      <div
+                        className="c20 c21"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
                       >
-                        <SnippetPreview__DesktopDescription
-                          className="c20"
+                        <SnippetPreview__MobileDescription
                           innerRef={[Function]}
                           isDescriptionPlaceholder={false}
                         >
-                          <div
-                            className="c20 c21"
+                          <SnippetPreview__DesktopDescription
+                            className="c20"
+                            innerRef={[Function]}
+                            isDescriptionPlaceholder={false}
                           >
-                            Test description, %%replacement_variable%%
-                          </div>
-                        </SnippetPreview__DesktopDescription>
-                      </SnippetPreview__MobileDescription>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c22"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
+                            <div
+                              className="c20 c21"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </div>
+                    </SnippetPreview__DesktopDescription>
+                  </SnippetPreview__MobileDescription>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+            </div>
+          </SnippetPreview__MobileContainer>
+        </section>
+      </SnippetPreview>
+      <ModeSwitcher
+        active="mobile"
+        onChange={[Function]}
+      >
+        <ModeSwitcher__Switcher>
+          <div
+            className="c22"
           >
-            <Button
+            <ModeSwitcher__SwitcherButton
               aria-pressed={true}
-              className="c23"
               isActive={true}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c23 c2"
+                className="c23"
                 isActive={true}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={true}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2 Button-kDSBcD c3"
+                  className="c23 c2"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -1632,7 +1624,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c23 c2 Button-kDSBcD c3"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -1643,47 +1635,48 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={true}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={true}
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={true}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
+                          <button
+                            aria-pressed={true}
+                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="mobile"
                               size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                className="yoast-svg-icon yoast-svg-icon-mobile"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -1691,64 +1684,63 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="22px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Mobile preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Mobile preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
+            </ModeSwitcher__SwitcherButton>
+            <ModeSwitcher__SwitcherButton
               aria-pressed={false}
-              className="c25"
               isActive={false}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c25"
                 isActive={false}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={false}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c25 c2"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -1759,7 +1751,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c25 c2 Button-kDSBcD c3"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -1770,47 +1762,48 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={false}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={false}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={false}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
+                          <button
+                            aria-pressed={false}
+                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="desktop"
                               size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                className="yoast-svg-icon yoast-svg-icon-desktop"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -1818,61 +1811,60 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="18px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Desktop preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Desktop preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
+            </ModeSwitcher__SwitcherButton>
+          </div>
+        </ModeSwitcher__Switcher>
+      </ModeSwitcher>
       <Button
         aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c27"
         innerRef={[Function]}
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           aria-expanded={true}
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c3"
+          className="c27"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -1883,7 +1875,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c27 Button-kDSBcD c3"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -1894,97 +1886,107 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 aria-expanded={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
+                <Button__BaseButton
                   aria-expanded={true}
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  innerRef={[Function]}
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
+                  <button
+                    aria-expanded={true}
+                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
+                    <SvgIcon
+                      icon="edit"
                       size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
+                      <SvgIcon__StyledSvg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c9"
+                        className="yoast-svg-icon yoast-svg-icon-edit"
                         focusable="false"
                         role="img"
                         size="16px"
                         viewBox="0 0 1792 1792"
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  Edit snippet
-                </button>
-              </Button__BaseButton>
+                        <svg
+                          aria-hidden={true}
+                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          focusable="false"
+                          role="img"
+                          size="16px"
+                          viewBox="0 0 1792 1792"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                          />
+                        </svg>
+                      </SvgIcon__StyledSvg>
+                    </SvgIcon>
+                    Edit snippet
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
+      <SnippetEditorFields
+        activeField={null}
+        data={
+          Object {
+            "description": "Test description, %%replacement_variable%%",
+            "slug": "test-slug",
+            "title": "Test title",
+          }
         }
-      }
-      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-      descriptionLengthProgress={
-        Object {
-          "actual": 42,
-          "max": 156,
-          "score": 6,
+        descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+        descriptionLengthProgress={
+          Object {
+            "actual": 42,
+            "max": 156,
+            "score": 6,
+          }
         }
-      }
-      hoveredField={null}
-      mobileWidth={356}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthProgress={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 1,
+        hoveredField={null}
+        mobileWidth={356}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        replacementVariables={Array []}
+        titleLengthProgress={
+          Object {
+            "actual": 0,
+            "max": 600,
+            "score": 1,
+          }
         }
-      }
-    >
-      <ErrorBoundary>
+      >
         <Shared__StyledEditor
           innerRef={[Function]}
         >
@@ -2382,25 +2384,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             </Shared__FormSection>
           </section>
         </Shared__StyledEditor>
-      </ErrorBoundary>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
+      </SnippetEditorFields>
       <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c38"
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c38"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -2409,7 +2401,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -2418,34 +2410,44 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                <Button__BaseButton
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  Close snippet editor
-                </button>
-              </Button__BaseButton>
+                  <button
+                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Close snippet editor
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-  </div>
+    </div>
+  </ErrorBoundary>
 </SnippetEditor>
 `;
 
@@ -3035,72 +3037,61 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
     }
   }
 >
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      keyword=""
-      locale="en"
-      mode="mobile"
-      onHover={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <div>
-          <HelpTextWrapper
-            className="yoast-help"
-            helpText={
-              Array [
-                "This is a rendering of what this post might look like in Google's search results. ",
-                <OutboundLink
-                  href="https://yoa.st/snippet-preview"
-                >
-                  Learn more about the Snippet Preview.
-                </OutboundLink>,
-              ]
-            }
-            helpTextButtonLabel="Help on the Snippet Preview"
-            panelMaxWidth="400px"
-          >
-            <HelpTextWrapper__HelpTextContainer
+  <ErrorBoundary>
+    <div>
+      <SnippetPreview
+        activeField={null}
+        breadcrumbs={null}
+        date=""
+        description="Test description, %%replacement_variable%%"
+        hoveredField={null}
+        isAmp={false}
+        keyword=""
+        locale="en"
+        mode="mobile"
+        onHover={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        title="Test title"
+        url="example.org/test-slug"
+      >
+        <section>
+          <div>
+            <HelpTextWrapper
               className="yoast-help"
+              helpText={
+                Array [
+                  "This is a rendering of what this post might look like in Google's search results. ",
+                  <OutboundLink
+                    href="https://yoa.st/snippet-preview"
+                  >
+                    Learn more about the Snippet Preview.
+                  </OutboundLink>,
+                ]
+              }
+              helpTextButtonLabel="Help on the Snippet Preview"
+              panelMaxWidth="400px"
             >
-              <div
-                className="yoast-help c0"
+              <HelpTextWrapper__HelpTextContainer
+                className="yoast-help"
               >
-                <HelpTextWrapper__HelpTextButton
-                  aria-controls={null}
-                  aria-expanded={false}
-                  aria-label="Help on the Snippet Preview"
-                  className="yoast-help__button"
-                  onClick={[Function]}
+                <div
+                  className="yoast-help c0"
                 >
-                  <Button
+                  <HelpTextWrapper__HelpTextButton
                     aria-controls={null}
                     aria-expanded={false}
                     aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button c1"
+                    className="yoast-help__button"
                     onClick={[Function]}
                   >
                     <Button
                       aria-controls={null}
                       aria-expanded={false}
                       aria-label="Help on the Snippet Preview"
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="yoast-help__button c1 c2"
+                      className="yoast-help__button c1"
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         aria-controls={null}
@@ -3109,7 +3100,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2 Button-kDSBcD c3"
+                        className="yoast-help__button c1 c2"
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -3121,7 +3112,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -3133,55 +3124,57 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               aria-controls={null}
                               aria-expanded={false}
                               aria-label="Help on the Snippet Preview"
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
+                              <Button__BaseButton
                                 aria-controls={null}
                                 aria-expanded={false}
                                 aria-label="Help on the Snippet Preview"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <HelpTextWrapper__StyledSvg
-                                  color="#646464"
-                                  icon="question-circle"
-                                  size="16px"
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-label="Help on the Snippet Preview"
+                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon
-                                    className="c8"
+                                  <HelpTextWrapper__StyledSvg
                                     color="#646464"
                                     icon="question-circle"
                                     size="16px"
                                   >
-                                    <SvgIcon__StyledSvg
-                                      aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                      fill="#646464"
-                                      focusable="false"
-                                      role="img"
+                                    <SvgIcon
+                                      className="c8"
+                                      color="#646464"
+                                      icon="question-circle"
                                       size="16px"
-                                      viewBox="0 0 1792 1792"
-                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <svg
+                                      <SvgIcon__StyledSvg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
                                         fill="#646464"
                                         focusable="false"
                                         role="img"
@@ -3189,268 +3182,267 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                         viewBox="0 0 1792 1792"
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                        />
-                                      </svg>
-                                    </SvgIcon__StyledSvg>
-                                  </SvgIcon>
-                                </HelpTextWrapper__StyledSvg>
-                              </button>
-                            </Button__BaseButton>
+                                        <svg
+                                          aria-hidden={true}
+                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                          fill="#646464"
+                                          focusable="false"
+                                          role="img"
+                                          size="16px"
+                                          viewBox="0 0 1792 1792"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                          />
+                                        </svg>
+                                      </SvgIcon__StyledSvg>
+                                    </SvgIcon>
+                                  </HelpTextWrapper__StyledSvg>
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </HelpTextWrapper__HelpTextButton>
-                <YoastSlideToggle
-                  duration={300}
-                  isOpen={false}
-                >
-                  <animations__YoastSlideToggleContainer
+                  </HelpTextWrapper__HelpTextButton>
+                  <YoastSlideToggle
                     duration={300}
+                    isOpen={false}
                   >
-                    <div
-                      className="c10"
+                    <animations__YoastSlideToggleContainer
+                      duration={300}
                     >
-                      <CSSTransition
-                        classNames="slide"
-                        in={false}
-                        onEnter={[Function]}
-                        onEntered={[Function]}
-                        onEntering={[Function]}
-                        onExit={[Function]}
-                        onExiting={[Function]}
-                        timeout={300}
-                        unmountOnExit={true}
+                      <div
+                        className="c10"
                       >
-                        <Transition
-                          appear={false}
-                          enter={true}
-                          exit={true}
+                        <CSSTransition
+                          classNames="slide"
                           in={false}
-                          mountOnEnter={false}
                           onEnter={[Function]}
                           onEntered={[Function]}
                           onEntering={[Function]}
                           onExit={[Function]}
-                          onExited={[Function]}
                           onExiting={[Function]}
                           timeout={300}
                           unmountOnExit={true}
-                        />
-                      </CSSTransition>
-                    </div>
-                  </animations__YoastSlideToggleContainer>
-                </YoastSlideToggle>
-              </div>
-            </HelpTextWrapper__HelpTextContainer>
-          </HelpTextWrapper>
-        </div>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c11"
+                        >
+                          <Transition
+                            appear={false}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            timeout={300}
+                            unmountOnExit={true}
+                          />
+                        </CSSTransition>
+                      </div>
+                    </animations__YoastSlideToggleContainer>
+                  </YoastSlideToggle>
+                </div>
+              </HelpTextWrapper__HelpTextContainer>
+            </HelpTextWrapper>
+          </div>
+          <SnippetPreview__MobileContainer
+            padding={20}
             width={640}
           >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    SEO title preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseTitle
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+            <div
+              className="c11"
+              width={640}
+            >
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <div
-                    className="c13"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      SEO title preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseTitle
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c14"
-                      >
-                        <div
-                          className="c14 c15"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c16"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Url preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseUrl>
-                  <div
-                    className="c17"
-                  >
-                    <SnippetPreview__BaseUrlOverflowContainer
+                    <div
+                      className="c13"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <div
-                        className="c18"
+                      <SnippetPreview__TitleBounded>
+                        <SnippetPreview__Title
+                          className="c14"
+                        >
+                          <div
+                            className="c14 c15"
+                          >
+                            <SnippetPreview__TitleUnboundedMobile
+                              innerRef={[Function]}
+                            >
+                              <span
+                                className="c16"
+                              >
+                                Test title
+                              </span>
+                            </SnippetPreview__TitleUnboundedMobile>
+                          </div>
+                        </SnippetPreview__Title>
+                      </SnippetPreview__TitleBounded>
+                    </div>
+                  </SnippetPreview__BaseTitle>
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Url preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseUrl>
+                    <div
+                      className="c17"
+                    >
+                      <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
-                        example.org › test-slug
-                      </div>
-                    </SnippetPreview__BaseUrlOverflowContainer>
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c19"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Meta description preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__MobileDescription
-                  isDescriptionPlaceholder={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+                        <div
+                          className="c18"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrlOverflowContainer>
+                    </div>
+                  </SnippetPreview__BaseUrl>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+              <SnippetPreview__Separator>
+                <hr
+                  className="c19"
+                />
+              </SnippetPreview__Separator>
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <SnippetPreview__DesktopDescription
-                    className="c20"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Meta description preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__MobileDescription
                     isDescriptionPlaceholder={false}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <div
-                      className="c20 c21"
+                    <SnippetPreview__DesktopDescription
+                      className="c20"
+                      isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <SnippetPreview__MobileDescription
-                        innerRef={[Function]}
-                        isDescriptionPlaceholder={false}
+                      <div
+                        className="c20 c21"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
                       >
-                        <SnippetPreview__DesktopDescription
-                          className="c20"
+                        <SnippetPreview__MobileDescription
                           innerRef={[Function]}
                           isDescriptionPlaceholder={false}
                         >
-                          <div
-                            className="c20 c21"
+                          <SnippetPreview__DesktopDescription
+                            className="c20"
+                            innerRef={[Function]}
+                            isDescriptionPlaceholder={false}
                           >
-                            Test description, %%replacement_variable%%
-                          </div>
-                        </SnippetPreview__DesktopDescription>
-                      </SnippetPreview__MobileDescription>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c22"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
+                            <div
+                              className="c20 c21"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </div>
+                    </SnippetPreview__DesktopDescription>
+                  </SnippetPreview__MobileDescription>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+            </div>
+          </SnippetPreview__MobileContainer>
+        </section>
+      </SnippetPreview>
+      <ModeSwitcher
+        active="mobile"
+        onChange={[Function]}
+      >
+        <ModeSwitcher__Switcher>
+          <div
+            className="c22"
           >
-            <Button
+            <ModeSwitcher__SwitcherButton
               aria-pressed={true}
-              className="c23"
               isActive={true}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c23 c2"
+                className="c23"
                 isActive={true}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={true}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2 Button-kDSBcD c3"
+                  className="c23 c2"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -3461,7 +3453,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c23 c2 Button-kDSBcD c3"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -3472,47 +3464,48 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={true}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={true}
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={true}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
+                          <button
+                            aria-pressed={true}
+                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="mobile"
                               size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                className="yoast-svg-icon yoast-svg-icon-mobile"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -3520,64 +3513,63 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="22px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Mobile preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Mobile preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
+            </ModeSwitcher__SwitcherButton>
+            <ModeSwitcher__SwitcherButton
               aria-pressed={false}
-              className="c25"
               isActive={false}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c25"
                 isActive={false}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={false}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c25 c2"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -3588,7 +3580,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c25 c2 Button-kDSBcD c3"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -3599,47 +3591,48 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={false}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={false}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={false}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
+                          <button
+                            aria-pressed={false}
+                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="desktop"
                               size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                className="yoast-svg-icon yoast-svg-icon-desktop"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -3647,61 +3640,60 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="18px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Desktop preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Desktop preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
+            </ModeSwitcher__SwitcherButton>
+          </div>
+        </ModeSwitcher__Switcher>
+      </ModeSwitcher>
       <Button
         aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c27"
         innerRef={[Function]}
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           aria-expanded={true}
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c3"
+          className="c27"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -3712,7 +3704,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c27 Button-kDSBcD c3"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -3723,97 +3715,107 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 aria-expanded={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
+                <Button__BaseButton
                   aria-expanded={true}
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  innerRef={[Function]}
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
+                  <button
+                    aria-expanded={true}
+                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
+                    <SvgIcon
+                      icon="edit"
                       size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
+                      <SvgIcon__StyledSvg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c9"
+                        className="yoast-svg-icon yoast-svg-icon-edit"
                         focusable="false"
                         role="img"
                         size="16px"
                         viewBox="0 0 1792 1792"
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  Edit snippet
-                </button>
-              </Button__BaseButton>
+                        <svg
+                          aria-hidden={true}
+                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          focusable="false"
+                          role="img"
+                          size="16px"
+                          viewBox="0 0 1792 1792"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                          />
+                        </svg>
+                      </SvgIcon__StyledSvg>
+                    </SvgIcon>
+                    Edit snippet
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
+      <SnippetEditorFields
+        activeField={null}
+        data={
+          Object {
+            "description": "Test description, %%replacement_variable%%",
+            "slug": "test-slug",
+            "title": "Test title",
+          }
         }
-      }
-      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-      descriptionLengthProgress={
-        Object {
-          "actual": 42,
-          "max": 156,
-          "score": 6,
+        descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+        descriptionLengthProgress={
+          Object {
+            "actual": 42,
+            "max": 156,
+            "score": 6,
+          }
         }
-      }
-      hoveredField={null}
-      mobileWidth={356}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthProgress={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 1,
+        hoveredField={null}
+        mobileWidth={356}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        replacementVariables={Array []}
+        titleLengthProgress={
+          Object {
+            "actual": 0,
+            "max": 600,
+            "score": 1,
+          }
         }
-      }
-    >
-      <ErrorBoundary>
+      >
         <Shared__StyledEditor
           innerRef={[Function]}
         >
@@ -4211,25 +4213,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             </Shared__FormSection>
           </section>
         </Shared__StyledEditor>
-      </ErrorBoundary>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
+      </SnippetEditorFields>
       <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c38"
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c38"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -4238,7 +4230,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -4247,34 +4239,44 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                <Button__BaseButton
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  Close snippet editor
-                </button>
-              </Button__BaseButton>
+                  <button
+                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Close snippet editor
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-  </div>
+    </div>
+  </ErrorBoundary>
 </SnippetEditor>
 `;
 
@@ -4864,72 +4866,61 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
     }
   }
 >
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      keyword=""
-      locale="en"
-      mode="mobile"
-      onHover={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <div>
-          <HelpTextWrapper
-            className="yoast-help"
-            helpText={
-              Array [
-                "This is a rendering of what this post might look like in Google's search results. ",
-                <OutboundLink
-                  href="https://yoa.st/snippet-preview"
-                >
-                  Learn more about the Snippet Preview.
-                </OutboundLink>,
-              ]
-            }
-            helpTextButtonLabel="Help on the Snippet Preview"
-            panelMaxWidth="400px"
-          >
-            <HelpTextWrapper__HelpTextContainer
+  <ErrorBoundary>
+    <div>
+      <SnippetPreview
+        activeField={null}
+        breadcrumbs={null}
+        date=""
+        description="Test description, %%replacement_variable%%"
+        hoveredField={null}
+        isAmp={false}
+        keyword=""
+        locale="en"
+        mode="mobile"
+        onHover={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        title="Test title"
+        url="example.org/test-slug"
+      >
+        <section>
+          <div>
+            <HelpTextWrapper
               className="yoast-help"
+              helpText={
+                Array [
+                  "This is a rendering of what this post might look like in Google's search results. ",
+                  <OutboundLink
+                    href="https://yoa.st/snippet-preview"
+                  >
+                    Learn more about the Snippet Preview.
+                  </OutboundLink>,
+                ]
+              }
+              helpTextButtonLabel="Help on the Snippet Preview"
+              panelMaxWidth="400px"
             >
-              <div
-                className="yoast-help c0"
+              <HelpTextWrapper__HelpTextContainer
+                className="yoast-help"
               >
-                <HelpTextWrapper__HelpTextButton
-                  aria-controls={null}
-                  aria-expanded={false}
-                  aria-label="Help on the Snippet Preview"
-                  className="yoast-help__button"
-                  onClick={[Function]}
+                <div
+                  className="yoast-help c0"
                 >
-                  <Button
+                  <HelpTextWrapper__HelpTextButton
                     aria-controls={null}
                     aria-expanded={false}
                     aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button c1"
+                    className="yoast-help__button"
                     onClick={[Function]}
                   >
                     <Button
                       aria-controls={null}
                       aria-expanded={false}
                       aria-label="Help on the Snippet Preview"
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="yoast-help__button c1 c2"
+                      className="yoast-help__button c1"
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         aria-controls={null}
@@ -4938,7 +4929,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2 Button-kDSBcD c3"
+                        className="yoast-help__button c1 c2"
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -4950,7 +4941,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -4962,55 +4953,57 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               aria-controls={null}
                               aria-expanded={false}
                               aria-label="Help on the Snippet Preview"
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
+                              <Button__BaseButton
                                 aria-controls={null}
                                 aria-expanded={false}
                                 aria-label="Help on the Snippet Preview"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <HelpTextWrapper__StyledSvg
-                                  color="#646464"
-                                  icon="question-circle"
-                                  size="16px"
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-label="Help on the Snippet Preview"
+                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon
-                                    className="c8"
+                                  <HelpTextWrapper__StyledSvg
                                     color="#646464"
                                     icon="question-circle"
                                     size="16px"
                                   >
-                                    <SvgIcon__StyledSvg
-                                      aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                      fill="#646464"
-                                      focusable="false"
-                                      role="img"
+                                    <SvgIcon
+                                      className="c8"
+                                      color="#646464"
+                                      icon="question-circle"
                                       size="16px"
-                                      viewBox="0 0 1792 1792"
-                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <svg
+                                      <SvgIcon__StyledSvg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
                                         fill="#646464"
                                         focusable="false"
                                         role="img"
@@ -5018,268 +5011,267 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                         viewBox="0 0 1792 1792"
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                        />
-                                      </svg>
-                                    </SvgIcon__StyledSvg>
-                                  </SvgIcon>
-                                </HelpTextWrapper__StyledSvg>
-                              </button>
-                            </Button__BaseButton>
+                                        <svg
+                                          aria-hidden={true}
+                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                          fill="#646464"
+                                          focusable="false"
+                                          role="img"
+                                          size="16px"
+                                          viewBox="0 0 1792 1792"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                          />
+                                        </svg>
+                                      </SvgIcon__StyledSvg>
+                                    </SvgIcon>
+                                  </HelpTextWrapper__StyledSvg>
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </HelpTextWrapper__HelpTextButton>
-                <YoastSlideToggle
-                  duration={300}
-                  isOpen={false}
-                >
-                  <animations__YoastSlideToggleContainer
+                  </HelpTextWrapper__HelpTextButton>
+                  <YoastSlideToggle
                     duration={300}
+                    isOpen={false}
                   >
-                    <div
-                      className="c10"
+                    <animations__YoastSlideToggleContainer
+                      duration={300}
                     >
-                      <CSSTransition
-                        classNames="slide"
-                        in={false}
-                        onEnter={[Function]}
-                        onEntered={[Function]}
-                        onEntering={[Function]}
-                        onExit={[Function]}
-                        onExiting={[Function]}
-                        timeout={300}
-                        unmountOnExit={true}
+                      <div
+                        className="c10"
                       >
-                        <Transition
-                          appear={false}
-                          enter={true}
-                          exit={true}
+                        <CSSTransition
+                          classNames="slide"
                           in={false}
-                          mountOnEnter={false}
                           onEnter={[Function]}
                           onEntered={[Function]}
                           onEntering={[Function]}
                           onExit={[Function]}
-                          onExited={[Function]}
                           onExiting={[Function]}
                           timeout={300}
                           unmountOnExit={true}
-                        />
-                      </CSSTransition>
-                    </div>
-                  </animations__YoastSlideToggleContainer>
-                </YoastSlideToggle>
-              </div>
-            </HelpTextWrapper__HelpTextContainer>
-          </HelpTextWrapper>
-        </div>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c11"
+                        >
+                          <Transition
+                            appear={false}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            timeout={300}
+                            unmountOnExit={true}
+                          />
+                        </CSSTransition>
+                      </div>
+                    </animations__YoastSlideToggleContainer>
+                  </YoastSlideToggle>
+                </div>
+              </HelpTextWrapper__HelpTextContainer>
+            </HelpTextWrapper>
+          </div>
+          <SnippetPreview__MobileContainer
+            padding={20}
             width={640}
           >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    SEO title preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseTitle
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+            <div
+              className="c11"
+              width={640}
+            >
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <div
-                    className="c13"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      SEO title preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseTitle
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c14"
-                      >
-                        <div
-                          className="c14 c15"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c16"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Url preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseUrl>
-                  <div
-                    className="c17"
-                  >
-                    <SnippetPreview__BaseUrlOverflowContainer
+                    <div
+                      className="c13"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <div
-                        className="c18"
+                      <SnippetPreview__TitleBounded>
+                        <SnippetPreview__Title
+                          className="c14"
+                        >
+                          <div
+                            className="c14 c15"
+                          >
+                            <SnippetPreview__TitleUnboundedMobile
+                              innerRef={[Function]}
+                            >
+                              <span
+                                className="c16"
+                              >
+                                Test title
+                              </span>
+                            </SnippetPreview__TitleUnboundedMobile>
+                          </div>
+                        </SnippetPreview__Title>
+                      </SnippetPreview__TitleBounded>
+                    </div>
+                  </SnippetPreview__BaseTitle>
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Url preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseUrl>
+                    <div
+                      className="c17"
+                    >
+                      <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
-                        example.org › test-slug
-                      </div>
-                    </SnippetPreview__BaseUrlOverflowContainer>
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c19"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Meta description preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__MobileDescription
-                  isDescriptionPlaceholder={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+                        <div
+                          className="c18"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrlOverflowContainer>
+                    </div>
+                  </SnippetPreview__BaseUrl>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+              <SnippetPreview__Separator>
+                <hr
+                  className="c19"
+                />
+              </SnippetPreview__Separator>
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <SnippetPreview__DesktopDescription
-                    className="c20"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Meta description preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__MobileDescription
                     isDescriptionPlaceholder={false}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <div
-                      className="c20 c21"
+                    <SnippetPreview__DesktopDescription
+                      className="c20"
+                      isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <SnippetPreview__MobileDescription
-                        innerRef={[Function]}
-                        isDescriptionPlaceholder={false}
+                      <div
+                        className="c20 c21"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
                       >
-                        <SnippetPreview__DesktopDescription
-                          className="c20"
+                        <SnippetPreview__MobileDescription
                           innerRef={[Function]}
                           isDescriptionPlaceholder={false}
                         >
-                          <div
-                            className="c20 c21"
+                          <SnippetPreview__DesktopDescription
+                            className="c20"
+                            innerRef={[Function]}
+                            isDescriptionPlaceholder={false}
                           >
-                            Test description, %%replacement_variable%%
-                          </div>
-                        </SnippetPreview__DesktopDescription>
-                      </SnippetPreview__MobileDescription>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c22"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
+                            <div
+                              className="c20 c21"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </div>
+                    </SnippetPreview__DesktopDescription>
+                  </SnippetPreview__MobileDescription>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+            </div>
+          </SnippetPreview__MobileContainer>
+        </section>
+      </SnippetPreview>
+      <ModeSwitcher
+        active="mobile"
+        onChange={[Function]}
+      >
+        <ModeSwitcher__Switcher>
+          <div
+            className="c22"
           >
-            <Button
+            <ModeSwitcher__SwitcherButton
               aria-pressed={true}
-              className="c23"
               isActive={true}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c23 c2"
+                className="c23"
                 isActive={true}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={true}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2 Button-kDSBcD c3"
+                  className="c23 c2"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -5290,7 +5282,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c23 c2 Button-kDSBcD c3"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -5301,47 +5293,48 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={true}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={true}
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={true}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
+                          <button
+                            aria-pressed={true}
+                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="mobile"
                               size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                className="yoast-svg-icon yoast-svg-icon-mobile"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -5349,64 +5342,63 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="22px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Mobile preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Mobile preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
+            </ModeSwitcher__SwitcherButton>
+            <ModeSwitcher__SwitcherButton
               aria-pressed={false}
-              className="c25"
               isActive={false}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c25"
                 isActive={false}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={false}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c25 c2"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -5417,7 +5409,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c25 c2 Button-kDSBcD c3"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -5428,47 +5420,48 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={false}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={false}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={false}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
+                          <button
+                            aria-pressed={false}
+                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="desktop"
                               size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                className="yoast-svg-icon yoast-svg-icon-desktop"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -5476,61 +5469,60 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="18px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Desktop preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Desktop preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
+            </ModeSwitcher__SwitcherButton>
+          </div>
+        </ModeSwitcher__Switcher>
+      </ModeSwitcher>
       <Button
         aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c27"
         innerRef={[Function]}
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           aria-expanded={true}
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c3"
+          className="c27"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -5541,7 +5533,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c27 Button-kDSBcD c3"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -5552,97 +5544,107 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 aria-expanded={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
+                <Button__BaseButton
                   aria-expanded={true}
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  innerRef={[Function]}
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
+                  <button
+                    aria-expanded={true}
+                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
+                    <SvgIcon
+                      icon="edit"
                       size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
+                      <SvgIcon__StyledSvg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c9"
+                        className="yoast-svg-icon yoast-svg-icon-edit"
                         focusable="false"
                         role="img"
                         size="16px"
                         viewBox="0 0 1792 1792"
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  Edit snippet
-                </button>
-              </Button__BaseButton>
+                        <svg
+                          aria-hidden={true}
+                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          focusable="false"
+                          role="img"
+                          size="16px"
+                          viewBox="0 0 1792 1792"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                          />
+                        </svg>
+                      </SvgIcon__StyledSvg>
+                    </SvgIcon>
+                    Edit snippet
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
+      <SnippetEditorFields
+        activeField={null}
+        data={
+          Object {
+            "description": "Test description, %%replacement_variable%%",
+            "slug": "test-slug",
+            "title": "Test title",
+          }
         }
-      }
-      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-      descriptionLengthProgress={
-        Object {
-          "actual": 42,
-          "max": 156,
-          "score": 6,
+        descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+        descriptionLengthProgress={
+          Object {
+            "actual": 42,
+            "max": 156,
+            "score": 6,
+          }
         }
-      }
-      hoveredField={null}
-      mobileWidth={356}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthProgress={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 1,
+        hoveredField={null}
+        mobileWidth={356}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        replacementVariables={Array []}
+        titleLengthProgress={
+          Object {
+            "actual": 0,
+            "max": 600,
+            "score": 1,
+          }
         }
-      }
-    >
-      <ErrorBoundary>
+      >
         <Shared__StyledEditor
           innerRef={[Function]}
         >
@@ -6040,25 +6042,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             </Shared__FormSection>
           </section>
         </Shared__StyledEditor>
-      </ErrorBoundary>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
+      </SnippetEditorFields>
       <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c38"
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c38"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -6067,7 +6059,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -6076,34 +6068,44 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                <Button__BaseButton
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  Close snippet editor
-                </button>
-              </Button__BaseButton>
+                  <button
+                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Close snippet editor
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-  </div>
+    </div>
+  </ErrorBoundary>
 </SnippetEditor>
 `;
 
@@ -6693,72 +6695,61 @@ exports[`SnippetEditor closes when calling close() 1`] = `
     }
   }
 >
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      keyword=""
-      locale="en"
-      mode="mobile"
-      onHover={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <div>
-          <HelpTextWrapper
-            className="yoast-help"
-            helpText={
-              Array [
-                "This is a rendering of what this post might look like in Google's search results. ",
-                <OutboundLink
-                  href="https://yoa.st/snippet-preview"
-                >
-                  Learn more about the Snippet Preview.
-                </OutboundLink>,
-              ]
-            }
-            helpTextButtonLabel="Help on the Snippet Preview"
-            panelMaxWidth="400px"
-          >
-            <HelpTextWrapper__HelpTextContainer
+  <ErrorBoundary>
+    <div>
+      <SnippetPreview
+        activeField={null}
+        breadcrumbs={null}
+        date=""
+        description="Test description, %%replacement_variable%%"
+        hoveredField={null}
+        isAmp={false}
+        keyword=""
+        locale="en"
+        mode="mobile"
+        onHover={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        title="Test title"
+        url="example.org/test-slug"
+      >
+        <section>
+          <div>
+            <HelpTextWrapper
               className="yoast-help"
+              helpText={
+                Array [
+                  "This is a rendering of what this post might look like in Google's search results. ",
+                  <OutboundLink
+                    href="https://yoa.st/snippet-preview"
+                  >
+                    Learn more about the Snippet Preview.
+                  </OutboundLink>,
+                ]
+              }
+              helpTextButtonLabel="Help on the Snippet Preview"
+              panelMaxWidth="400px"
             >
-              <div
-                className="yoast-help c0"
+              <HelpTextWrapper__HelpTextContainer
+                className="yoast-help"
               >
-                <HelpTextWrapper__HelpTextButton
-                  aria-controls={null}
-                  aria-expanded={false}
-                  aria-label="Help on the Snippet Preview"
-                  className="yoast-help__button"
-                  onClick={[Function]}
+                <div
+                  className="yoast-help c0"
                 >
-                  <Button
+                  <HelpTextWrapper__HelpTextButton
                     aria-controls={null}
                     aria-expanded={false}
                     aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button c1"
+                    className="yoast-help__button"
                     onClick={[Function]}
                   >
                     <Button
                       aria-controls={null}
                       aria-expanded={false}
                       aria-label="Help on the Snippet Preview"
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="yoast-help__button c1 c2"
+                      className="yoast-help__button c1"
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         aria-controls={null}
@@ -6767,7 +6758,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2 Button-kDSBcD c3"
+                        className="yoast-help__button c1 c2"
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -6779,7 +6770,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -6791,55 +6782,57 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               aria-controls={null}
                               aria-expanded={false}
                               aria-label="Help on the Snippet Preview"
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
+                              <Button__BaseButton
                                 aria-controls={null}
                                 aria-expanded={false}
                                 aria-label="Help on the Snippet Preview"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <HelpTextWrapper__StyledSvg
-                                  color="#646464"
-                                  icon="question-circle"
-                                  size="16px"
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-label="Help on the Snippet Preview"
+                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon
-                                    className="c8"
+                                  <HelpTextWrapper__StyledSvg
                                     color="#646464"
                                     icon="question-circle"
                                     size="16px"
                                   >
-                                    <SvgIcon__StyledSvg
-                                      aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                      fill="#646464"
-                                      focusable="false"
-                                      role="img"
+                                    <SvgIcon
+                                      className="c8"
+                                      color="#646464"
+                                      icon="question-circle"
                                       size="16px"
-                                      viewBox="0 0 1792 1792"
-                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <svg
+                                      <SvgIcon__StyledSvg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
                                         fill="#646464"
                                         focusable="false"
                                         role="img"
@@ -6847,268 +6840,267 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                         viewBox="0 0 1792 1792"
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                        />
-                                      </svg>
-                                    </SvgIcon__StyledSvg>
-                                  </SvgIcon>
-                                </HelpTextWrapper__StyledSvg>
-                              </button>
-                            </Button__BaseButton>
+                                        <svg
+                                          aria-hidden={true}
+                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                          fill="#646464"
+                                          focusable="false"
+                                          role="img"
+                                          size="16px"
+                                          viewBox="0 0 1792 1792"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                          />
+                                        </svg>
+                                      </SvgIcon__StyledSvg>
+                                    </SvgIcon>
+                                  </HelpTextWrapper__StyledSvg>
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </HelpTextWrapper__HelpTextButton>
-                <YoastSlideToggle
-                  duration={300}
-                  isOpen={false}
-                >
-                  <animations__YoastSlideToggleContainer
+                  </HelpTextWrapper__HelpTextButton>
+                  <YoastSlideToggle
                     duration={300}
+                    isOpen={false}
                   >
-                    <div
-                      className="c10"
+                    <animations__YoastSlideToggleContainer
+                      duration={300}
                     >
-                      <CSSTransition
-                        classNames="slide"
-                        in={false}
-                        onEnter={[Function]}
-                        onEntered={[Function]}
-                        onEntering={[Function]}
-                        onExit={[Function]}
-                        onExiting={[Function]}
-                        timeout={300}
-                        unmountOnExit={true}
+                      <div
+                        className="c10"
                       >
-                        <Transition
-                          appear={false}
-                          enter={true}
-                          exit={true}
+                        <CSSTransition
+                          classNames="slide"
                           in={false}
-                          mountOnEnter={false}
                           onEnter={[Function]}
                           onEntered={[Function]}
                           onEntering={[Function]}
                           onExit={[Function]}
-                          onExited={[Function]}
                           onExiting={[Function]}
                           timeout={300}
                           unmountOnExit={true}
-                        />
-                      </CSSTransition>
-                    </div>
-                  </animations__YoastSlideToggleContainer>
-                </YoastSlideToggle>
-              </div>
-            </HelpTextWrapper__HelpTextContainer>
-          </HelpTextWrapper>
-        </div>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c11"
+                        >
+                          <Transition
+                            appear={false}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            timeout={300}
+                            unmountOnExit={true}
+                          />
+                        </CSSTransition>
+                      </div>
+                    </animations__YoastSlideToggleContainer>
+                  </YoastSlideToggle>
+                </div>
+              </HelpTextWrapper__HelpTextContainer>
+            </HelpTextWrapper>
+          </div>
+          <SnippetPreview__MobileContainer
+            padding={20}
             width={640}
           >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    SEO title preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseTitle
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+            <div
+              className="c11"
+              width={640}
+            >
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <div
-                    className="c13"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      SEO title preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseTitle
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c14"
-                      >
-                        <div
-                          className="c14 c15"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c16"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Url preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseUrl>
-                  <div
-                    className="c17"
-                  >
-                    <SnippetPreview__BaseUrlOverflowContainer
+                    <div
+                      className="c13"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <div
-                        className="c18"
+                      <SnippetPreview__TitleBounded>
+                        <SnippetPreview__Title
+                          className="c14"
+                        >
+                          <div
+                            className="c14 c15"
+                          >
+                            <SnippetPreview__TitleUnboundedMobile
+                              innerRef={[Function]}
+                            >
+                              <span
+                                className="c16"
+                              >
+                                Test title
+                              </span>
+                            </SnippetPreview__TitleUnboundedMobile>
+                          </div>
+                        </SnippetPreview__Title>
+                      </SnippetPreview__TitleBounded>
+                    </div>
+                  </SnippetPreview__BaseTitle>
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Url preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseUrl>
+                    <div
+                      className="c17"
+                    >
+                      <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
-                        example.org › test-slug
-                      </div>
-                    </SnippetPreview__BaseUrlOverflowContainer>
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c19"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Meta description preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__MobileDescription
-                  isDescriptionPlaceholder={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+                        <div
+                          className="c18"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrlOverflowContainer>
+                    </div>
+                  </SnippetPreview__BaseUrl>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+              <SnippetPreview__Separator>
+                <hr
+                  className="c19"
+                />
+              </SnippetPreview__Separator>
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <SnippetPreview__DesktopDescription
-                    className="c20"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Meta description preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__MobileDescription
                     isDescriptionPlaceholder={false}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <div
-                      className="c20 c21"
+                    <SnippetPreview__DesktopDescription
+                      className="c20"
+                      isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <SnippetPreview__MobileDescription
-                        innerRef={[Function]}
-                        isDescriptionPlaceholder={false}
+                      <div
+                        className="c20 c21"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
                       >
-                        <SnippetPreview__DesktopDescription
-                          className="c20"
+                        <SnippetPreview__MobileDescription
                           innerRef={[Function]}
                           isDescriptionPlaceholder={false}
                         >
-                          <div
-                            className="c20 c21"
+                          <SnippetPreview__DesktopDescription
+                            className="c20"
+                            innerRef={[Function]}
+                            isDescriptionPlaceholder={false}
                           >
-                            Test description, %%replacement_variable%%
-                          </div>
-                        </SnippetPreview__DesktopDescription>
-                      </SnippetPreview__MobileDescription>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c22"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
+                            <div
+                              className="c20 c21"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </div>
+                    </SnippetPreview__DesktopDescription>
+                  </SnippetPreview__MobileDescription>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+            </div>
+          </SnippetPreview__MobileContainer>
+        </section>
+      </SnippetPreview>
+      <ModeSwitcher
+        active="mobile"
+        onChange={[Function]}
+      >
+        <ModeSwitcher__Switcher>
+          <div
+            className="c22"
           >
-            <Button
+            <ModeSwitcher__SwitcherButton
               aria-pressed={true}
-              className="c23"
               isActive={true}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c23 c2"
+                className="c23"
                 isActive={true}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={true}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2 Button-kDSBcD c3"
+                  className="c23 c2"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -7119,7 +7111,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c23 c2 Button-kDSBcD c3"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -7130,47 +7122,48 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={true}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={true}
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={true}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
+                          <button
+                            aria-pressed={true}
+                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="mobile"
                               size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                className="yoast-svg-icon yoast-svg-icon-mobile"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -7178,64 +7171,63 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="22px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Mobile preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Mobile preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
+            </ModeSwitcher__SwitcherButton>
+            <ModeSwitcher__SwitcherButton
               aria-pressed={false}
-              className="c25"
               isActive={false}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c25"
                 isActive={false}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={false}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c25 c2"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -7246,7 +7238,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c25 c2 Button-kDSBcD c3"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -7257,47 +7249,48 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={false}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={false}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={false}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
+                          <button
+                            aria-pressed={false}
+                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="desktop"
                               size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                className="yoast-svg-icon yoast-svg-icon-desktop"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -7305,61 +7298,60 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="18px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Desktop preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Desktop preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
+            </ModeSwitcher__SwitcherButton>
+          </div>
+        </ModeSwitcher__Switcher>
+      </ModeSwitcher>
       <Button
         aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c27"
         innerRef={[Function]}
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           aria-expanded={true}
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c3"
+          className="c27"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -7370,7 +7362,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c27 Button-kDSBcD c3"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -7381,97 +7373,107 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 aria-expanded={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
+                <Button__BaseButton
                   aria-expanded={true}
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  innerRef={[Function]}
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
+                  <button
+                    aria-expanded={true}
+                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
+                    <SvgIcon
+                      icon="edit"
                       size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
+                      <SvgIcon__StyledSvg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c9"
+                        className="yoast-svg-icon yoast-svg-icon-edit"
                         focusable="false"
                         role="img"
                         size="16px"
                         viewBox="0 0 1792 1792"
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  Edit snippet
-                </button>
-              </Button__BaseButton>
+                        <svg
+                          aria-hidden={true}
+                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          focusable="false"
+                          role="img"
+                          size="16px"
+                          viewBox="0 0 1792 1792"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                          />
+                        </svg>
+                      </SvgIcon__StyledSvg>
+                    </SvgIcon>
+                    Edit snippet
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
+      <SnippetEditorFields
+        activeField={null}
+        data={
+          Object {
+            "description": "Test description, %%replacement_variable%%",
+            "slug": "test-slug",
+            "title": "Test title",
+          }
         }
-      }
-      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-      descriptionLengthProgress={
-        Object {
-          "actual": 42,
-          "max": 156,
-          "score": 6,
+        descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+        descriptionLengthProgress={
+          Object {
+            "actual": 42,
+            "max": 156,
+            "score": 6,
+          }
         }
-      }
-      hoveredField={null}
-      mobileWidth={356}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthProgress={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 1,
+        hoveredField={null}
+        mobileWidth={356}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        replacementVariables={Array []}
+        titleLengthProgress={
+          Object {
+            "actual": 0,
+            "max": 600,
+            "score": 1,
+          }
         }
-      }
-    >
-      <ErrorBoundary>
+      >
         <Shared__StyledEditor
           innerRef={[Function]}
         >
@@ -7869,25 +7871,15 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             </Shared__FormSection>
           </section>
         </Shared__StyledEditor>
-      </ErrorBoundary>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
+      </SnippetEditorFields>
       <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c38"
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c38"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -7896,7 +7888,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -7905,34 +7897,44 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                <Button__BaseButton
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  Close snippet editor
-                </button>
-              </Button__BaseButton>
+                  <button
+                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Close snippet editor
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-  </div>
+    </div>
+  </ErrorBoundary>
 </SnippetEditor>
 `;
 
@@ -8305,72 +8307,61 @@ exports[`SnippetEditor closes when calling close() 2`] = `
     }
   }
 >
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      keyword=""
-      locale="en"
-      mode="mobile"
-      onHover={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <div>
-          <HelpTextWrapper
-            className="yoast-help"
-            helpText={
-              Array [
-                "This is a rendering of what this post might look like in Google's search results. ",
-                <OutboundLink
-                  href="https://yoa.st/snippet-preview"
-                >
-                  Learn more about the Snippet Preview.
-                </OutboundLink>,
-              ]
-            }
-            helpTextButtonLabel="Help on the Snippet Preview"
-            panelMaxWidth="400px"
-          >
-            <HelpTextWrapper__HelpTextContainer
+  <ErrorBoundary>
+    <div>
+      <SnippetPreview
+        activeField={null}
+        breadcrumbs={null}
+        date=""
+        description="Test description, %%replacement_variable%%"
+        hoveredField={null}
+        isAmp={false}
+        keyword=""
+        locale="en"
+        mode="mobile"
+        onHover={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        title="Test title"
+        url="example.org/test-slug"
+      >
+        <section>
+          <div>
+            <HelpTextWrapper
               className="yoast-help"
+              helpText={
+                Array [
+                  "This is a rendering of what this post might look like in Google's search results. ",
+                  <OutboundLink
+                    href="https://yoa.st/snippet-preview"
+                  >
+                    Learn more about the Snippet Preview.
+                  </OutboundLink>,
+                ]
+              }
+              helpTextButtonLabel="Help on the Snippet Preview"
+              panelMaxWidth="400px"
             >
-              <div
-                className="yoast-help c0"
+              <HelpTextWrapper__HelpTextContainer
+                className="yoast-help"
               >
-                <HelpTextWrapper__HelpTextButton
-                  aria-controls={null}
-                  aria-expanded={false}
-                  aria-label="Help on the Snippet Preview"
-                  className="yoast-help__button"
-                  onClick={[Function]}
+                <div
+                  className="yoast-help c0"
                 >
-                  <Button
+                  <HelpTextWrapper__HelpTextButton
                     aria-controls={null}
                     aria-expanded={false}
                     aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button c1"
+                    className="yoast-help__button"
                     onClick={[Function]}
                   >
                     <Button
                       aria-controls={null}
                       aria-expanded={false}
                       aria-label="Help on the Snippet Preview"
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="yoast-help__button c1 c2"
+                      className="yoast-help__button c1"
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         aria-controls={null}
@@ -8379,7 +8370,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2 Button-kDSBcD c3"
+                        className="yoast-help__button c1 c2"
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -8391,7 +8382,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -8403,55 +8394,57 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               aria-controls={null}
                               aria-expanded={false}
                               aria-label="Help on the Snippet Preview"
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
+                              <Button__BaseButton
                                 aria-controls={null}
                                 aria-expanded={false}
                                 aria-label="Help on the Snippet Preview"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <HelpTextWrapper__StyledSvg
-                                  color="#646464"
-                                  icon="question-circle"
-                                  size="16px"
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-label="Help on the Snippet Preview"
+                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon
-                                    className="c8"
+                                  <HelpTextWrapper__StyledSvg
                                     color="#646464"
                                     icon="question-circle"
                                     size="16px"
                                   >
-                                    <SvgIcon__StyledSvg
-                                      aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                      fill="#646464"
-                                      focusable="false"
-                                      role="img"
+                                    <SvgIcon
+                                      className="c8"
+                                      color="#646464"
+                                      icon="question-circle"
                                       size="16px"
-                                      viewBox="0 0 1792 1792"
-                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <svg
+                                      <SvgIcon__StyledSvg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
                                         fill="#646464"
                                         focusable="false"
                                         role="img"
@@ -8459,268 +8452,267 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                                         viewBox="0 0 1792 1792"
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                        />
-                                      </svg>
-                                    </SvgIcon__StyledSvg>
-                                  </SvgIcon>
-                                </HelpTextWrapper__StyledSvg>
-                              </button>
-                            </Button__BaseButton>
+                                        <svg
+                                          aria-hidden={true}
+                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                          fill="#646464"
+                                          focusable="false"
+                                          role="img"
+                                          size="16px"
+                                          viewBox="0 0 1792 1792"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                          />
+                                        </svg>
+                                      </SvgIcon__StyledSvg>
+                                    </SvgIcon>
+                                  </HelpTextWrapper__StyledSvg>
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </HelpTextWrapper__HelpTextButton>
-                <YoastSlideToggle
-                  duration={300}
-                  isOpen={false}
-                >
-                  <animations__YoastSlideToggleContainer
+                  </HelpTextWrapper__HelpTextButton>
+                  <YoastSlideToggle
                     duration={300}
+                    isOpen={false}
                   >
-                    <div
-                      className="c10"
+                    <animations__YoastSlideToggleContainer
+                      duration={300}
                     >
-                      <CSSTransition
-                        classNames="slide"
-                        in={false}
-                        onEnter={[Function]}
-                        onEntered={[Function]}
-                        onEntering={[Function]}
-                        onExit={[Function]}
-                        onExiting={[Function]}
-                        timeout={300}
-                        unmountOnExit={true}
+                      <div
+                        className="c10"
                       >
-                        <Transition
-                          appear={false}
-                          enter={true}
-                          exit={true}
+                        <CSSTransition
+                          classNames="slide"
                           in={false}
-                          mountOnEnter={false}
                           onEnter={[Function]}
                           onEntered={[Function]}
                           onEntering={[Function]}
                           onExit={[Function]}
-                          onExited={[Function]}
                           onExiting={[Function]}
                           timeout={300}
                           unmountOnExit={true}
-                        />
-                      </CSSTransition>
-                    </div>
-                  </animations__YoastSlideToggleContainer>
-                </YoastSlideToggle>
-              </div>
-            </HelpTextWrapper__HelpTextContainer>
-          </HelpTextWrapper>
-        </div>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c11"
+                        >
+                          <Transition
+                            appear={false}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            timeout={300}
+                            unmountOnExit={true}
+                          />
+                        </CSSTransition>
+                      </div>
+                    </animations__YoastSlideToggleContainer>
+                  </YoastSlideToggle>
+                </div>
+              </HelpTextWrapper__HelpTextContainer>
+            </HelpTextWrapper>
+          </div>
+          <SnippetPreview__MobileContainer
+            padding={20}
             width={640}
           >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    SEO title preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseTitle
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+            <div
+              className="c11"
+              width={640}
+            >
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <div
-                    className="c13"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      SEO title preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseTitle
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c14"
-                      >
-                        <div
-                          className="c14 c15"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c16"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Url preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseUrl>
-                  <div
-                    className="c17"
-                  >
-                    <SnippetPreview__BaseUrlOverflowContainer
+                    <div
+                      className="c13"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <div
-                        className="c18"
+                      <SnippetPreview__TitleBounded>
+                        <SnippetPreview__Title
+                          className="c14"
+                        >
+                          <div
+                            className="c14 c15"
+                          >
+                            <SnippetPreview__TitleUnboundedMobile
+                              innerRef={[Function]}
+                            >
+                              <span
+                                className="c16"
+                              >
+                                Test title
+                              </span>
+                            </SnippetPreview__TitleUnboundedMobile>
+                          </div>
+                        </SnippetPreview__Title>
+                      </SnippetPreview__TitleBounded>
+                    </div>
+                  </SnippetPreview__BaseTitle>
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Url preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseUrl>
+                    <div
+                      className="c17"
+                    >
+                      <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
-                        example.org › test-slug
-                      </div>
-                    </SnippetPreview__BaseUrlOverflowContainer>
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c19"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Meta description preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__MobileDescription
-                  isDescriptionPlaceholder={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+                        <div
+                          className="c18"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrlOverflowContainer>
+                    </div>
+                  </SnippetPreview__BaseUrl>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+              <SnippetPreview__Separator>
+                <hr
+                  className="c19"
+                />
+              </SnippetPreview__Separator>
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <SnippetPreview__DesktopDescription
-                    className="c20"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Meta description preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__MobileDescription
                     isDescriptionPlaceholder={false}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <div
-                      className="c20 c21"
+                    <SnippetPreview__DesktopDescription
+                      className="c20"
+                      isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <SnippetPreview__MobileDescription
-                        innerRef={[Function]}
-                        isDescriptionPlaceholder={false}
+                      <div
+                        className="c20 c21"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
                       >
-                        <SnippetPreview__DesktopDescription
-                          className="c20"
+                        <SnippetPreview__MobileDescription
                           innerRef={[Function]}
                           isDescriptionPlaceholder={false}
                         >
-                          <div
-                            className="c20 c21"
+                          <SnippetPreview__DesktopDescription
+                            className="c20"
+                            innerRef={[Function]}
+                            isDescriptionPlaceholder={false}
                           >
-                            Test description, %%replacement_variable%%
-                          </div>
-                        </SnippetPreview__DesktopDescription>
-                      </SnippetPreview__MobileDescription>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c22"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
+                            <div
+                              className="c20 c21"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </div>
+                    </SnippetPreview__DesktopDescription>
+                  </SnippetPreview__MobileDescription>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+            </div>
+          </SnippetPreview__MobileContainer>
+        </section>
+      </SnippetPreview>
+      <ModeSwitcher
+        active="mobile"
+        onChange={[Function]}
+      >
+        <ModeSwitcher__Switcher>
+          <div
+            className="c22"
           >
-            <Button
+            <ModeSwitcher__SwitcherButton
               aria-pressed={true}
-              className="c23"
               isActive={true}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c23 c2"
+                className="c23"
                 isActive={true}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={true}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2 Button-kDSBcD c3"
+                  className="c23 c2"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -8731,7 +8723,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c23 c2 Button-kDSBcD c3"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -8742,47 +8734,48 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={true}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={true}
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={true}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
+                          <button
+                            aria-pressed={true}
+                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="mobile"
                               size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                className="yoast-svg-icon yoast-svg-icon-mobile"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -8790,64 +8783,63 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="22px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Mobile preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Mobile preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
+            </ModeSwitcher__SwitcherButton>
+            <ModeSwitcher__SwitcherButton
               aria-pressed={false}
-              className="c25"
               isActive={false}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c25"
                 isActive={false}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={false}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c25 c2"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -8858,7 +8850,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c25 c2 Button-kDSBcD c3"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -8869,47 +8861,48 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={false}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={false}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={false}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
+                          <button
+                            aria-pressed={false}
+                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="desktop"
                               size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                className="yoast-svg-icon yoast-svg-icon-desktop"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -8917,61 +8910,60 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="18px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Desktop preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Desktop preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={false}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
+            </ModeSwitcher__SwitcherButton>
+          </div>
+        </ModeSwitcher__Switcher>
+      </ModeSwitcher>
       <Button
         aria-expanded={false}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c27"
         innerRef={[Function]}
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           aria-expanded={false}
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c3"
+          className="c27"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -8982,7 +8974,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c27 Button-kDSBcD c3"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -8993,66 +8985,78 @@ exports[`SnippetEditor closes when calling close() 2`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 aria-expanded={false}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
+                <Button__BaseButton
                   aria-expanded={false}
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  innerRef={[Function]}
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
+                  <button
+                    aria-expanded={false}
+                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
+                    <SvgIcon
+                      icon="edit"
                       size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
+                      <SvgIcon__StyledSvg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c9"
+                        className="yoast-svg-icon yoast-svg-icon-edit"
                         focusable="false"
                         role="img"
                         size="16px"
                         viewBox="0 0 1792 1792"
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  Edit snippet
-                </button>
-              </Button__BaseButton>
+                        <svg
+                          aria-hidden={true}
+                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          focusable="false"
+                          role="img"
+                          size="16px"
+                          viewBox="0 0 1792 1792"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                          />
+                        </svg>
+                      </SvgIcon__StyledSvg>
+                    </SvgIcon>
+                    Edit snippet
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-  </div>
+    </div>
+  </ErrorBoundary>
 </SnippetEditor>
 `;
 
@@ -9642,72 +9646,61 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
     }
   }
 >
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      keyword=""
-      locale="en"
-      mode="mobile"
-      onHover={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <div>
-          <HelpTextWrapper
-            className="yoast-help"
-            helpText={
-              Array [
-                "This is a rendering of what this post might look like in Google's search results. ",
-                <OutboundLink
-                  href="https://yoa.st/snippet-preview"
-                >
-                  Learn more about the Snippet Preview.
-                </OutboundLink>,
-              ]
-            }
-            helpTextButtonLabel="Help on the Snippet Preview"
-            panelMaxWidth="400px"
-          >
-            <HelpTextWrapper__HelpTextContainer
+  <ErrorBoundary>
+    <div>
+      <SnippetPreview
+        activeField={null}
+        breadcrumbs={null}
+        date=""
+        description="Test description, %%replacement_variable%%"
+        hoveredField={null}
+        isAmp={false}
+        keyword=""
+        locale="en"
+        mode="mobile"
+        onHover={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        title="Test title"
+        url="example.org/test-slug"
+      >
+        <section>
+          <div>
+            <HelpTextWrapper
               className="yoast-help"
+              helpText={
+                Array [
+                  "This is a rendering of what this post might look like in Google's search results. ",
+                  <OutboundLink
+                    href="https://yoa.st/snippet-preview"
+                  >
+                    Learn more about the Snippet Preview.
+                  </OutboundLink>,
+                ]
+              }
+              helpTextButtonLabel="Help on the Snippet Preview"
+              panelMaxWidth="400px"
             >
-              <div
-                className="yoast-help c0"
+              <HelpTextWrapper__HelpTextContainer
+                className="yoast-help"
               >
-                <HelpTextWrapper__HelpTextButton
-                  aria-controls={null}
-                  aria-expanded={false}
-                  aria-label="Help on the Snippet Preview"
-                  className="yoast-help__button"
-                  onClick={[Function]}
+                <div
+                  className="yoast-help c0"
                 >
-                  <Button
+                  <HelpTextWrapper__HelpTextButton
                     aria-controls={null}
                     aria-expanded={false}
                     aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button c1"
+                    className="yoast-help__button"
                     onClick={[Function]}
                   >
                     <Button
                       aria-controls={null}
                       aria-expanded={false}
                       aria-label="Help on the Snippet Preview"
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="yoast-help__button c1 c2"
+                      className="yoast-help__button c1"
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         aria-controls={null}
@@ -9716,7 +9709,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2 Button-kDSBcD c3"
+                        className="yoast-help__button c1 c2"
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -9728,7 +9721,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -9740,55 +9733,57 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               aria-controls={null}
                               aria-expanded={false}
                               aria-label="Help on the Snippet Preview"
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
+                              <Button__BaseButton
                                 aria-controls={null}
                                 aria-expanded={false}
                                 aria-label="Help on the Snippet Preview"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <HelpTextWrapper__StyledSvg
-                                  color="#646464"
-                                  icon="question-circle"
-                                  size="16px"
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-label="Help on the Snippet Preview"
+                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon
-                                    className="c8"
+                                  <HelpTextWrapper__StyledSvg
                                     color="#646464"
                                     icon="question-circle"
                                     size="16px"
                                   >
-                                    <SvgIcon__StyledSvg
-                                      aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                      fill="#646464"
-                                      focusable="false"
-                                      role="img"
+                                    <SvgIcon
+                                      className="c8"
+                                      color="#646464"
+                                      icon="question-circle"
                                       size="16px"
-                                      viewBox="0 0 1792 1792"
-                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <svg
+                                      <SvgIcon__StyledSvg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
                                         fill="#646464"
                                         focusable="false"
                                         role="img"
@@ -9796,268 +9791,267 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                         viewBox="0 0 1792 1792"
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                        />
-                                      </svg>
-                                    </SvgIcon__StyledSvg>
-                                  </SvgIcon>
-                                </HelpTextWrapper__StyledSvg>
-                              </button>
-                            </Button__BaseButton>
+                                        <svg
+                                          aria-hidden={true}
+                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                          fill="#646464"
+                                          focusable="false"
+                                          role="img"
+                                          size="16px"
+                                          viewBox="0 0 1792 1792"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                          />
+                                        </svg>
+                                      </SvgIcon__StyledSvg>
+                                    </SvgIcon>
+                                  </HelpTextWrapper__StyledSvg>
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </HelpTextWrapper__HelpTextButton>
-                <YoastSlideToggle
-                  duration={300}
-                  isOpen={false}
-                >
-                  <animations__YoastSlideToggleContainer
+                  </HelpTextWrapper__HelpTextButton>
+                  <YoastSlideToggle
                     duration={300}
+                    isOpen={false}
                   >
-                    <div
-                      className="c10"
+                    <animations__YoastSlideToggleContainer
+                      duration={300}
                     >
-                      <CSSTransition
-                        classNames="slide"
-                        in={false}
-                        onEnter={[Function]}
-                        onEntered={[Function]}
-                        onEntering={[Function]}
-                        onExit={[Function]}
-                        onExiting={[Function]}
-                        timeout={300}
-                        unmountOnExit={true}
+                      <div
+                        className="c10"
                       >
-                        <Transition
-                          appear={false}
-                          enter={true}
-                          exit={true}
+                        <CSSTransition
+                          classNames="slide"
                           in={false}
-                          mountOnEnter={false}
                           onEnter={[Function]}
                           onEntered={[Function]}
                           onEntering={[Function]}
                           onExit={[Function]}
-                          onExited={[Function]}
                           onExiting={[Function]}
                           timeout={300}
                           unmountOnExit={true}
-                        />
-                      </CSSTransition>
-                    </div>
-                  </animations__YoastSlideToggleContainer>
-                </YoastSlideToggle>
-              </div>
-            </HelpTextWrapper__HelpTextContainer>
-          </HelpTextWrapper>
-        </div>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c11"
+                        >
+                          <Transition
+                            appear={false}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            timeout={300}
+                            unmountOnExit={true}
+                          />
+                        </CSSTransition>
+                      </div>
+                    </animations__YoastSlideToggleContainer>
+                  </YoastSlideToggle>
+                </div>
+              </HelpTextWrapper__HelpTextContainer>
+            </HelpTextWrapper>
+          </div>
+          <SnippetPreview__MobileContainer
+            padding={20}
             width={640}
           >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    SEO title preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseTitle
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+            <div
+              className="c11"
+              width={640}
+            >
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <div
-                    className="c13"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      SEO title preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseTitle
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c14"
-                      >
-                        <div
-                          className="c14 c15"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c16"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Url preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseUrl>
-                  <div
-                    className="c17"
-                  >
-                    <SnippetPreview__BaseUrlOverflowContainer
+                    <div
+                      className="c13"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <div
-                        className="c18"
+                      <SnippetPreview__TitleBounded>
+                        <SnippetPreview__Title
+                          className="c14"
+                        >
+                          <div
+                            className="c14 c15"
+                          >
+                            <SnippetPreview__TitleUnboundedMobile
+                              innerRef={[Function]}
+                            >
+                              <span
+                                className="c16"
+                              >
+                                Test title
+                              </span>
+                            </SnippetPreview__TitleUnboundedMobile>
+                          </div>
+                        </SnippetPreview__Title>
+                      </SnippetPreview__TitleBounded>
+                    </div>
+                  </SnippetPreview__BaseTitle>
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Url preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseUrl>
+                    <div
+                      className="c17"
+                    >
+                      <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
-                        example.org › test-slug
-                      </div>
-                    </SnippetPreview__BaseUrlOverflowContainer>
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c19"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Meta description preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__MobileDescription
-                  isDescriptionPlaceholder={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+                        <div
+                          className="c18"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrlOverflowContainer>
+                    </div>
+                  </SnippetPreview__BaseUrl>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+              <SnippetPreview__Separator>
+                <hr
+                  className="c19"
+                />
+              </SnippetPreview__Separator>
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <SnippetPreview__DesktopDescription
-                    className="c20"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Meta description preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__MobileDescription
                     isDescriptionPlaceholder={false}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <div
-                      className="c20 c21"
+                    <SnippetPreview__DesktopDescription
+                      className="c20"
+                      isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <SnippetPreview__MobileDescription
-                        innerRef={[Function]}
-                        isDescriptionPlaceholder={false}
+                      <div
+                        className="c20 c21"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
                       >
-                        <SnippetPreview__DesktopDescription
-                          className="c20"
+                        <SnippetPreview__MobileDescription
                           innerRef={[Function]}
                           isDescriptionPlaceholder={false}
                         >
-                          <div
-                            className="c20 c21"
+                          <SnippetPreview__DesktopDescription
+                            className="c20"
+                            innerRef={[Function]}
+                            isDescriptionPlaceholder={false}
                           >
-                            Test description, %%replacement_variable%%
-                          </div>
-                        </SnippetPreview__DesktopDescription>
-                      </SnippetPreview__MobileDescription>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c22"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
+                            <div
+                              className="c20 c21"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </div>
+                    </SnippetPreview__DesktopDescription>
+                  </SnippetPreview__MobileDescription>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+            </div>
+          </SnippetPreview__MobileContainer>
+        </section>
+      </SnippetPreview>
+      <ModeSwitcher
+        active="mobile"
+        onChange={[Function]}
+      >
+        <ModeSwitcher__Switcher>
+          <div
+            className="c22"
           >
-            <Button
+            <ModeSwitcher__SwitcherButton
               aria-pressed={true}
-              className="c23"
               isActive={true}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c23 c2"
+                className="c23"
                 isActive={true}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={true}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2 Button-kDSBcD c3"
+                  className="c23 c2"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -10068,7 +10062,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c23 c2 Button-kDSBcD c3"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -10079,47 +10073,48 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={true}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={true}
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={true}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
+                          <button
+                            aria-pressed={true}
+                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="mobile"
                               size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                className="yoast-svg-icon yoast-svg-icon-mobile"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -10127,64 +10122,63 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="22px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Mobile preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Mobile preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
+            </ModeSwitcher__SwitcherButton>
+            <ModeSwitcher__SwitcherButton
               aria-pressed={false}
-              className="c25"
               isActive={false}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c25"
                 isActive={false}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={false}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c25 c2"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -10195,7 +10189,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c25 c2 Button-kDSBcD c3"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -10206,47 +10200,48 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={false}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={false}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={false}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
+                          <button
+                            aria-pressed={false}
+                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="desktop"
                               size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                className="yoast-svg-icon yoast-svg-icon-desktop"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -10254,61 +10249,60 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="18px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Desktop preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Desktop preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
+            </ModeSwitcher__SwitcherButton>
+          </div>
+        </ModeSwitcher__Switcher>
+      </ModeSwitcher>
       <Button
         aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c27"
         innerRef={[Function]}
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           aria-expanded={true}
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c3"
+          className="c27"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -10319,7 +10313,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c27 Button-kDSBcD c3"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -10330,97 +10324,107 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 aria-expanded={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
+                <Button__BaseButton
                   aria-expanded={true}
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  innerRef={[Function]}
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
+                  <button
+                    aria-expanded={true}
+                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
+                    <SvgIcon
+                      icon="edit"
                       size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
+                      <SvgIcon__StyledSvg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c9"
+                        className="yoast-svg-icon yoast-svg-icon-edit"
                         focusable="false"
                         role="img"
                         size="16px"
                         viewBox="0 0 1792 1792"
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  Edit snippet
-                </button>
-              </Button__BaseButton>
+                        <svg
+                          aria-hidden={true}
+                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          focusable="false"
+                          role="img"
+                          size="16px"
+                          viewBox="0 0 1792 1792"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                          />
+                        </svg>
+                      </SvgIcon__StyledSvg>
+                    </SvgIcon>
+                    Edit snippet
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
+      <SnippetEditorFields
+        activeField={null}
+        data={
+          Object {
+            "description": "Test description, %%replacement_variable%%",
+            "slug": "test-slug",
+            "title": "Test title",
+          }
         }
-      }
-      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-      descriptionLengthProgress={
-        Object {
-          "actual": 42,
-          "max": 156,
-          "score": 6,
+        descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+        descriptionLengthProgress={
+          Object {
+            "actual": 42,
+            "max": 156,
+            "score": 6,
+          }
         }
-      }
-      hoveredField={null}
-      mobileWidth={356}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthProgress={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 1,
+        hoveredField={null}
+        mobileWidth={356}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        replacementVariables={Array []}
+        titleLengthProgress={
+          Object {
+            "actual": 0,
+            "max": 600,
+            "score": 1,
+          }
         }
-      }
-    >
-      <ErrorBoundary>
+      >
         <Shared__StyledEditor
           innerRef={[Function]}
         >
@@ -10818,25 +10822,15 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             </Shared__FormSection>
           </section>
         </Shared__StyledEditor>
-      </ErrorBoundary>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
+      </SnippetEditorFields>
       <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c38"
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c38"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -10845,7 +10839,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -10854,34 +10848,44 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                <Button__BaseButton
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  Close snippet editor
-                </button>
-              </Button__BaseButton>
+                  <button
+                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Close snippet editor
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-  </div>
+    </div>
+  </ErrorBoundary>
 </SnippetEditor>
 `;
 
@@ -11471,72 +11475,61 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
     }
   }
 >
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      keyword=""
-      locale="en"
-      mode="mobile"
-      onHover={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <div>
-          <HelpTextWrapper
-            className="yoast-help"
-            helpText={
-              Array [
-                "This is a rendering of what this post might look like in Google's search results. ",
-                <OutboundLink
-                  href="https://yoa.st/snippet-preview"
-                >
-                  Learn more about the Snippet Preview.
-                </OutboundLink>,
-              ]
-            }
-            helpTextButtonLabel="Help on the Snippet Preview"
-            panelMaxWidth="400px"
-          >
-            <HelpTextWrapper__HelpTextContainer
+  <ErrorBoundary>
+    <div>
+      <SnippetPreview
+        activeField={null}
+        breadcrumbs={null}
+        date=""
+        description="Test description, %%replacement_variable%%"
+        hoveredField={null}
+        isAmp={false}
+        keyword=""
+        locale="en"
+        mode="mobile"
+        onHover={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        title="Test title"
+        url="example.org/test-slug"
+      >
+        <section>
+          <div>
+            <HelpTextWrapper
               className="yoast-help"
+              helpText={
+                Array [
+                  "This is a rendering of what this post might look like in Google's search results. ",
+                  <OutboundLink
+                    href="https://yoa.st/snippet-preview"
+                  >
+                    Learn more about the Snippet Preview.
+                  </OutboundLink>,
+                ]
+              }
+              helpTextButtonLabel="Help on the Snippet Preview"
+              panelMaxWidth="400px"
             >
-              <div
-                className="yoast-help c0"
+              <HelpTextWrapper__HelpTextContainer
+                className="yoast-help"
               >
-                <HelpTextWrapper__HelpTextButton
-                  aria-controls={null}
-                  aria-expanded={false}
-                  aria-label="Help on the Snippet Preview"
-                  className="yoast-help__button"
-                  onClick={[Function]}
+                <div
+                  className="yoast-help c0"
                 >
-                  <Button
+                  <HelpTextWrapper__HelpTextButton
                     aria-controls={null}
                     aria-expanded={false}
                     aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button c1"
+                    className="yoast-help__button"
                     onClick={[Function]}
                   >
                     <Button
                       aria-controls={null}
                       aria-expanded={false}
                       aria-label="Help on the Snippet Preview"
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="yoast-help__button c1 c2"
+                      className="yoast-help__button c1"
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         aria-controls={null}
@@ -11545,7 +11538,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2 Button-kDSBcD c3"
+                        className="yoast-help__button c1 c2"
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -11557,7 +11550,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -11569,55 +11562,57 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               aria-controls={null}
                               aria-expanded={false}
                               aria-label="Help on the Snippet Preview"
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
+                              <Button__BaseButton
                                 aria-controls={null}
                                 aria-expanded={false}
                                 aria-label="Help on the Snippet Preview"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <HelpTextWrapper__StyledSvg
-                                  color="#646464"
-                                  icon="question-circle"
-                                  size="16px"
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-label="Help on the Snippet Preview"
+                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon
-                                    className="c8"
+                                  <HelpTextWrapper__StyledSvg
                                     color="#646464"
                                     icon="question-circle"
                                     size="16px"
                                   >
-                                    <SvgIcon__StyledSvg
-                                      aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                      fill="#646464"
-                                      focusable="false"
-                                      role="img"
+                                    <SvgIcon
+                                      className="c8"
+                                      color="#646464"
+                                      icon="question-circle"
                                       size="16px"
-                                      viewBox="0 0 1792 1792"
-                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <svg
+                                      <SvgIcon__StyledSvg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
                                         fill="#646464"
                                         focusable="false"
                                         role="img"
@@ -11625,268 +11620,267 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                         viewBox="0 0 1792 1792"
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                        />
-                                      </svg>
-                                    </SvgIcon__StyledSvg>
-                                  </SvgIcon>
-                                </HelpTextWrapper__StyledSvg>
-                              </button>
-                            </Button__BaseButton>
+                                        <svg
+                                          aria-hidden={true}
+                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                          fill="#646464"
+                                          focusable="false"
+                                          role="img"
+                                          size="16px"
+                                          viewBox="0 0 1792 1792"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                          />
+                                        </svg>
+                                      </SvgIcon__StyledSvg>
+                                    </SvgIcon>
+                                  </HelpTextWrapper__StyledSvg>
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </HelpTextWrapper__HelpTextButton>
-                <YoastSlideToggle
-                  duration={300}
-                  isOpen={false}
-                >
-                  <animations__YoastSlideToggleContainer
+                  </HelpTextWrapper__HelpTextButton>
+                  <YoastSlideToggle
                     duration={300}
+                    isOpen={false}
                   >
-                    <div
-                      className="c10"
+                    <animations__YoastSlideToggleContainer
+                      duration={300}
                     >
-                      <CSSTransition
-                        classNames="slide"
-                        in={false}
-                        onEnter={[Function]}
-                        onEntered={[Function]}
-                        onEntering={[Function]}
-                        onExit={[Function]}
-                        onExiting={[Function]}
-                        timeout={300}
-                        unmountOnExit={true}
+                      <div
+                        className="c10"
                       >
-                        <Transition
-                          appear={false}
-                          enter={true}
-                          exit={true}
+                        <CSSTransition
+                          classNames="slide"
                           in={false}
-                          mountOnEnter={false}
                           onEnter={[Function]}
                           onEntered={[Function]}
                           onEntering={[Function]}
                           onExit={[Function]}
-                          onExited={[Function]}
                           onExiting={[Function]}
                           timeout={300}
                           unmountOnExit={true}
-                        />
-                      </CSSTransition>
-                    </div>
-                  </animations__YoastSlideToggleContainer>
-                </YoastSlideToggle>
-              </div>
-            </HelpTextWrapper__HelpTextContainer>
-          </HelpTextWrapper>
-        </div>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c11"
+                        >
+                          <Transition
+                            appear={false}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            timeout={300}
+                            unmountOnExit={true}
+                          />
+                        </CSSTransition>
+                      </div>
+                    </animations__YoastSlideToggleContainer>
+                  </YoastSlideToggle>
+                </div>
+              </HelpTextWrapper__HelpTextContainer>
+            </HelpTextWrapper>
+          </div>
+          <SnippetPreview__MobileContainer
+            padding={20}
             width={640}
           >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    SEO title preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseTitle
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+            <div
+              className="c11"
+              width={640}
+            >
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <div
-                    className="c13"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      SEO title preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseTitle
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c14"
-                      >
-                        <div
-                          className="c14 c15"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c16"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Url preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseUrl>
-                  <div
-                    className="c17"
-                  >
-                    <SnippetPreview__BaseUrlOverflowContainer
+                    <div
+                      className="c13"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <div
-                        className="c18"
+                      <SnippetPreview__TitleBounded>
+                        <SnippetPreview__Title
+                          className="c14"
+                        >
+                          <div
+                            className="c14 c15"
+                          >
+                            <SnippetPreview__TitleUnboundedMobile
+                              innerRef={[Function]}
+                            >
+                              <span
+                                className="c16"
+                              >
+                                Test title
+                              </span>
+                            </SnippetPreview__TitleUnboundedMobile>
+                          </div>
+                        </SnippetPreview__Title>
+                      </SnippetPreview__TitleBounded>
+                    </div>
+                  </SnippetPreview__BaseTitle>
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Url preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseUrl>
+                    <div
+                      className="c17"
+                    >
+                      <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
-                        example.org › test-slug
-                      </div>
-                    </SnippetPreview__BaseUrlOverflowContainer>
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c19"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Meta description preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__MobileDescription
-                  isDescriptionPlaceholder={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+                        <div
+                          className="c18"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrlOverflowContainer>
+                    </div>
+                  </SnippetPreview__BaseUrl>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+              <SnippetPreview__Separator>
+                <hr
+                  className="c19"
+                />
+              </SnippetPreview__Separator>
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <SnippetPreview__DesktopDescription
-                    className="c20"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Meta description preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__MobileDescription
                     isDescriptionPlaceholder={false}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <div
-                      className="c20 c21"
+                    <SnippetPreview__DesktopDescription
+                      className="c20"
+                      isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <SnippetPreview__MobileDescription
-                        innerRef={[Function]}
-                        isDescriptionPlaceholder={false}
+                      <div
+                        className="c20 c21"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
                       >
-                        <SnippetPreview__DesktopDescription
-                          className="c20"
+                        <SnippetPreview__MobileDescription
                           innerRef={[Function]}
                           isDescriptionPlaceholder={false}
                         >
-                          <div
-                            className="c20 c21"
+                          <SnippetPreview__DesktopDescription
+                            className="c20"
+                            innerRef={[Function]}
+                            isDescriptionPlaceholder={false}
                           >
-                            Test description, %%replacement_variable%%
-                          </div>
-                        </SnippetPreview__DesktopDescription>
-                      </SnippetPreview__MobileDescription>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c22"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
+                            <div
+                              className="c20 c21"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </div>
+                    </SnippetPreview__DesktopDescription>
+                  </SnippetPreview__MobileDescription>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+            </div>
+          </SnippetPreview__MobileContainer>
+        </section>
+      </SnippetPreview>
+      <ModeSwitcher
+        active="mobile"
+        onChange={[Function]}
+      >
+        <ModeSwitcher__Switcher>
+          <div
+            className="c22"
           >
-            <Button
+            <ModeSwitcher__SwitcherButton
               aria-pressed={true}
-              className="c23"
               isActive={true}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c23 c2"
+                className="c23"
                 isActive={true}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={true}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2 Button-kDSBcD c3"
+                  className="c23 c2"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -11897,7 +11891,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c23 c2 Button-kDSBcD c3"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -11908,47 +11902,48 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={true}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={true}
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={true}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
+                          <button
+                            aria-pressed={true}
+                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="mobile"
                               size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                className="yoast-svg-icon yoast-svg-icon-mobile"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -11956,64 +11951,63 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="22px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Mobile preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Mobile preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
+            </ModeSwitcher__SwitcherButton>
+            <ModeSwitcher__SwitcherButton
               aria-pressed={false}
-              className="c25"
               isActive={false}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c25"
                 isActive={false}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={false}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c25 c2"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -12024,7 +12018,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c25 c2 Button-kDSBcD c3"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -12035,47 +12029,48 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={false}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={false}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={false}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
+                          <button
+                            aria-pressed={false}
+                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="desktop"
                               size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                className="yoast-svg-icon yoast-svg-icon-desktop"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -12083,61 +12078,60 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="18px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Desktop preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Desktop preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
+            </ModeSwitcher__SwitcherButton>
+          </div>
+        </ModeSwitcher__Switcher>
+      </ModeSwitcher>
       <Button
         aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c27"
         innerRef={[Function]}
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           aria-expanded={true}
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c3"
+          className="c27"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -12148,7 +12142,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c27 Button-kDSBcD c3"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -12159,97 +12153,107 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 aria-expanded={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
+                <Button__BaseButton
                   aria-expanded={true}
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  innerRef={[Function]}
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
+                  <button
+                    aria-expanded={true}
+                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
+                    <SvgIcon
+                      icon="edit"
                       size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
+                      <SvgIcon__StyledSvg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c9"
+                        className="yoast-svg-icon yoast-svg-icon-edit"
                         focusable="false"
                         role="img"
                         size="16px"
                         viewBox="0 0 1792 1792"
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  Edit snippet
-                </button>
-              </Button__BaseButton>
+                        <svg
+                          aria-hidden={true}
+                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          focusable="false"
+                          role="img"
+                          size="16px"
+                          viewBox="0 0 1792 1792"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                          />
+                        </svg>
+                      </SvgIcon__StyledSvg>
+                    </SvgIcon>
+                    Edit snippet
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
+      <SnippetEditorFields
+        activeField={null}
+        data={
+          Object {
+            "description": "Test description, %%replacement_variable%%",
+            "slug": "test-slug",
+            "title": "Test title",
+          }
         }
-      }
-      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-      descriptionLengthProgress={
-        Object {
-          "actual": 42,
-          "max": 156,
-          "score": 6,
+        descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+        descriptionLengthProgress={
+          Object {
+            "actual": 42,
+            "max": 156,
+            "score": 6,
+          }
         }
-      }
-      hoveredField={null}
-      mobileWidth={356}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthProgress={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 1,
+        hoveredField={null}
+        mobileWidth={356}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        replacementVariables={Array []}
+        titleLengthProgress={
+          Object {
+            "actual": 0,
+            "max": 600,
+            "score": 1,
+          }
         }
-      }
-    >
-      <ErrorBoundary>
+      >
         <Shared__StyledEditor
           innerRef={[Function]}
         >
@@ -12647,25 +12651,15 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             </Shared__FormSection>
           </section>
         </Shared__StyledEditor>
-      </ErrorBoundary>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
+      </SnippetEditorFields>
       <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c38"
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c38"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -12674,7 +12668,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -12683,34 +12677,44 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                <Button__BaseButton
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  Close snippet editor
-                </button>
-              </Button__BaseButton>
+                  <button
+                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Close snippet editor
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-  </div>
+    </div>
+  </ErrorBoundary>
 </SnippetEditor>
 `;
 
@@ -14402,72 +14406,61 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
     }
   }
 >
-  <div>
-    <SnippetPreview
-      activeField="description"
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      keyword=""
-      locale="en"
-      mode="mobile"
-      onHover={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <div>
-          <HelpTextWrapper
-            className="yoast-help"
-            helpText={
-              Array [
-                "This is a rendering of what this post might look like in Google's search results. ",
-                <OutboundLink
-                  href="https://yoa.st/snippet-preview"
-                >
-                  Learn more about the Snippet Preview.
-                </OutboundLink>,
-              ]
-            }
-            helpTextButtonLabel="Help on the Snippet Preview"
-            panelMaxWidth="400px"
-          >
-            <HelpTextWrapper__HelpTextContainer
+  <ErrorBoundary>
+    <div>
+      <SnippetPreview
+        activeField="description"
+        breadcrumbs={null}
+        date=""
+        description="Test description, %%replacement_variable%%"
+        hoveredField={null}
+        isAmp={false}
+        keyword=""
+        locale="en"
+        mode="mobile"
+        onHover={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        title="Test title"
+        url="example.org/test-slug"
+      >
+        <section>
+          <div>
+            <HelpTextWrapper
               className="yoast-help"
+              helpText={
+                Array [
+                  "This is a rendering of what this post might look like in Google's search results. ",
+                  <OutboundLink
+                    href="https://yoa.st/snippet-preview"
+                  >
+                    Learn more about the Snippet Preview.
+                  </OutboundLink>,
+                ]
+              }
+              helpTextButtonLabel="Help on the Snippet Preview"
+              panelMaxWidth="400px"
             >
-              <div
-                className="yoast-help c0"
+              <HelpTextWrapper__HelpTextContainer
+                className="yoast-help"
               >
-                <HelpTextWrapper__HelpTextButton
-                  aria-controls={null}
-                  aria-expanded={false}
-                  aria-label="Help on the Snippet Preview"
-                  className="yoast-help__button"
-                  onClick={[Function]}
+                <div
+                  className="yoast-help c0"
                 >
-                  <Button
+                  <HelpTextWrapper__HelpTextButton
                     aria-controls={null}
                     aria-expanded={false}
                     aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button c1"
+                    className="yoast-help__button"
                     onClick={[Function]}
                   >
                     <Button
                       aria-controls={null}
                       aria-expanded={false}
                       aria-label="Help on the Snippet Preview"
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="yoast-help__button c1 c2"
+                      className="yoast-help__button c1"
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         aria-controls={null}
@@ -14476,7 +14469,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2 Button-kDSBcD c3"
+                        className="yoast-help__button c1 c2"
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -14488,7 +14481,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -14500,55 +14493,57 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               aria-controls={null}
                               aria-expanded={false}
                               aria-label="Help on the Snippet Preview"
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
+                              <Button__BaseButton
                                 aria-controls={null}
                                 aria-expanded={false}
                                 aria-label="Help on the Snippet Preview"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <HelpTextWrapper__StyledSvg
-                                  color="#646464"
-                                  icon="question-circle"
-                                  size="16px"
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-label="Help on the Snippet Preview"
+                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon
-                                    className="c8"
+                                  <HelpTextWrapper__StyledSvg
                                     color="#646464"
                                     icon="question-circle"
                                     size="16px"
                                   >
-                                    <SvgIcon__StyledSvg
-                                      aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                      fill="#646464"
-                                      focusable="false"
-                                      role="img"
+                                    <SvgIcon
+                                      className="c8"
+                                      color="#646464"
+                                      icon="question-circle"
                                       size="16px"
-                                      viewBox="0 0 1792 1792"
-                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <svg
+                                      <SvgIcon__StyledSvg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
                                         fill="#646464"
                                         focusable="false"
                                         role="img"
@@ -14556,276 +14551,275 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                         viewBox="0 0 1792 1792"
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                        />
-                                      </svg>
-                                    </SvgIcon__StyledSvg>
-                                  </SvgIcon>
-                                </HelpTextWrapper__StyledSvg>
-                              </button>
-                            </Button__BaseButton>
+                                        <svg
+                                          aria-hidden={true}
+                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                          fill="#646464"
+                                          focusable="false"
+                                          role="img"
+                                          size="16px"
+                                          viewBox="0 0 1792 1792"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                          />
+                                        </svg>
+                                      </SvgIcon__StyledSvg>
+                                    </SvgIcon>
+                                  </HelpTextWrapper__StyledSvg>
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </HelpTextWrapper__HelpTextButton>
-                <YoastSlideToggle
-                  duration={300}
-                  isOpen={false}
-                >
-                  <animations__YoastSlideToggleContainer
+                  </HelpTextWrapper__HelpTextButton>
+                  <YoastSlideToggle
                     duration={300}
+                    isOpen={false}
                   >
-                    <div
-                      className="c10"
+                    <animations__YoastSlideToggleContainer
+                      duration={300}
                     >
-                      <CSSTransition
-                        classNames="slide"
-                        in={false}
-                        onEnter={[Function]}
-                        onEntered={[Function]}
-                        onEntering={[Function]}
-                        onExit={[Function]}
-                        onExiting={[Function]}
-                        timeout={300}
-                        unmountOnExit={true}
+                      <div
+                        className="c10"
                       >
-                        <Transition
-                          appear={false}
-                          enter={true}
-                          exit={true}
+                        <CSSTransition
+                          classNames="slide"
                           in={false}
-                          mountOnEnter={false}
                           onEnter={[Function]}
                           onEntered={[Function]}
                           onEntering={[Function]}
                           onExit={[Function]}
-                          onExited={[Function]}
                           onExiting={[Function]}
                           timeout={300}
                           unmountOnExit={true}
-                        />
-                      </CSSTransition>
-                    </div>
-                  </animations__YoastSlideToggleContainer>
-                </YoastSlideToggle>
-              </div>
-            </HelpTextWrapper__HelpTextContainer>
-          </HelpTextWrapper>
-        </div>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c11"
+                        >
+                          <Transition
+                            appear={false}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            timeout={300}
+                            unmountOnExit={true}
+                          />
+                        </CSSTransition>
+                      </div>
+                    </animations__YoastSlideToggleContainer>
+                  </YoastSlideToggle>
+                </div>
+              </HelpTextWrapper__HelpTextContainer>
+            </HelpTextWrapper>
+          </div>
+          <SnippetPreview__MobileContainer
+            padding={20}
             width={640}
           >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    SEO title preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseTitle
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+            <div
+              className="c11"
+              width={640}
+            >
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <div
-                    className="c13"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      SEO title preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseTitle
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c14"
-                      >
-                        <div
-                          className="c14 c15"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c16"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Url preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseUrl>
-                  <div
-                    className="c17"
-                  >
-                    <SnippetPreview__BaseUrlOverflowContainer
+                    <div
+                      className="c13"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <div
-                        className="c18"
+                      <SnippetPreview__TitleBounded>
+                        <SnippetPreview__Title
+                          className="c14"
+                        >
+                          <div
+                            className="c14 c15"
+                          >
+                            <SnippetPreview__TitleUnboundedMobile
+                              innerRef={[Function]}
+                            >
+                              <span
+                                className="c16"
+                              >
+                                Test title
+                              </span>
+                            </SnippetPreview__TitleUnboundedMobile>
+                          </div>
+                        </SnippetPreview__Title>
+                      </SnippetPreview__TitleBounded>
+                    </div>
+                  </SnippetPreview__BaseTitle>
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Url preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseUrl>
+                    <div
+                      className="c17"
+                    >
+                      <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
-                        example.org › test-slug
-                      </div>
-                    </SnippetPreview__BaseUrlOverflowContainer>
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c19"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Meta description preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview
-                  isDescriptionPlaceholder={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+                        <div
+                          className="c18"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrlOverflowContainer>
+                    </div>
+                  </SnippetPreview__BaseUrl>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+              <SnippetPreview__Separator>
+                <hr
+                  className="c19"
+                />
+              </SnippetPreview__Separator>
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <SnippetPreview__MobileDescription
-                    className="c20"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Meta description preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview
                     isDescriptionPlaceholder={false}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <SnippetPreview__DesktopDescription
-                      className="c20 c21"
+                    <SnippetPreview__MobileDescription
+                      className="c20"
                       isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <div
-                        className="c20 c21 c22"
+                      <SnippetPreview__DesktopDescription
+                        className="c20 c21"
+                        isDescriptionPlaceholder={false}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
-                        <SnippetPreview__MobileDescription
-                          innerRef={[Function]}
-                          isDescriptionPlaceholder={false}
+                        <div
+                          className="c20 c21 c22"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
                         >
-                          <SnippetPreview__DesktopDescription
-                            className="c21"
+                          <SnippetPreview__MobileDescription
                             innerRef={[Function]}
                             isDescriptionPlaceholder={false}
                           >
-                            <div
-                              className="c21 c22"
+                            <SnippetPreview__DesktopDescription
+                              className="c21"
+                              innerRef={[Function]}
+                              isDescriptionPlaceholder={false}
                             >
-                              Test description, %%replacement_variable%%
-                            </div>
-                          </SnippetPreview__DesktopDescription>
-                        </SnippetPreview__MobileDescription>
-                      </div>
-                    </SnippetPreview__DesktopDescription>
-                  </SnippetPreview__MobileDescription>
-                </SnippetPreview>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c23"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
+                              <div
+                                className="c21 c22"
+                              >
+                                Test description, %%replacement_variable%%
+                              </div>
+                            </SnippetPreview__DesktopDescription>
+                          </SnippetPreview__MobileDescription>
+                        </div>
+                      </SnippetPreview__DesktopDescription>
+                    </SnippetPreview__MobileDescription>
+                  </SnippetPreview>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+            </div>
+          </SnippetPreview__MobileContainer>
+        </section>
+      </SnippetPreview>
+      <ModeSwitcher
+        active="mobile"
+        onChange={[Function]}
+      >
+        <ModeSwitcher__Switcher>
+          <div
+            className="c23"
           >
-            <Button
+            <ModeSwitcher__SwitcherButton
               aria-pressed={true}
-              className="c24"
               isActive={true}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c24 c2"
+                className="c24"
                 isActive={true}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={true}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c24 c2 Button-kDSBcD c3"
+                  className="c24 c2"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -14836,7 +14830,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c24 c2 Button-kDSBcD c3"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -14847,47 +14841,48 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={true}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={true}
-                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={true}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
+                          <button
+                            aria-pressed={true}
+                            className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="mobile"
                               size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c25"
+                                className="yoast-svg-icon yoast-svg-icon-mobile"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -14895,64 +14890,63 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c25"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="22px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Mobile preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Mobile preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
+            </ModeSwitcher__SwitcherButton>
+            <ModeSwitcher__SwitcherButton
               aria-pressed={false}
-              className="c26"
               isActive={false}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c26 c2"
+                className="c26"
                 isActive={false}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={false}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c26 c2 Button-kDSBcD c3"
+                  className="c26 c2"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -14963,7 +14957,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c26 c2 Button-kDSBcD c3"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -14974,47 +14968,48 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={false}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={false}
-                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={false}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
+                          <button
+                            aria-pressed={false}
+                            className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="desktop"
                               size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c27"
+                                className="yoast-svg-icon yoast-svg-icon-desktop"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -15022,61 +15017,60 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c27"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="18px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Desktop preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Desktop preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
+            </ModeSwitcher__SwitcherButton>
+          </div>
+        </ModeSwitcher__Switcher>
+      </ModeSwitcher>
       <Button
         aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c28"
         innerRef={[Function]}
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           aria-expanded={true}
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c28 Button-kDSBcD c3"
+          className="c28"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -15087,7 +15081,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c28 Button-kDSBcD c3"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -15098,97 +15092,107 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 aria-expanded={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
+                <Button__BaseButton
                   aria-expanded={true}
-                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  innerRef={[Function]}
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
+                  <button
+                    aria-expanded={true}
+                    className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
+                    <SvgIcon
+                      icon="edit"
                       size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
+                      <SvgIcon__StyledSvg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c9"
+                        className="yoast-svg-icon yoast-svg-icon-edit"
                         focusable="false"
                         role="img"
                         size="16px"
                         viewBox="0 0 1792 1792"
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  Edit snippet
-                </button>
-              </Button__BaseButton>
+                        <svg
+                          aria-hidden={true}
+                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          focusable="false"
+                          role="img"
+                          size="16px"
+                          viewBox="0 0 1792 1792"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                          />
+                        </svg>
+                      </SvgIcon__StyledSvg>
+                    </SvgIcon>
+                    Edit snippet
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField="description"
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
+      <SnippetEditorFields
+        activeField="description"
+        data={
+          Object {
+            "description": "Test description, %%replacement_variable%%",
+            "slug": "test-slug",
+            "title": "Test title",
+          }
         }
-      }
-      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-      descriptionLengthProgress={
-        Object {
-          "actual": 42,
-          "max": 156,
-          "score": 6,
+        descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+        descriptionLengthProgress={
+          Object {
+            "actual": 42,
+            "max": 156,
+            "score": 6,
+          }
         }
-      }
-      hoveredField={null}
-      mobileWidth={356}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthProgress={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 1,
+        hoveredField={null}
+        mobileWidth={356}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        replacementVariables={Array []}
+        titleLengthProgress={
+          Object {
+            "actual": 0,
+            "max": 600,
+            "score": 1,
+          }
         }
-      }
-    >
-      <ErrorBoundary>
+      >
         <Shared__StyledEditor
           innerRef={[Function]}
         >
@@ -15586,25 +15590,15 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
             </Shared__FormSection>
           </section>
         </Shared__StyledEditor>
-      </ErrorBoundary>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
+      </SnippetEditorFields>
       <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c39"
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c39 Button-kDSBcD c3"
+          className="c39"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -15613,7 +15607,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c39 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c39 Button-kDSBcD c3"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -15622,34 +15616,44 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c39 Button-kDSBcD c3 Button-kDSBcD c4"
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
-                  className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                <Button__BaseButton
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  Close snippet editor
-                </button>
-              </Button__BaseButton>
+                  <button
+                    className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Close snippet editor
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-  </div>
+    </div>
+  </ErrorBoundary>
 </SnippetEditor>
 `;
 
@@ -16251,72 +16255,61 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
     }
   }
 >
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField="description"
-      isAmp={false}
-      keyword=""
-      locale="en"
-      mode="mobile"
-      onHover={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <div>
-          <HelpTextWrapper
-            className="yoast-help"
-            helpText={
-              Array [
-                "This is a rendering of what this post might look like in Google's search results. ",
-                <OutboundLink
-                  href="https://yoa.st/snippet-preview"
-                >
-                  Learn more about the Snippet Preview.
-                </OutboundLink>,
-              ]
-            }
-            helpTextButtonLabel="Help on the Snippet Preview"
-            panelMaxWidth="400px"
-          >
-            <HelpTextWrapper__HelpTextContainer
+  <ErrorBoundary>
+    <div>
+      <SnippetPreview
+        activeField={null}
+        breadcrumbs={null}
+        date=""
+        description="Test description, %%replacement_variable%%"
+        hoveredField="description"
+        isAmp={false}
+        keyword=""
+        locale="en"
+        mode="mobile"
+        onHover={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        title="Test title"
+        url="example.org/test-slug"
+      >
+        <section>
+          <div>
+            <HelpTextWrapper
               className="yoast-help"
+              helpText={
+                Array [
+                  "This is a rendering of what this post might look like in Google's search results. ",
+                  <OutboundLink
+                    href="https://yoa.st/snippet-preview"
+                  >
+                    Learn more about the Snippet Preview.
+                  </OutboundLink>,
+                ]
+              }
+              helpTextButtonLabel="Help on the Snippet Preview"
+              panelMaxWidth="400px"
             >
-              <div
-                className="yoast-help c0"
+              <HelpTextWrapper__HelpTextContainer
+                className="yoast-help"
               >
-                <HelpTextWrapper__HelpTextButton
-                  aria-controls={null}
-                  aria-expanded={false}
-                  aria-label="Help on the Snippet Preview"
-                  className="yoast-help__button"
-                  onClick={[Function]}
+                <div
+                  className="yoast-help c0"
                 >
-                  <Button
+                  <HelpTextWrapper__HelpTextButton
                     aria-controls={null}
                     aria-expanded={false}
                     aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button c1"
+                    className="yoast-help__button"
                     onClick={[Function]}
                   >
                     <Button
                       aria-controls={null}
                       aria-expanded={false}
                       aria-label="Help on the Snippet Preview"
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="yoast-help__button c1 c2"
+                      className="yoast-help__button c1"
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         aria-controls={null}
@@ -16325,7 +16318,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2 Button-kDSBcD c3"
+                        className="yoast-help__button c1 c2"
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -16337,7 +16330,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -16349,55 +16342,57 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               aria-controls={null}
                               aria-expanded={false}
                               aria-label="Help on the Snippet Preview"
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
+                              <Button__BaseButton
                                 aria-controls={null}
                                 aria-expanded={false}
                                 aria-label="Help on the Snippet Preview"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <HelpTextWrapper__StyledSvg
-                                  color="#646464"
-                                  icon="question-circle"
-                                  size="16px"
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-label="Help on the Snippet Preview"
+                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon
-                                    className="c8"
+                                  <HelpTextWrapper__StyledSvg
                                     color="#646464"
                                     icon="question-circle"
                                     size="16px"
                                   >
-                                    <SvgIcon__StyledSvg
-                                      aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                      fill="#646464"
-                                      focusable="false"
-                                      role="img"
+                                    <SvgIcon
+                                      className="c8"
+                                      color="#646464"
+                                      icon="question-circle"
                                       size="16px"
-                                      viewBox="0 0 1792 1792"
-                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <svg
+                                      <SvgIcon__StyledSvg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
                                         fill="#646464"
                                         focusable="false"
                                         role="img"
@@ -16405,276 +16400,275 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                         viewBox="0 0 1792 1792"
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                        />
-                                      </svg>
-                                    </SvgIcon__StyledSvg>
-                                  </SvgIcon>
-                                </HelpTextWrapper__StyledSvg>
-                              </button>
-                            </Button__BaseButton>
+                                        <svg
+                                          aria-hidden={true}
+                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                          fill="#646464"
+                                          focusable="false"
+                                          role="img"
+                                          size="16px"
+                                          viewBox="0 0 1792 1792"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                          />
+                                        </svg>
+                                      </SvgIcon__StyledSvg>
+                                    </SvgIcon>
+                                  </HelpTextWrapper__StyledSvg>
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </HelpTextWrapper__HelpTextButton>
-                <YoastSlideToggle
-                  duration={300}
-                  isOpen={false}
-                >
-                  <animations__YoastSlideToggleContainer
+                  </HelpTextWrapper__HelpTextButton>
+                  <YoastSlideToggle
                     duration={300}
+                    isOpen={false}
                   >
-                    <div
-                      className="c10"
+                    <animations__YoastSlideToggleContainer
+                      duration={300}
                     >
-                      <CSSTransition
-                        classNames="slide"
-                        in={false}
-                        onEnter={[Function]}
-                        onEntered={[Function]}
-                        onEntering={[Function]}
-                        onExit={[Function]}
-                        onExiting={[Function]}
-                        timeout={300}
-                        unmountOnExit={true}
+                      <div
+                        className="c10"
                       >
-                        <Transition
-                          appear={false}
-                          enter={true}
-                          exit={true}
+                        <CSSTransition
+                          classNames="slide"
                           in={false}
-                          mountOnEnter={false}
                           onEnter={[Function]}
                           onEntered={[Function]}
                           onEntering={[Function]}
                           onExit={[Function]}
-                          onExited={[Function]}
                           onExiting={[Function]}
                           timeout={300}
                           unmountOnExit={true}
-                        />
-                      </CSSTransition>
-                    </div>
-                  </animations__YoastSlideToggleContainer>
-                </YoastSlideToggle>
-              </div>
-            </HelpTextWrapper__HelpTextContainer>
-          </HelpTextWrapper>
-        </div>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c11"
+                        >
+                          <Transition
+                            appear={false}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            timeout={300}
+                            unmountOnExit={true}
+                          />
+                        </CSSTransition>
+                      </div>
+                    </animations__YoastSlideToggleContainer>
+                  </YoastSlideToggle>
+                </div>
+              </HelpTextWrapper__HelpTextContainer>
+            </HelpTextWrapper>
+          </div>
+          <SnippetPreview__MobileContainer
+            padding={20}
             width={640}
           >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    SEO title preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseTitle
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+            <div
+              className="c11"
+              width={640}
+            >
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <div
-                    className="c13"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      SEO title preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseTitle
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c14"
-                      >
-                        <div
-                          className="c14 c15"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c16"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Url preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseUrl>
-                  <div
-                    className="c17"
-                  >
-                    <SnippetPreview__BaseUrlOverflowContainer
+                    <div
+                      className="c13"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <div
-                        className="c18"
+                      <SnippetPreview__TitleBounded>
+                        <SnippetPreview__Title
+                          className="c14"
+                        >
+                          <div
+                            className="c14 c15"
+                          >
+                            <SnippetPreview__TitleUnboundedMobile
+                              innerRef={[Function]}
+                            >
+                              <span
+                                className="c16"
+                              >
+                                Test title
+                              </span>
+                            </SnippetPreview__TitleUnboundedMobile>
+                          </div>
+                        </SnippetPreview__Title>
+                      </SnippetPreview__TitleBounded>
+                    </div>
+                  </SnippetPreview__BaseTitle>
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Url preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseUrl>
+                    <div
+                      className="c17"
+                    >
+                      <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
-                        example.org › test-slug
-                      </div>
-                    </SnippetPreview__BaseUrlOverflowContainer>
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c19"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Meta description preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview
-                  isDescriptionPlaceholder={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+                        <div
+                          className="c18"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrlOverflowContainer>
+                    </div>
+                  </SnippetPreview__BaseUrl>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+              <SnippetPreview__Separator>
+                <hr
+                  className="c19"
+                />
+              </SnippetPreview__Separator>
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <SnippetPreview__MobileDescription
-                    className="c20"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Meta description preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview
                     isDescriptionPlaceholder={false}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <SnippetPreview__DesktopDescription
-                      className="c20 c21"
+                    <SnippetPreview__MobileDescription
+                      className="c20"
                       isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <div
-                        className="c20 c21 c22"
+                      <SnippetPreview__DesktopDescription
+                        className="c20 c21"
+                        isDescriptionPlaceholder={false}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
-                        <SnippetPreview__MobileDescription
-                          innerRef={[Function]}
-                          isDescriptionPlaceholder={false}
+                        <div
+                          className="c20 c21 c22"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
                         >
-                          <SnippetPreview__DesktopDescription
-                            className="c21"
+                          <SnippetPreview__MobileDescription
                             innerRef={[Function]}
                             isDescriptionPlaceholder={false}
                           >
-                            <div
-                              className="c21 c22"
+                            <SnippetPreview__DesktopDescription
+                              className="c21"
+                              innerRef={[Function]}
+                              isDescriptionPlaceholder={false}
                             >
-                              Test description, %%replacement_variable%%
-                            </div>
-                          </SnippetPreview__DesktopDescription>
-                        </SnippetPreview__MobileDescription>
-                      </div>
-                    </SnippetPreview__DesktopDescription>
-                  </SnippetPreview__MobileDescription>
-                </SnippetPreview>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c23"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
+                              <div
+                                className="c21 c22"
+                              >
+                                Test description, %%replacement_variable%%
+                              </div>
+                            </SnippetPreview__DesktopDescription>
+                          </SnippetPreview__MobileDescription>
+                        </div>
+                      </SnippetPreview__DesktopDescription>
+                    </SnippetPreview__MobileDescription>
+                  </SnippetPreview>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+            </div>
+          </SnippetPreview__MobileContainer>
+        </section>
+      </SnippetPreview>
+      <ModeSwitcher
+        active="mobile"
+        onChange={[Function]}
+      >
+        <ModeSwitcher__Switcher>
+          <div
+            className="c23"
           >
-            <Button
+            <ModeSwitcher__SwitcherButton
               aria-pressed={true}
-              className="c24"
               isActive={true}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c24 c2"
+                className="c24"
                 isActive={true}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={true}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c24 c2 Button-kDSBcD c3"
+                  className="c24 c2"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -16685,7 +16679,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c24 c2 Button-kDSBcD c3"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -16696,47 +16690,48 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={true}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={true}
-                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={true}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
+                          <button
+                            aria-pressed={true}
+                            className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="mobile"
                               size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c25"
+                                className="yoast-svg-icon yoast-svg-icon-mobile"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -16744,64 +16739,63 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c25"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="22px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Mobile preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Mobile preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
+            </ModeSwitcher__SwitcherButton>
+            <ModeSwitcher__SwitcherButton
               aria-pressed={false}
-              className="c26"
               isActive={false}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c26 c2"
+                className="c26"
                 isActive={false}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={false}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c26 c2 Button-kDSBcD c3"
+                  className="c26 c2"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -16812,7 +16806,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c26 c2 Button-kDSBcD c3"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -16823,47 +16817,48 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={false}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={false}
-                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={false}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
+                          <button
+                            aria-pressed={false}
+                            className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="desktop"
                               size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c27"
+                                className="yoast-svg-icon yoast-svg-icon-desktop"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -16871,61 +16866,60 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c27"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="18px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Desktop preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Desktop preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
+            </ModeSwitcher__SwitcherButton>
+          </div>
+        </ModeSwitcher__Switcher>
+      </ModeSwitcher>
       <Button
         aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c28"
         innerRef={[Function]}
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           aria-expanded={true}
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c28 Button-kDSBcD c3"
+          className="c28"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -16936,7 +16930,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c28 Button-kDSBcD c3"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -16947,97 +16941,107 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 aria-expanded={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
+                <Button__BaseButton
                   aria-expanded={true}
-                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  innerRef={[Function]}
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
+                  <button
+                    aria-expanded={true}
+                    className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
+                    <SvgIcon
+                      icon="edit"
                       size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
+                      <SvgIcon__StyledSvg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c9"
+                        className="yoast-svg-icon yoast-svg-icon-edit"
                         focusable="false"
                         role="img"
                         size="16px"
                         viewBox="0 0 1792 1792"
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  Edit snippet
-                </button>
-              </Button__BaseButton>
+                        <svg
+                          aria-hidden={true}
+                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          focusable="false"
+                          role="img"
+                          size="16px"
+                          viewBox="0 0 1792 1792"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                          />
+                        </svg>
+                      </SvgIcon__StyledSvg>
+                    </SvgIcon>
+                    Edit snippet
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
+      <SnippetEditorFields
+        activeField={null}
+        data={
+          Object {
+            "description": "Test description, %%replacement_variable%%",
+            "slug": "test-slug",
+            "title": "Test title",
+          }
         }
-      }
-      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-      descriptionLengthProgress={
-        Object {
-          "actual": 42,
-          "max": 156,
-          "score": 6,
+        descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+        descriptionLengthProgress={
+          Object {
+            "actual": 42,
+            "max": 156,
+            "score": 6,
+          }
         }
-      }
-      hoveredField="description"
-      mobileWidth={356}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthProgress={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 1,
+        hoveredField="description"
+        mobileWidth={356}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        replacementVariables={Array []}
+        titleLengthProgress={
+          Object {
+            "actual": 0,
+            "max": 600,
+            "score": 1,
+          }
         }
-      }
-    >
-      <ErrorBoundary>
+      >
         <Shared__StyledEditor
           innerRef={[Function]}
         >
@@ -17435,25 +17439,15 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
             </Shared__FormSection>
           </section>
         </Shared__StyledEditor>
-      </ErrorBoundary>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
+      </SnippetEditorFields>
       <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c39"
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c39 Button-kDSBcD c3"
+          className="c39"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -17462,7 +17456,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c39 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c39 Button-kDSBcD c3"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -17471,34 +17465,44 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c39 Button-kDSBcD c3 Button-kDSBcD c4"
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
-                  className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                <Button__BaseButton
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  Close snippet editor
-                </button>
-              </Button__BaseButton>
+                  <button
+                    className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Close snippet editor
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-  </div>
+    </div>
+  </ErrorBoundary>
 </SnippetEditor>
 `;
 
@@ -18088,72 +18092,61 @@ exports[`SnippetEditor opens when calling open() 1`] = `
     }
   }
 >
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      keyword=""
-      locale="en"
-      mode="mobile"
-      onHover={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <div>
-          <HelpTextWrapper
-            className="yoast-help"
-            helpText={
-              Array [
-                "This is a rendering of what this post might look like in Google's search results. ",
-                <OutboundLink
-                  href="https://yoa.st/snippet-preview"
-                >
-                  Learn more about the Snippet Preview.
-                </OutboundLink>,
-              ]
-            }
-            helpTextButtonLabel="Help on the Snippet Preview"
-            panelMaxWidth="400px"
-          >
-            <HelpTextWrapper__HelpTextContainer
+  <ErrorBoundary>
+    <div>
+      <SnippetPreview
+        activeField={null}
+        breadcrumbs={null}
+        date=""
+        description="Test description, %%replacement_variable%%"
+        hoveredField={null}
+        isAmp={false}
+        keyword=""
+        locale="en"
+        mode="mobile"
+        onHover={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        title="Test title"
+        url="example.org/test-slug"
+      >
+        <section>
+          <div>
+            <HelpTextWrapper
               className="yoast-help"
+              helpText={
+                Array [
+                  "This is a rendering of what this post might look like in Google's search results. ",
+                  <OutboundLink
+                    href="https://yoa.st/snippet-preview"
+                  >
+                    Learn more about the Snippet Preview.
+                  </OutboundLink>,
+                ]
+              }
+              helpTextButtonLabel="Help on the Snippet Preview"
+              panelMaxWidth="400px"
             >
-              <div
-                className="yoast-help c0"
+              <HelpTextWrapper__HelpTextContainer
+                className="yoast-help"
               >
-                <HelpTextWrapper__HelpTextButton
-                  aria-controls={null}
-                  aria-expanded={false}
-                  aria-label="Help on the Snippet Preview"
-                  className="yoast-help__button"
-                  onClick={[Function]}
+                <div
+                  className="yoast-help c0"
                 >
-                  <Button
+                  <HelpTextWrapper__HelpTextButton
                     aria-controls={null}
                     aria-expanded={false}
                     aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button c1"
+                    className="yoast-help__button"
                     onClick={[Function]}
                   >
                     <Button
                       aria-controls={null}
                       aria-expanded={false}
                       aria-label="Help on the Snippet Preview"
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="yoast-help__button c1 c2"
+                      className="yoast-help__button c1"
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         aria-controls={null}
@@ -18162,7 +18155,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2 Button-kDSBcD c3"
+                        className="yoast-help__button c1 c2"
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -18174,7 +18167,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -18186,55 +18179,57 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               aria-controls={null}
                               aria-expanded={false}
                               aria-label="Help on the Snippet Preview"
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
+                              <Button__BaseButton
                                 aria-controls={null}
                                 aria-expanded={false}
                                 aria-label="Help on the Snippet Preview"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <HelpTextWrapper__StyledSvg
-                                  color="#646464"
-                                  icon="question-circle"
-                                  size="16px"
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-label="Help on the Snippet Preview"
+                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon
-                                    className="c8"
+                                  <HelpTextWrapper__StyledSvg
                                     color="#646464"
                                     icon="question-circle"
                                     size="16px"
                                   >
-                                    <SvgIcon__StyledSvg
-                                      aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                      fill="#646464"
-                                      focusable="false"
-                                      role="img"
+                                    <SvgIcon
+                                      className="c8"
+                                      color="#646464"
+                                      icon="question-circle"
                                       size="16px"
-                                      viewBox="0 0 1792 1792"
-                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <svg
+                                      <SvgIcon__StyledSvg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
                                         fill="#646464"
                                         focusable="false"
                                         role="img"
@@ -18242,268 +18237,267 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                         viewBox="0 0 1792 1792"
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                        />
-                                      </svg>
-                                    </SvgIcon__StyledSvg>
-                                  </SvgIcon>
-                                </HelpTextWrapper__StyledSvg>
-                              </button>
-                            </Button__BaseButton>
+                                        <svg
+                                          aria-hidden={true}
+                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                          fill="#646464"
+                                          focusable="false"
+                                          role="img"
+                                          size="16px"
+                                          viewBox="0 0 1792 1792"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                          />
+                                        </svg>
+                                      </SvgIcon__StyledSvg>
+                                    </SvgIcon>
+                                  </HelpTextWrapper__StyledSvg>
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </HelpTextWrapper__HelpTextButton>
-                <YoastSlideToggle
-                  duration={300}
-                  isOpen={false}
-                >
-                  <animations__YoastSlideToggleContainer
+                  </HelpTextWrapper__HelpTextButton>
+                  <YoastSlideToggle
                     duration={300}
+                    isOpen={false}
                   >
-                    <div
-                      className="c10"
+                    <animations__YoastSlideToggleContainer
+                      duration={300}
                     >
-                      <CSSTransition
-                        classNames="slide"
-                        in={false}
-                        onEnter={[Function]}
-                        onEntered={[Function]}
-                        onEntering={[Function]}
-                        onExit={[Function]}
-                        onExiting={[Function]}
-                        timeout={300}
-                        unmountOnExit={true}
+                      <div
+                        className="c10"
                       >
-                        <Transition
-                          appear={false}
-                          enter={true}
-                          exit={true}
+                        <CSSTransition
+                          classNames="slide"
                           in={false}
-                          mountOnEnter={false}
                           onEnter={[Function]}
                           onEntered={[Function]}
                           onEntering={[Function]}
                           onExit={[Function]}
-                          onExited={[Function]}
                           onExiting={[Function]}
                           timeout={300}
                           unmountOnExit={true}
-                        />
-                      </CSSTransition>
-                    </div>
-                  </animations__YoastSlideToggleContainer>
-                </YoastSlideToggle>
-              </div>
-            </HelpTextWrapper__HelpTextContainer>
-          </HelpTextWrapper>
-        </div>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c11"
+                        >
+                          <Transition
+                            appear={false}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            timeout={300}
+                            unmountOnExit={true}
+                          />
+                        </CSSTransition>
+                      </div>
+                    </animations__YoastSlideToggleContainer>
+                  </YoastSlideToggle>
+                </div>
+              </HelpTextWrapper__HelpTextContainer>
+            </HelpTextWrapper>
+          </div>
+          <SnippetPreview__MobileContainer
+            padding={20}
             width={640}
           >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    SEO title preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseTitle
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+            <div
+              className="c11"
+              width={640}
+            >
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <div
-                    className="c13"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      SEO title preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseTitle
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c14"
-                      >
-                        <div
-                          className="c14 c15"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c16"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Url preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseUrl>
-                  <div
-                    className="c17"
-                  >
-                    <SnippetPreview__BaseUrlOverflowContainer
+                    <div
+                      className="c13"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <div
-                        className="c18"
+                      <SnippetPreview__TitleBounded>
+                        <SnippetPreview__Title
+                          className="c14"
+                        >
+                          <div
+                            className="c14 c15"
+                          >
+                            <SnippetPreview__TitleUnboundedMobile
+                              innerRef={[Function]}
+                            >
+                              <span
+                                className="c16"
+                              >
+                                Test title
+                              </span>
+                            </SnippetPreview__TitleUnboundedMobile>
+                          </div>
+                        </SnippetPreview__Title>
+                      </SnippetPreview__TitleBounded>
+                    </div>
+                  </SnippetPreview__BaseTitle>
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Url preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseUrl>
+                    <div
+                      className="c17"
+                    >
+                      <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
-                        example.org › test-slug
-                      </div>
-                    </SnippetPreview__BaseUrlOverflowContainer>
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c19"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Meta description preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__MobileDescription
-                  isDescriptionPlaceholder={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+                        <div
+                          className="c18"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrlOverflowContainer>
+                    </div>
+                  </SnippetPreview__BaseUrl>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+              <SnippetPreview__Separator>
+                <hr
+                  className="c19"
+                />
+              </SnippetPreview__Separator>
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <SnippetPreview__DesktopDescription
-                    className="c20"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Meta description preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__MobileDescription
                     isDescriptionPlaceholder={false}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <div
-                      className="c20 c21"
+                    <SnippetPreview__DesktopDescription
+                      className="c20"
+                      isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <SnippetPreview__MobileDescription
-                        innerRef={[Function]}
-                        isDescriptionPlaceholder={false}
+                      <div
+                        className="c20 c21"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
                       >
-                        <SnippetPreview__DesktopDescription
-                          className="c20"
+                        <SnippetPreview__MobileDescription
                           innerRef={[Function]}
                           isDescriptionPlaceholder={false}
                         >
-                          <div
-                            className="c20 c21"
+                          <SnippetPreview__DesktopDescription
+                            className="c20"
+                            innerRef={[Function]}
+                            isDescriptionPlaceholder={false}
                           >
-                            Test description, %%replacement_variable%%
-                          </div>
-                        </SnippetPreview__DesktopDescription>
-                      </SnippetPreview__MobileDescription>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c22"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
+                            <div
+                              className="c20 c21"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </div>
+                    </SnippetPreview__DesktopDescription>
+                  </SnippetPreview__MobileDescription>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+            </div>
+          </SnippetPreview__MobileContainer>
+        </section>
+      </SnippetPreview>
+      <ModeSwitcher
+        active="mobile"
+        onChange={[Function]}
+      >
+        <ModeSwitcher__Switcher>
+          <div
+            className="c22"
           >
-            <Button
+            <ModeSwitcher__SwitcherButton
               aria-pressed={true}
-              className="c23"
               isActive={true}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c23 c2"
+                className="c23"
                 isActive={true}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={true}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2 Button-kDSBcD c3"
+                  className="c23 c2"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -18514,7 +18508,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c23 c2 Button-kDSBcD c3"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -18525,47 +18519,48 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={true}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={true}
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={true}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
+                          <button
+                            aria-pressed={true}
+                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="mobile"
                               size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                className="yoast-svg-icon yoast-svg-icon-mobile"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -18573,64 +18568,63 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="22px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Mobile preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Mobile preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
+            </ModeSwitcher__SwitcherButton>
+            <ModeSwitcher__SwitcherButton
               aria-pressed={false}
-              className="c25"
               isActive={false}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c25"
                 isActive={false}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={false}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c25 c2"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -18641,7 +18635,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c25 c2 Button-kDSBcD c3"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -18652,47 +18646,48 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={false}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={false}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={false}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
+                          <button
+                            aria-pressed={false}
+                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="desktop"
                               size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                className="yoast-svg-icon yoast-svg-icon-desktop"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -18700,61 +18695,60 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="18px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Desktop preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Desktop preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
+            </ModeSwitcher__SwitcherButton>
+          </div>
+        </ModeSwitcher__Switcher>
+      </ModeSwitcher>
       <Button
         aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c27"
         innerRef={[Function]}
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           aria-expanded={true}
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c3"
+          className="c27"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -18765,7 +18759,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c27 Button-kDSBcD c3"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -18776,97 +18770,107 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 aria-expanded={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
+                <Button__BaseButton
                   aria-expanded={true}
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  innerRef={[Function]}
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
+                  <button
+                    aria-expanded={true}
+                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
+                    <SvgIcon
+                      icon="edit"
                       size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
+                      <SvgIcon__StyledSvg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c9"
+                        className="yoast-svg-icon yoast-svg-icon-edit"
                         focusable="false"
                         role="img"
                         size="16px"
                         viewBox="0 0 1792 1792"
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  Edit snippet
-                </button>
-              </Button__BaseButton>
+                        <svg
+                          aria-hidden={true}
+                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          focusable="false"
+                          role="img"
+                          size="16px"
+                          viewBox="0 0 1792 1792"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                          />
+                        </svg>
+                      </SvgIcon__StyledSvg>
+                    </SvgIcon>
+                    Edit snippet
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
+      <SnippetEditorFields
+        activeField={null}
+        data={
+          Object {
+            "description": "Test description, %%replacement_variable%%",
+            "slug": "test-slug",
+            "title": "Test title",
+          }
         }
-      }
-      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-      descriptionLengthProgress={
-        Object {
-          "actual": 42,
-          "max": 156,
-          "score": 6,
+        descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+        descriptionLengthProgress={
+          Object {
+            "actual": 42,
+            "max": 156,
+            "score": 6,
+          }
         }
-      }
-      hoveredField={null}
-      mobileWidth={356}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthProgress={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 1,
+        hoveredField={null}
+        mobileWidth={356}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        replacementVariables={Array []}
+        titleLengthProgress={
+          Object {
+            "actual": 0,
+            "max": 600,
+            "score": 1,
+          }
         }
-      }
-    >
-      <ErrorBoundary>
+      >
         <Shared__StyledEditor
           innerRef={[Function]}
         >
@@ -19264,25 +19268,15 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             </Shared__FormSection>
           </section>
         </Shared__StyledEditor>
-      </ErrorBoundary>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
+      </SnippetEditorFields>
       <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c38"
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c38"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -19291,7 +19285,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -19300,34 +19294,44 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                <Button__BaseButton
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  Close snippet editor
-                </button>
-              </Button__BaseButton>
+                  <button
+                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Close snippet editor
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-  </div>
+    </div>
+  </ErrorBoundary>
 </SnippetEditor>
 `;
 
@@ -19928,72 +19932,61 @@ exports[`SnippetEditor passes replacement variables to the title and description
     }
   }
 >
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      keyword=""
-      locale="en"
-      mode="mobile"
-      onHover={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <div>
-          <HelpTextWrapper
-            className="yoast-help"
-            helpText={
-              Array [
-                "This is a rendering of what this post might look like in Google's search results. ",
-                <OutboundLink
-                  href="https://yoa.st/snippet-preview"
-                >
-                  Learn more about the Snippet Preview.
-                </OutboundLink>,
-              ]
-            }
-            helpTextButtonLabel="Help on the Snippet Preview"
-            panelMaxWidth="400px"
-          >
-            <HelpTextWrapper__HelpTextContainer
+  <ErrorBoundary>
+    <div>
+      <SnippetPreview
+        activeField={null}
+        breadcrumbs={null}
+        date=""
+        description="Test description, %%replacement_variable%%"
+        hoveredField={null}
+        isAmp={false}
+        keyword=""
+        locale="en"
+        mode="mobile"
+        onHover={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        title="Test title"
+        url="example.org/test-slug"
+      >
+        <section>
+          <div>
+            <HelpTextWrapper
               className="yoast-help"
+              helpText={
+                Array [
+                  "This is a rendering of what this post might look like in Google's search results. ",
+                  <OutboundLink
+                    href="https://yoa.st/snippet-preview"
+                  >
+                    Learn more about the Snippet Preview.
+                  </OutboundLink>,
+                ]
+              }
+              helpTextButtonLabel="Help on the Snippet Preview"
+              panelMaxWidth="400px"
             >
-              <div
-                className="yoast-help c0"
+              <HelpTextWrapper__HelpTextContainer
+                className="yoast-help"
               >
-                <HelpTextWrapper__HelpTextButton
-                  aria-controls={null}
-                  aria-expanded={false}
-                  aria-label="Help on the Snippet Preview"
-                  className="yoast-help__button"
-                  onClick={[Function]}
+                <div
+                  className="yoast-help c0"
                 >
-                  <Button
+                  <HelpTextWrapper__HelpTextButton
                     aria-controls={null}
                     aria-expanded={false}
                     aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button c1"
+                    className="yoast-help__button"
                     onClick={[Function]}
                   >
                     <Button
                       aria-controls={null}
                       aria-expanded={false}
                       aria-label="Help on the Snippet Preview"
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="yoast-help__button c1 c2"
+                      className="yoast-help__button c1"
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         aria-controls={null}
@@ -20002,7 +19995,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2 Button-kDSBcD c3"
+                        className="yoast-help__button c1 c2"
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -20014,7 +20007,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -20026,55 +20019,57 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               aria-controls={null}
                               aria-expanded={false}
                               aria-label="Help on the Snippet Preview"
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
+                              <Button__BaseButton
                                 aria-controls={null}
                                 aria-expanded={false}
                                 aria-label="Help on the Snippet Preview"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <HelpTextWrapper__StyledSvg
-                                  color="#646464"
-                                  icon="question-circle"
-                                  size="16px"
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-label="Help on the Snippet Preview"
+                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon
-                                    className="c8"
+                                  <HelpTextWrapper__StyledSvg
                                     color="#646464"
                                     icon="question-circle"
                                     size="16px"
                                   >
-                                    <SvgIcon__StyledSvg
-                                      aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                      fill="#646464"
-                                      focusable="false"
-                                      role="img"
+                                    <SvgIcon
+                                      className="c8"
+                                      color="#646464"
+                                      icon="question-circle"
                                       size="16px"
-                                      viewBox="0 0 1792 1792"
-                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <svg
+                                      <SvgIcon__StyledSvg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
                                         fill="#646464"
                                         focusable="false"
                                         role="img"
@@ -20082,268 +20077,267 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                         viewBox="0 0 1792 1792"
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                        />
-                                      </svg>
-                                    </SvgIcon__StyledSvg>
-                                  </SvgIcon>
-                                </HelpTextWrapper__StyledSvg>
-                              </button>
-                            </Button__BaseButton>
+                                        <svg
+                                          aria-hidden={true}
+                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                          fill="#646464"
+                                          focusable="false"
+                                          role="img"
+                                          size="16px"
+                                          viewBox="0 0 1792 1792"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                          />
+                                        </svg>
+                                      </SvgIcon__StyledSvg>
+                                    </SvgIcon>
+                                  </HelpTextWrapper__StyledSvg>
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </HelpTextWrapper__HelpTextButton>
-                <YoastSlideToggle
-                  duration={300}
-                  isOpen={false}
-                >
-                  <animations__YoastSlideToggleContainer
+                  </HelpTextWrapper__HelpTextButton>
+                  <YoastSlideToggle
                     duration={300}
+                    isOpen={false}
                   >
-                    <div
-                      className="c10"
+                    <animations__YoastSlideToggleContainer
+                      duration={300}
                     >
-                      <CSSTransition
-                        classNames="slide"
-                        in={false}
-                        onEnter={[Function]}
-                        onEntered={[Function]}
-                        onEntering={[Function]}
-                        onExit={[Function]}
-                        onExiting={[Function]}
-                        timeout={300}
-                        unmountOnExit={true}
+                      <div
+                        className="c10"
                       >
-                        <Transition
-                          appear={false}
-                          enter={true}
-                          exit={true}
+                        <CSSTransition
+                          classNames="slide"
                           in={false}
-                          mountOnEnter={false}
                           onEnter={[Function]}
                           onEntered={[Function]}
                           onEntering={[Function]}
                           onExit={[Function]}
-                          onExited={[Function]}
                           onExiting={[Function]}
                           timeout={300}
                           unmountOnExit={true}
-                        />
-                      </CSSTransition>
-                    </div>
-                  </animations__YoastSlideToggleContainer>
-                </YoastSlideToggle>
-              </div>
-            </HelpTextWrapper__HelpTextContainer>
-          </HelpTextWrapper>
-        </div>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c11"
+                        >
+                          <Transition
+                            appear={false}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            timeout={300}
+                            unmountOnExit={true}
+                          />
+                        </CSSTransition>
+                      </div>
+                    </animations__YoastSlideToggleContainer>
+                  </YoastSlideToggle>
+                </div>
+              </HelpTextWrapper__HelpTextContainer>
+            </HelpTextWrapper>
+          </div>
+          <SnippetPreview__MobileContainer
+            padding={20}
             width={640}
           >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    SEO title preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseTitle
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+            <div
+              className="c11"
+              width={640}
+            >
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <div
-                    className="c13"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      SEO title preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseTitle
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c14"
-                      >
-                        <div
-                          className="c14 c15"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c16"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Url preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseUrl>
-                  <div
-                    className="c17"
-                  >
-                    <SnippetPreview__BaseUrlOverflowContainer
+                    <div
+                      className="c13"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <div
-                        className="c18"
+                      <SnippetPreview__TitleBounded>
+                        <SnippetPreview__Title
+                          className="c14"
+                        >
+                          <div
+                            className="c14 c15"
+                          >
+                            <SnippetPreview__TitleUnboundedMobile
+                              innerRef={[Function]}
+                            >
+                              <span
+                                className="c16"
+                              >
+                                Test title
+                              </span>
+                            </SnippetPreview__TitleUnboundedMobile>
+                          </div>
+                        </SnippetPreview__Title>
+                      </SnippetPreview__TitleBounded>
+                    </div>
+                  </SnippetPreview__BaseTitle>
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Url preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseUrl>
+                    <div
+                      className="c17"
+                    >
+                      <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
-                        example.org › test-slug
-                      </div>
-                    </SnippetPreview__BaseUrlOverflowContainer>
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c19"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Meta description preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__MobileDescription
-                  isDescriptionPlaceholder={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+                        <div
+                          className="c18"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrlOverflowContainer>
+                    </div>
+                  </SnippetPreview__BaseUrl>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+              <SnippetPreview__Separator>
+                <hr
+                  className="c19"
+                />
+              </SnippetPreview__Separator>
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <SnippetPreview__DesktopDescription
-                    className="c20"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Meta description preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__MobileDescription
                     isDescriptionPlaceholder={false}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <div
-                      className="c20 c21"
+                    <SnippetPreview__DesktopDescription
+                      className="c20"
+                      isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <SnippetPreview__MobileDescription
-                        innerRef={[Function]}
-                        isDescriptionPlaceholder={false}
+                      <div
+                        className="c20 c21"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
                       >
-                        <SnippetPreview__DesktopDescription
-                          className="c20"
+                        <SnippetPreview__MobileDescription
                           innerRef={[Function]}
                           isDescriptionPlaceholder={false}
                         >
-                          <div
-                            className="c20 c21"
+                          <SnippetPreview__DesktopDescription
+                            className="c20"
+                            innerRef={[Function]}
+                            isDescriptionPlaceholder={false}
                           >
-                            Test description, %%replacement_variable%%
-                          </div>
-                        </SnippetPreview__DesktopDescription>
-                      </SnippetPreview__MobileDescription>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c22"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
+                            <div
+                              className="c20 c21"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </div>
+                    </SnippetPreview__DesktopDescription>
+                  </SnippetPreview__MobileDescription>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+            </div>
+          </SnippetPreview__MobileContainer>
+        </section>
+      </SnippetPreview>
+      <ModeSwitcher
+        active="mobile"
+        onChange={[Function]}
+      >
+        <ModeSwitcher__Switcher>
+          <div
+            className="c22"
           >
-            <Button
+            <ModeSwitcher__SwitcherButton
               aria-pressed={true}
-              className="c23"
               isActive={true}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c23 c2"
+                className="c23"
                 isActive={true}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={true}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2 Button-kDSBcD c3"
+                  className="c23 c2"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -20354,7 +20348,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c23 c2 Button-kDSBcD c3"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -20365,47 +20359,48 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={true}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={true}
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={true}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
+                          <button
+                            aria-pressed={true}
+                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="mobile"
                               size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                className="yoast-svg-icon yoast-svg-icon-mobile"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -20413,64 +20408,63 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="22px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Mobile preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Mobile preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
+            </ModeSwitcher__SwitcherButton>
+            <ModeSwitcher__SwitcherButton
               aria-pressed={false}
-              className="c25"
               isActive={false}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c25"
                 isActive={false}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={false}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c25 c2"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -20481,7 +20475,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c25 c2 Button-kDSBcD c3"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -20492,47 +20486,48 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={false}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={false}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={false}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
+                          <button
+                            aria-pressed={false}
+                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="desktop"
                               size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                className="yoast-svg-icon yoast-svg-icon-desktop"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -20540,61 +20535,60 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="18px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Desktop preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Desktop preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
+            </ModeSwitcher__SwitcherButton>
+          </div>
+        </ModeSwitcher__Switcher>
+      </ModeSwitcher>
       <Button
         aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c27"
         innerRef={[Function]}
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           aria-expanded={true}
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c3"
+          className="c27"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -20605,7 +20599,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c27 Button-kDSBcD c3"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -20616,108 +20610,118 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 aria-expanded={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
+                <Button__BaseButton
                   aria-expanded={true}
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  innerRef={[Function]}
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
+                  <button
+                    aria-expanded={true}
+                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
+                    <SvgIcon
+                      icon="edit"
                       size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
+                      <SvgIcon__StyledSvg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c9"
+                        className="yoast-svg-icon yoast-svg-icon-edit"
                         focusable="false"
                         role="img"
                         size="16px"
                         viewBox="0 0 1792 1792"
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  Edit snippet
-                </button>
-              </Button__BaseButton>
+                        <svg
+                          aria-hidden={true}
+                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          focusable="false"
+                          role="img"
+                          size="16px"
+                          viewBox="0 0 1792 1792"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                          />
+                        </svg>
+                      </SvgIcon__StyledSvg>
+                    </SvgIcon>
+                    Edit snippet
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
-        }
-      }
-      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-      descriptionLengthProgress={
-        Object {
-          "actual": 42,
-          "max": 156,
-          "score": 6,
-        }
-      }
-      hoveredField={null}
-      mobileWidth={356}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={
-        Array [
+      <SnippetEditorFields
+        activeField={null}
+        data={
           Object {
-            "name": "title",
-            "value": "Title!!!",
-          },
-          Object {
-            "name": "excerpt",
-            "value": "Excerpt!!!",
-          },
-        ]
-      }
-      titleLengthProgress={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 1,
+            "description": "Test description, %%replacement_variable%%",
+            "slug": "test-slug",
+            "title": "Test title",
+          }
         }
-      }
-    >
-      <ErrorBoundary>
+        descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+        descriptionLengthProgress={
+          Object {
+            "actual": 42,
+            "max": 156,
+            "score": 6,
+          }
+        }
+        hoveredField={null}
+        mobileWidth={356}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        replacementVariables={
+          Array [
+            Object {
+              "name": "title",
+              "value": "Title!!!",
+            },
+            Object {
+              "name": "excerpt",
+              "value": "Excerpt!!!",
+            },
+          ]
+        }
+        titleLengthProgress={
+          Object {
+            "actual": 0,
+            "max": 600,
+            "score": 1,
+          }
+        }
+      >
         <Shared__StyledEditor
           innerRef={[Function]}
         >
@@ -21159,25 +21163,15 @@ exports[`SnippetEditor passes replacement variables to the title and description
             </Shared__FormSection>
           </section>
         </Shared__StyledEditor>
-      </ErrorBoundary>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
+      </SnippetEditorFields>
       <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c38"
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c38"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -21186,7 +21180,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -21195,34 +21189,44 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                <Button__BaseButton
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  Close snippet editor
-                </button>
-              </Button__BaseButton>
+                  <button
+                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Close snippet editor
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-  </div>
+    </div>
+  </ErrorBoundary>
 </SnippetEditor>
 `;
 
@@ -21782,78 +21786,80 @@ exports[`SnippetEditor passes the date prop 1`] = `
 `;
 
 exports[`SnippetEditor removes the highlight from the hovered field on calling onMouseLeave() 1`] = `
-<div>
-  <SnippetPreview
-    activeField={null}
-    breadcrumbs={null}
-    date=""
-    description="Test description, %%replacement_variable%%"
-    hoveredField={null}
-    isAmp={false}
-    keyword=""
-    locale="en"
-    mode="mobile"
-    onHover={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    title="Test title"
-    url="example.org/test-slug"
-  />
-  <ModeSwitcher
-    active="mobile"
-    onChange={[Function]}
-  />
-  <Button
-    aria-expanded={true}
-    innerRef={[Function]}
-    onClick={[Function]}
-  >
-    <SvgIcon
-      icon="edit"
-      size="16px"
-    />
-    Edit snippet
-  </Button>
-  <React.Fragment>
-    <SnippetEditorFields
+<ErrorBoundary>
+  <div>
+    <SnippetPreview
       activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
-        }
-      }
-      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-      descriptionLengthProgress={
-        Object {
-          "actual": 42,
-          "max": 156,
-          "score": 6,
-        }
-      }
+      breadcrumbs={null}
+      date=""
+      description="Test description, %%replacement_variable%%"
       hoveredField={null}
-      mobileWidth={356}
-      onBlur={[Function]}
+      isAmp={false}
+      keyword=""
+      locale="en"
+      mode="mobile"
+      onHover={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      title="Test title"
+      url="example.org/test-slug"
+    />
+    <ModeSwitcher
+      active="mobile"
       onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthProgress={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 1,
-        }
-      }
     />
     <Button
+      aria-expanded={true}
+      innerRef={[Function]}
       onClick={[Function]}
     >
-      Close snippet editor
+      <SvgIcon
+        icon="edit"
+        size="16px"
+      />
+      Edit snippet
     </Button>
-  </React.Fragment>
-</div>
+    <React.Fragment>
+      <SnippetEditorFields
+        activeField={null}
+        data={
+          Object {
+            "description": "Test description, %%replacement_variable%%",
+            "slug": "test-slug",
+            "title": "Test title",
+          }
+        }
+        descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+        descriptionLengthProgress={
+          Object {
+            "actual": 42,
+            "max": 156,
+            "score": 6,
+          }
+        }
+        hoveredField={null}
+        mobileWidth={356}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        replacementVariables={Array []}
+        titleLengthProgress={
+          Object {
+            "actual": 0,
+            "max": 600,
+            "score": 1,
+          }
+        }
+      />
+      <Button
+        onClick={[Function]}
+      >
+        Close snippet editor
+      </Button>
+    </React.Fragment>
+  </div>
+</ErrorBoundary>
 `;
 
 exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = `
@@ -22442,72 +22448,61 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
     }
   }
 >
-  <div>
-    <SnippetPreview
-      activeField={null}
-      breadcrumbs={null}
-      date=""
-      description="Test description, %%replacement_variable%%"
-      hoveredField={null}
-      isAmp={false}
-      keyword=""
-      locale="en"
-      mode="mobile"
-      onHover={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      title="Test title"
-      url="example.org/test-slug"
-    >
-      <section>
-        <div>
-          <HelpTextWrapper
-            className="yoast-help"
-            helpText={
-              Array [
-                "This is a rendering of what this post might look like in Google's search results. ",
-                <OutboundLink
-                  href="https://yoa.st/snippet-preview"
-                >
-                  Learn more about the Snippet Preview.
-                </OutboundLink>,
-              ]
-            }
-            helpTextButtonLabel="Help on the Snippet Preview"
-            panelMaxWidth="400px"
-          >
-            <HelpTextWrapper__HelpTextContainer
+  <ErrorBoundary>
+    <div>
+      <SnippetPreview
+        activeField={null}
+        breadcrumbs={null}
+        date=""
+        description="Test description, %%replacement_variable%%"
+        hoveredField={null}
+        isAmp={false}
+        keyword=""
+        locale="en"
+        mode="mobile"
+        onHover={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        title="Test title"
+        url="example.org/test-slug"
+      >
+        <section>
+          <div>
+            <HelpTextWrapper
               className="yoast-help"
+              helpText={
+                Array [
+                  "This is a rendering of what this post might look like in Google's search results. ",
+                  <OutboundLink
+                    href="https://yoa.st/snippet-preview"
+                  >
+                    Learn more about the Snippet Preview.
+                  </OutboundLink>,
+                ]
+              }
+              helpTextButtonLabel="Help on the Snippet Preview"
+              panelMaxWidth="400px"
             >
-              <div
-                className="yoast-help c0"
+              <HelpTextWrapper__HelpTextContainer
+                className="yoast-help"
               >
-                <HelpTextWrapper__HelpTextButton
-                  aria-controls={null}
-                  aria-expanded={false}
-                  aria-label="Help on the Snippet Preview"
-                  className="yoast-help__button"
-                  onClick={[Function]}
+                <div
+                  className="yoast-help c0"
                 >
-                  <Button
+                  <HelpTextWrapper__HelpTextButton
                     aria-controls={null}
                     aria-expanded={false}
                     aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button c1"
+                    className="yoast-help__button"
                     onClick={[Function]}
                   >
                     <Button
                       aria-controls={null}
                       aria-expanded={false}
                       aria-label="Help on the Snippet Preview"
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="yoast-help__button c1 c2"
+                      className="yoast-help__button c1"
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         aria-controls={null}
@@ -22516,7 +22511,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2 Button-kDSBcD c3"
+                        className="yoast-help__button c1 c2"
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -22528,7 +22523,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -22540,55 +22535,57 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               aria-controls={null}
                               aria-expanded={false}
                               aria-label="Help on the Snippet Preview"
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
+                              <Button__BaseButton
                                 aria-controls={null}
                                 aria-expanded={false}
                                 aria-label="Help on the Snippet Preview"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <HelpTextWrapper__StyledSvg
-                                  color="#646464"
-                                  icon="question-circle"
-                                  size="16px"
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-label="Help on the Snippet Preview"
+                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon
-                                    className="c8"
+                                  <HelpTextWrapper__StyledSvg
                                     color="#646464"
                                     icon="question-circle"
                                     size="16px"
                                   >
-                                    <SvgIcon__StyledSvg
-                                      aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                      fill="#646464"
-                                      focusable="false"
-                                      role="img"
+                                    <SvgIcon
+                                      className="c8"
+                                      color="#646464"
+                                      icon="question-circle"
                                       size="16px"
-                                      viewBox="0 0 1792 1792"
-                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <svg
+                                      <SvgIcon__StyledSvg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
                                         fill="#646464"
                                         focusable="false"
                                         role="img"
@@ -22596,268 +22593,267 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                         viewBox="0 0 1792 1792"
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                        />
-                                      </svg>
-                                    </SvgIcon__StyledSvg>
-                                  </SvgIcon>
-                                </HelpTextWrapper__StyledSvg>
-                              </button>
-                            </Button__BaseButton>
+                                        <svg
+                                          aria-hidden={true}
+                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
+                                          fill="#646464"
+                                          focusable="false"
+                                          role="img"
+                                          size="16px"
+                                          viewBox="0 0 1792 1792"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                          />
+                                        </svg>
+                                      </SvgIcon__StyledSvg>
+                                    </SvgIcon>
+                                  </HelpTextWrapper__StyledSvg>
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </HelpTextWrapper__HelpTextButton>
-                <YoastSlideToggle
-                  duration={300}
-                  isOpen={false}
-                >
-                  <animations__YoastSlideToggleContainer
+                  </HelpTextWrapper__HelpTextButton>
+                  <YoastSlideToggle
                     duration={300}
+                    isOpen={false}
                   >
-                    <div
-                      className="c10"
+                    <animations__YoastSlideToggleContainer
+                      duration={300}
                     >
-                      <CSSTransition
-                        classNames="slide"
-                        in={false}
-                        onEnter={[Function]}
-                        onEntered={[Function]}
-                        onEntering={[Function]}
-                        onExit={[Function]}
-                        onExiting={[Function]}
-                        timeout={300}
-                        unmountOnExit={true}
+                      <div
+                        className="c10"
                       >
-                        <Transition
-                          appear={false}
-                          enter={true}
-                          exit={true}
+                        <CSSTransition
+                          classNames="slide"
                           in={false}
-                          mountOnEnter={false}
                           onEnter={[Function]}
                           onEntered={[Function]}
                           onEntering={[Function]}
                           onExit={[Function]}
-                          onExited={[Function]}
                           onExiting={[Function]}
                           timeout={300}
                           unmountOnExit={true}
-                        />
-                      </CSSTransition>
-                    </div>
-                  </animations__YoastSlideToggleContainer>
-                </YoastSlideToggle>
-              </div>
-            </HelpTextWrapper__HelpTextContainer>
-          </HelpTextWrapper>
-        </div>
-        <SnippetPreview__MobileContainer
-          padding={20}
-          width={640}
-        >
-          <div
-            className="c11"
+                        >
+                          <Transition
+                            appear={false}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            timeout={300}
+                            unmountOnExit={true}
+                          />
+                        </CSSTransition>
+                      </div>
+                    </animations__YoastSlideToggleContainer>
+                  </YoastSlideToggle>
+                </div>
+              </HelpTextWrapper__HelpTextContainer>
+            </HelpTextWrapper>
+          </div>
+          <SnippetPreview__MobileContainer
+            padding={20}
             width={640}
           >
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    SEO title preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseTitle
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+            <div
+              className="c11"
+              width={640}
+            >
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <div
-                    className="c13"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      SEO title preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseTitle
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <SnippetPreview__TitleBounded>
-                      <SnippetPreview__Title
-                        className="c14"
-                      >
-                        <div
-                          className="c14 c15"
-                        >
-                          <SnippetPreview__TitleUnboundedMobile
-                            innerRef={[Function]}
-                          >
-                            <span
-                              className="c16"
-                            >
-                              Test title
-                            </span>
-                          </SnippetPreview__TitleUnboundedMobile>
-                        </div>
-                      </SnippetPreview__Title>
-                    </SnippetPreview__TitleBounded>
-                  </div>
-                </SnippetPreview__BaseTitle>
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Url preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__BaseUrl>
-                  <div
-                    className="c17"
-                  >
-                    <SnippetPreview__BaseUrlOverflowContainer
+                    <div
+                      className="c13"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <div
-                        className="c18"
+                      <SnippetPreview__TitleBounded>
+                        <SnippetPreview__Title
+                          className="c14"
+                        >
+                          <div
+                            className="c14 c15"
+                          >
+                            <SnippetPreview__TitleUnboundedMobile
+                              innerRef={[Function]}
+                            >
+                              <span
+                                className="c16"
+                              >
+                                Test title
+                              </span>
+                            </SnippetPreview__TitleUnboundedMobile>
+                          </div>
+                        </SnippetPreview__Title>
+                      </SnippetPreview__TitleBounded>
+                    </div>
+                  </SnippetPreview__BaseTitle>
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Url preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__BaseUrl>
+                    <div
+                      className="c17"
+                    >
+                      <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
-                        example.org › test-slug
-                      </div>
-                    </SnippetPreview__BaseUrlOverflowContainer>
-                  </div>
-                </SnippetPreview__BaseUrl>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-            <SnippetPreview__Separator>
-              <hr
-                className="c19"
-              />
-            </SnippetPreview__Separator>
-            <SnippetPreview__MobilePartContainer>
-              <div
-                className="c12"
-              >
-                <ScreenReaderText>
-                  <span
-                    className="screen-reader-text"
-                    style={
-                      Object {
-                        "clip": "rect(1px, 1px, 1px, 1px)",
-                        "height": "1px",
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "width": "1px",
-                      }
-                    }
-                  >
-                    Meta description preview:
-                  </span>
-                </ScreenReaderText>
-                <SnippetPreview__MobileDescription
-                  isDescriptionPlaceholder={false}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
+                        <div
+                          className="c18"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                        >
+                          example.org › test-slug
+                        </div>
+                      </SnippetPreview__BaseUrlOverflowContainer>
+                    </div>
+                  </SnippetPreview__BaseUrl>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+              <SnippetPreview__Separator>
+                <hr
+                  className="c19"
+                />
+              </SnippetPreview__Separator>
+              <SnippetPreview__MobilePartContainer>
+                <div
+                  className="c12"
                 >
-                  <SnippetPreview__DesktopDescription
-                    className="c20"
+                  <ScreenReaderText>
+                    <span
+                      className="screen-reader-text"
+                      style={
+                        Object {
+                          "clip": "rect(1px, 1px, 1px, 1px)",
+                          "height": "1px",
+                          "overflow": "hidden",
+                          "position": "absolute",
+                          "width": "1px",
+                        }
+                      }
+                    >
+                      Meta description preview:
+                    </span>
+                  </ScreenReaderText>
+                  <SnippetPreview__MobileDescription
                     isDescriptionPlaceholder={false}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     onMouseUp={[Function]}
                   >
-                    <div
-                      className="c20 c21"
+                    <SnippetPreview__DesktopDescription
+                      className="c20"
+                      isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
-                      <SnippetPreview__MobileDescription
-                        innerRef={[Function]}
-                        isDescriptionPlaceholder={false}
+                      <div
+                        className="c20 c21"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
                       >
-                        <SnippetPreview__DesktopDescription
-                          className="c20"
+                        <SnippetPreview__MobileDescription
                           innerRef={[Function]}
                           isDescriptionPlaceholder={false}
                         >
-                          <div
-                            className="c20 c21"
+                          <SnippetPreview__DesktopDescription
+                            className="c20"
+                            innerRef={[Function]}
+                            isDescriptionPlaceholder={false}
                           >
-                            Test description, %%replacement_variable%%
-                          </div>
-                        </SnippetPreview__DesktopDescription>
-                      </SnippetPreview__MobileDescription>
-                    </div>
-                  </SnippetPreview__DesktopDescription>
-                </SnippetPreview__MobileDescription>
-              </div>
-            </SnippetPreview__MobilePartContainer>
-          </div>
-        </SnippetPreview__MobileContainer>
-      </section>
-    </SnippetPreview>
-    <ModeSwitcher
-      active="mobile"
-      onChange={[Function]}
-    >
-      <ModeSwitcher__Switcher>
-        <div
-          className="c22"
-        >
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={true}
-            isActive={true}
-            onClick={[Function]}
+                            <div
+                              className="c20 c21"
+                            >
+                              Test description, %%replacement_variable%%
+                            </div>
+                          </SnippetPreview__DesktopDescription>
+                        </SnippetPreview__MobileDescription>
+                      </div>
+                    </SnippetPreview__DesktopDescription>
+                  </SnippetPreview__MobileDescription>
+                </div>
+              </SnippetPreview__MobilePartContainer>
+            </div>
+          </SnippetPreview__MobileContainer>
+        </section>
+      </SnippetPreview>
+      <ModeSwitcher
+        active="mobile"
+        onChange={[Function]}
+      >
+        <ModeSwitcher__Switcher>
+          <div
+            className="c22"
           >
-            <Button
+            <ModeSwitcher__SwitcherButton
               aria-pressed={true}
-              className="c23"
               isActive={true}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={true}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c23 c2"
+                className="c23"
                 isActive={true}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={true}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2 Button-kDSBcD c3"
+                  className="c23 c2"
                   isActive={true}
                   onClick={[Function]}
                   textColor="#555"
@@ -22868,7 +22864,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c23 c2 Button-kDSBcD c3"
                     isActive={true}
                     onClick={[Function]}
                     textColor="#555"
@@ -22879,47 +22875,48 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={true}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={true}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={true}
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={true}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="mobile"
-                            size="22px"
+                          <button
+                            aria-pressed={true}
+                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-mobile"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="mobile"
                               size="22px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                className="yoast-svg-icon yoast-svg-icon-mobile"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -22927,64 +22924,63 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="22px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M976 1408q0-33-23.5-56.5t-56.5-23.5-56.5 23.5-23.5 56.5 23.5 56.5 56.5 23.5 56.5-23.5 23.5-56.5zm208-160v-704q0-13-9.5-22.5t-22.5-9.5h-512q-13 0-22.5 9.5t-9.5 22.5v704q0 13 9.5 22.5t22.5 9.5h512q13 0 22.5-9.5t9.5-22.5zm-192-848q0-16-16-16h-160q-16 0-16 16t16 16h160q16 0 16-16zm288-16v1024q0 52-38 90t-90 38h-512q-52 0-90-38t-38-90v-1024q0-52 38-90t90-38h512q52 0 90 38t38 90z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Mobile preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Mobile preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-          <ModeSwitcher__SwitcherButton
-            aria-pressed={false}
-            isActive={false}
-            onClick={[Function]}
-          >
-            <Button
+            </ModeSwitcher__SwitcherButton>
+            <ModeSwitcher__SwitcherButton
               aria-pressed={false}
-              className="c25"
               isActive={false}
               onClick={[Function]}
             >
               <Button
                 aria-pressed={false}
-                backgroundColor="#f7f7f7"
-                borderColor="#ccc"
-                boxShadowColor="#ccc"
-                className="c25 c2"
+                className="c25"
                 isActive={false}
                 onClick={[Function]}
-                textColor="#555"
-                type="button"
               >
                 <Button
                   aria-pressed={false}
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2 Button-kDSBcD c3"
+                  className="c25 c2"
                   isActive={false}
                   onClick={[Function]}
                   textColor="#555"
@@ -22995,7 +22991,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                    className="c25 c2 Button-kDSBcD c3"
                     isActive={false}
                     onClick={[Function]}
                     textColor="#555"
@@ -23006,47 +23002,48 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                       isActive={false}
                       onClick={[Function]}
                       textColor="#555"
                       type="button"
                     >
-                      <Button__BaseButton
+                      <Button
                         aria-pressed={false}
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                         isActive={false}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
                       >
-                        <button
+                        <Button__BaseButton
                           aria-pressed={false}
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                          backgroundColor="#f7f7f7"
+                          borderColor="#ccc"
+                          boxShadowColor="#ccc"
+                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          isActive={false}
                           onClick={[Function]}
+                          textColor="#555"
                           type="button"
                         >
-                          <SvgIcon
-                            color="currentColor"
-                            icon="desktop"
-                            size="18px"
+                          <button
+                            aria-pressed={false}
+                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <SvgIcon__StyledSvg
-                              aria-hidden={true}
-                              className="yoast-svg-icon yoast-svg-icon-desktop"
-                              fill="currentColor"
-                              focusable="false"
-                              role="img"
+                            <SvgIcon
+                              color="currentColor"
+                              icon="desktop"
                               size="18px"
-                              viewBox="0 0 1792 1792"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
+                              <SvgIcon__StyledSvg
                                 aria-hidden={true}
-                                className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                className="yoast-svg-icon yoast-svg-icon-desktop"
                                 fill="currentColor"
                                 focusable="false"
                                 role="img"
@@ -23054,61 +23051,60 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                 viewBox="0 0 1792 1792"
                                 xmlns="http://www.w3.org/2000/svg"
                               >
-                                <path
-                                  d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
-                                />
-                              </svg>
-                            </SvgIcon__StyledSvg>
-                          </SvgIcon>
-                          <ScreenReaderText>
-                            <span
-                              className="screen-reader-text"
-                              style={
-                                Object {
-                                  "clip": "rect(1px, 1px, 1px, 1px)",
-                                  "height": "1px",
-                                  "overflow": "hidden",
-                                  "position": "absolute",
-                                  "width": "1px",
+                                <svg
+                                  aria-hidden={true}
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  role="img"
+                                  size="18px"
+                                  viewBox="0 0 1792 1792"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M1728 992v-832q0-13-9.5-22.5t-22.5-9.5h-1600q-13 0-22.5 9.5t-9.5 22.5v832q0 13 9.5 22.5t22.5 9.5h1600q13 0 22.5-9.5t9.5-22.5zm128-832v1088q0 66-47 113t-113 47h-544q0 37 16 77.5t32 71 16 43.5q0 26-19 45t-45 19h-512q-26 0-45-19t-19-45q0-14 16-44t32-70 16-78h-544q-66 0-113-47t-47-113v-1088q0-66 47-113t113-47h1600q66 0 113 47t47 113z"
+                                  />
+                                </svg>
+                              </SvgIcon__StyledSvg>
+                            </SvgIcon>
+                            <ScreenReaderText>
+                              <span
+                                className="screen-reader-text"
+                                style={
+                                  Object {
+                                    "clip": "rect(1px, 1px, 1px, 1px)",
+                                    "height": "1px",
+                                    "overflow": "hidden",
+                                    "position": "absolute",
+                                    "width": "1px",
+                                  }
                                 }
-                              }
-                            >
-                              Desktop preview
-                            </span>
-                          </ScreenReaderText>
-                        </button>
-                      </Button__BaseButton>
+                              >
+                                Desktop preview
+                              </span>
+                            </ScreenReaderText>
+                          </button>
+                        </Button__BaseButton>
+                      </Button>
                     </Button>
                   </Button>
                 </Button>
               </Button>
-            </Button>
-          </ModeSwitcher__SwitcherButton>
-        </div>
-      </ModeSwitcher__Switcher>
-    </ModeSwitcher>
-    <Button
-      aria-expanded={true}
-      innerRef={[Function]}
-      onClick={[Function]}
-    >
+            </ModeSwitcher__SwitcherButton>
+          </div>
+        </ModeSwitcher__Switcher>
+      </ModeSwitcher>
       <Button
         aria-expanded={true}
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c27"
         innerRef={[Function]}
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           aria-expanded={true}
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27 Button-kDSBcD c3"
+          className="c27"
           innerRef={[Function]}
           onClick={[Function]}
           textColor="#555"
@@ -23119,7 +23115,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c27 Button-kDSBcD c3"
             innerRef={[Function]}
             onClick={[Function]}
             textColor="#555"
@@ -23130,97 +23126,107 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
               innerRef={[Function]}
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 aria-expanded={true}
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 innerRef={[Function]}
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
+                <Button__BaseButton
                   aria-expanded={true}
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  innerRef={[Function]}
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  <SvgIcon
-                    icon="edit"
-                    size="16px"
+                  <button
+                    aria-expanded={true}
+                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <SvgIcon__StyledSvg
-                      aria-hidden={true}
-                      className="yoast-svg-icon yoast-svg-icon-edit"
-                      focusable="false"
-                      role="img"
+                    <SvgIcon
+                      icon="edit"
                       size="16px"
-                      viewBox="0 0 1792 1792"
-                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
+                      <SvgIcon__StyledSvg
                         aria-hidden={true}
-                        className="yoast-svg-icon yoast-svg-icon-edit c9"
+                        className="yoast-svg-icon yoast-svg-icon-edit"
                         focusable="false"
                         role="img"
                         size="16px"
                         viewBox="0 0 1792 1792"
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-                        />
-                      </svg>
-                    </SvgIcon__StyledSvg>
-                  </SvgIcon>
-                  Edit snippet
-                </button>
-              </Button__BaseButton>
+                        <svg
+                          aria-hidden={true}
+                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          focusable="false"
+                          role="img"
+                          size="16px"
+                          viewBox="0 0 1792 1792"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
+                          />
+                        </svg>
+                      </SvgIcon__StyledSvg>
+                    </SvgIcon>
+                    Edit snippet
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-    <SnippetEditorFields
-      activeField={null}
-      data={
-        Object {
-          "description": "Test description, %%replacement_variable%%",
-          "slug": "test-slug",
-          "title": "Test title",
+      <SnippetEditorFields
+        activeField={null}
+        data={
+          Object {
+            "description": "Test description, %%replacement_variable%%",
+            "slug": "test-slug",
+            "title": "Test title",
+          }
         }
-      }
-      descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
-      descriptionLengthProgress={
-        Object {
-          "actual": 42,
-          "max": 156,
-          "score": 6,
+        descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
+        descriptionLengthProgress={
+          Object {
+            "actual": 42,
+            "max": 156,
+            "score": 6,
+          }
         }
-      }
-      hoveredField={null}
-      mobileWidth={356}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      replacementVariables={Array []}
-      titleLengthProgress={
-        Object {
-          "actual": 0,
-          "max": 600,
-          "score": 1,
+        hoveredField={null}
+        mobileWidth={356}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        replacementVariables={Array []}
+        titleLengthProgress={
+          Object {
+            "actual": 0,
+            "max": 600,
+            "score": 1,
+          }
         }
-      }
-    >
-      <ErrorBoundary>
+      >
         <Shared__StyledEditor
           innerRef={[Function]}
         >
@@ -23618,25 +23624,15 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
             </Shared__FormSection>
           </section>
         </Shared__StyledEditor>
-      </ErrorBoundary>
-    </SnippetEditorFields>
-    <Button
-      onClick={[Function]}
-    >
+      </SnippetEditorFields>
       <Button
-        backgroundColor="#f7f7f7"
-        borderColor="#ccc"
-        boxShadowColor="#ccc"
-        className="c38"
         onClick={[Function]}
-        textColor="#555"
-        type="button"
       >
         <Button
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38 Button-kDSBcD c3"
+          className="c38"
           onClick={[Function]}
           textColor="#555"
           type="button"
@@ -23645,7 +23641,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+            className="c38 Button-kDSBcD c3"
             onClick={[Function]}
             textColor="#555"
             type="button"
@@ -23654,34 +23650,44 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
               onClick={[Function]}
               textColor="#555"
               type="button"
             >
-              <Button__BaseButton
+              <Button
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                 onClick={[Function]}
                 textColor="#555"
                 type="button"
               >
-                <button
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                <Button__BaseButton
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ccc"
+                  boxShadowColor="#ccc"
+                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
                   onClick={[Function]}
+                  textColor="#555"
                   type="button"
                 >
-                  Close snippet editor
-                </button>
-              </Button__BaseButton>
+                  <button
+                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Close snippet editor
+                  </button>
+                </Button__BaseButton>
+              </Button>
             </Button>
           </Button>
         </Button>
       </Button>
-    </Button>
-  </div>
+    </div>
+  </ErrorBoundary>
 </SnippetEditor>
 `;
 

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -1984,66 +1984,57 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
         }
       }
     >
-      <Shared__StyledEditor
-        innerRef={[Function]}
-      >
-        <section
-          className="c28"
+      <ErrorBoundary>
+        <Shared__StyledEditor
+          innerRef={[Function]}
         >
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test title"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="SEO title"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                replacementVariables={Array []}
-                styleForMobile={true}
-                withCaret={true}
+          <section
+            className="c28"
+          >
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="30"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test title"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="SEO title"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="30"
                     onClick={[Function]}
                   >
-                    SEO title
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="30"
+                      onClick={[Function]}
+                    >
+                      SEO title
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -2053,7 +2044,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -2063,205 +2054,205 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="c32"
+                      onClick={[Function]}
+                    >
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="30"
+                        content="Test title"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
+                  aria-hidden="true"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
+                  max={600}
+                  progressColor="#dc3232"
+                  value={0}
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c33"
+                    max={600}
+                    value={0}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
+              >
+                <Shared__SimulatedLabel
+                  id="snippet-editor-field-29-slug"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="c30"
+                    id="snippet-editor-field-29-slug"
+                    onClick={[Function]}
+                  >
+                    Slug
+                  </div>
+                </Shared__SimulatedLabel>
                 <Shared__InputContainer
                   isActive={false}
                   isHovered={false}
                   onClick={[Function]}
                 >
                   <div
-                    className="c32"
+                    className="c34"
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="30"
-                      content="Test title"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      replacementVariables={Array []}
-                    >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c33"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <Shared__SimulatedLabel
-                id="snippet-editor-field-29-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c30"
-                  id="snippet-editor-field-29-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </Shared__SimulatedLabel>
-              <Shared__InputContainer
-                isActive={false}
-                isHovered={false}
-                onClick={[Function]}
-              >
-                <div
-                  className="c34"
-                  onClick={[Function]}
-                >
-                  <SnippetEditorFields__SlugInput
-                    aria-labelledby="snippet-editor-field-29-slug"
-                    innerRef={[Function]}
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    value="test-slug"
-                  >
-                    <input
+                    <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-29-slug"
-                      className="c35"
+                      innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
                       value="test-slug"
-                    />
-                  </SnippetEditorFields__SlugInput>
-                </div>
-              </Shared__InputContainer>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test description, %%replacement_variable%%"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="Meta description"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder="Modify your meta description by editing it right here"
-                replacementVariables={Array []}
-                styleForMobile={true}
-                type="description"
-                withCaret={true}
+                    >
+                      <input
+                        aria-labelledby="snippet-editor-field-29-slug"
+                        className="c35"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        value="test-slug"
+                      />
+                    </SnippetEditorFields__SlugInput>
+                  </div>
+                </Shared__InputContainer>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="31"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test description, %%replacement_variable%%"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="Meta description"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder="Modify your meta description by editing it right here"
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  type="description"
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="31"
                     onClick={[Function]}
                   >
-                    Meta description
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="31"
+                      onClick={[Function]}
+                    >
+                      Meta description
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -2271,7 +2262,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -2281,106 +2272,117 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
-                <Shared__InputContainer
-                  isActive={false}
-                  isHovered={false}
-                  onClick={[Function]}
-                >
-                  <div
-                    className="c36"
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="31"
-                      content="Test description, %%replacement_variable%%"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Modify your meta description by editing it right here"
-                      replacementVariables={Array []}
+                    <div
+                      className="c36"
+                      onClick={[Function]}
                     >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={156}
-                progressColor="#ee7c1b"
-                value={42}
-              >
-                <progress
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="31"
+                        content="Test description, %%replacement_variable%%"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="Modify your meta description by editing it right here"
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
                   aria-hidden="true"
-                  className="c37"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
                   max={156}
+                  progressColor="#ee7c1b"
                   value={42}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-        </section>
-      </Shared__StyledEditor>
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c37"
+                    max={156}
+                    value={42}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+          </section>
+        </Shared__StyledEditor>
+      </ErrorBoundary>
     </SnippetEditorFields>
     <Button
       onClick={[Function]}
@@ -3811,66 +3813,57 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
         }
       }
     >
-      <Shared__StyledEditor
-        innerRef={[Function]}
-      >
-        <section
-          className="c28"
+      <ErrorBoundary>
+        <Shared__StyledEditor
+          innerRef={[Function]}
         >
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test title"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="SEO title"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                replacementVariables={Array []}
-                styleForMobile={true}
-                withCaret={true}
+          <section
+            className="c28"
+          >
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="30"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test title"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="SEO title"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="30"
                     onClick={[Function]}
                   >
-                    SEO title
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="30"
+                      onClick={[Function]}
+                    >
+                      SEO title
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -3880,7 +3873,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -3890,205 +3883,205 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="c32"
+                      onClick={[Function]}
+                    >
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="30"
+                        content="Test title"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
+                  aria-hidden="true"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
+                  max={600}
+                  progressColor="#dc3232"
+                  value={0}
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c33"
+                    max={600}
+                    value={0}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
+              >
+                <Shared__SimulatedLabel
+                  id="snippet-editor-field-29-slug"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="c30"
+                    id="snippet-editor-field-29-slug"
+                    onClick={[Function]}
+                  >
+                    Slug
+                  </div>
+                </Shared__SimulatedLabel>
                 <Shared__InputContainer
                   isActive={false}
                   isHovered={false}
                   onClick={[Function]}
                 >
                   <div
-                    className="c32"
+                    className="c34"
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="30"
-                      content="Test title"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      replacementVariables={Array []}
-                    >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c33"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <Shared__SimulatedLabel
-                id="snippet-editor-field-29-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c30"
-                  id="snippet-editor-field-29-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </Shared__SimulatedLabel>
-              <Shared__InputContainer
-                isActive={false}
-                isHovered={false}
-                onClick={[Function]}
-              >
-                <div
-                  className="c34"
-                  onClick={[Function]}
-                >
-                  <SnippetEditorFields__SlugInput
-                    aria-labelledby="snippet-editor-field-29-slug"
-                    innerRef={[Function]}
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    value="test-slug"
-                  >
-                    <input
+                    <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-29-slug"
-                      className="c35"
+                      innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
                       value="test-slug"
-                    />
-                  </SnippetEditorFields__SlugInput>
-                </div>
-              </Shared__InputContainer>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test description, %%replacement_variable%%"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="Meta description"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder="Modify your meta description by editing it right here"
-                replacementVariables={Array []}
-                styleForMobile={true}
-                type="description"
-                withCaret={true}
+                    >
+                      <input
+                        aria-labelledby="snippet-editor-field-29-slug"
+                        className="c35"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        value="test-slug"
+                      />
+                    </SnippetEditorFields__SlugInput>
+                  </div>
+                </Shared__InputContainer>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="31"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test description, %%replacement_variable%%"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="Meta description"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder="Modify your meta description by editing it right here"
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  type="description"
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="31"
                     onClick={[Function]}
                   >
-                    Meta description
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="31"
+                      onClick={[Function]}
+                    >
+                      Meta description
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -4098,7 +4091,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -4108,106 +4101,117 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
-                <Shared__InputContainer
-                  isActive={false}
-                  isHovered={false}
-                  onClick={[Function]}
-                >
-                  <div
-                    className="c36"
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="31"
-                      content="Test description, %%replacement_variable%%"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Modify your meta description by editing it right here"
-                      replacementVariables={Array []}
+                    <div
+                      className="c36"
+                      onClick={[Function]}
                     >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={156}
-                progressColor="#ee7c1b"
-                value={42}
-              >
-                <progress
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="31"
+                        content="Test description, %%replacement_variable%%"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="Modify your meta description by editing it right here"
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
                   aria-hidden="true"
-                  className="c37"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
                   max={156}
+                  progressColor="#ee7c1b"
                   value={42}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-        </section>
-      </Shared__StyledEditor>
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c37"
+                    max={156}
+                    value={42}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+          </section>
+        </Shared__StyledEditor>
+      </ErrorBoundary>
     </SnippetEditorFields>
     <Button
       onClick={[Function]}
@@ -5638,66 +5642,57 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
         }
       }
     >
-      <Shared__StyledEditor
-        innerRef={[Function]}
-      >
-        <section
-          className="c28"
+      <ErrorBoundary>
+        <Shared__StyledEditor
+          innerRef={[Function]}
         >
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test title"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="SEO title"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                replacementVariables={Array []}
-                styleForMobile={true}
-                withCaret={true}
+          <section
+            className="c28"
+          >
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="30"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test title"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="SEO title"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="30"
                     onClick={[Function]}
                   >
-                    SEO title
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="30"
+                      onClick={[Function]}
+                    >
+                      SEO title
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -5707,7 +5702,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -5717,205 +5712,205 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="c32"
+                      onClick={[Function]}
+                    >
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="30"
+                        content="Test title"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
+                  aria-hidden="true"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
+                  max={600}
+                  progressColor="#dc3232"
+                  value={0}
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c33"
+                    max={600}
+                    value={0}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
+              >
+                <Shared__SimulatedLabel
+                  id="snippet-editor-field-29-slug"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="c30"
+                    id="snippet-editor-field-29-slug"
+                    onClick={[Function]}
+                  >
+                    Slug
+                  </div>
+                </Shared__SimulatedLabel>
                 <Shared__InputContainer
                   isActive={false}
                   isHovered={false}
                   onClick={[Function]}
                 >
                   <div
-                    className="c32"
+                    className="c34"
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="30"
-                      content="Test title"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      replacementVariables={Array []}
-                    >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c33"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <Shared__SimulatedLabel
-                id="snippet-editor-field-29-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c30"
-                  id="snippet-editor-field-29-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </Shared__SimulatedLabel>
-              <Shared__InputContainer
-                isActive={false}
-                isHovered={false}
-                onClick={[Function]}
-              >
-                <div
-                  className="c34"
-                  onClick={[Function]}
-                >
-                  <SnippetEditorFields__SlugInput
-                    aria-labelledby="snippet-editor-field-29-slug"
-                    innerRef={[Function]}
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    value="test-slug"
-                  >
-                    <input
+                    <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-29-slug"
-                      className="c35"
+                      innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
                       value="test-slug"
-                    />
-                  </SnippetEditorFields__SlugInput>
-                </div>
-              </Shared__InputContainer>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test description, %%replacement_variable%%"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="Meta description"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder="Modify your meta description by editing it right here"
-                replacementVariables={Array []}
-                styleForMobile={true}
-                type="description"
-                withCaret={true}
+                    >
+                      <input
+                        aria-labelledby="snippet-editor-field-29-slug"
+                        className="c35"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        value="test-slug"
+                      />
+                    </SnippetEditorFields__SlugInput>
+                  </div>
+                </Shared__InputContainer>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="31"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test description, %%replacement_variable%%"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="Meta description"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder="Modify your meta description by editing it right here"
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  type="description"
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="31"
                     onClick={[Function]}
                   >
-                    Meta description
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="31"
+                      onClick={[Function]}
+                    >
+                      Meta description
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -5925,7 +5920,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -5935,106 +5930,117 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
-                <Shared__InputContainer
-                  isActive={false}
-                  isHovered={false}
-                  onClick={[Function]}
-                >
-                  <div
-                    className="c36"
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="31"
-                      content="Test description, %%replacement_variable%%"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Modify your meta description by editing it right here"
-                      replacementVariables={Array []}
+                    <div
+                      className="c36"
+                      onClick={[Function]}
                     >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={156}
-                progressColor="#ee7c1b"
-                value={42}
-              >
-                <progress
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="31"
+                        content="Test description, %%replacement_variable%%"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="Modify your meta description by editing it right here"
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
                   aria-hidden="true"
-                  className="c37"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
                   max={156}
+                  progressColor="#ee7c1b"
                   value={42}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-        </section>
-      </Shared__StyledEditor>
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c37"
+                    max={156}
+                    value={42}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+          </section>
+        </Shared__StyledEditor>
+      </ErrorBoundary>
     </SnippetEditorFields>
     <Button
       onClick={[Function]}
@@ -7465,66 +7471,57 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         }
       }
     >
-      <Shared__StyledEditor
-        innerRef={[Function]}
-      >
-        <section
-          className="c28"
+      <ErrorBoundary>
+        <Shared__StyledEditor
+          innerRef={[Function]}
         >
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test title"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="SEO title"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                replacementVariables={Array []}
-                styleForMobile={true}
-                withCaret={true}
+          <section
+            className="c28"
+          >
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="13"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test title"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="SEO title"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="13"
                     onClick={[Function]}
                   >
-                    SEO title
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="13"
+                      onClick={[Function]}
+                    >
+                      SEO title
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -7534,7 +7531,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -7544,205 +7541,205 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="c32"
+                      onClick={[Function]}
+                    >
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="13"
+                        content="Test title"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
+                  aria-hidden="true"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
+                  max={600}
+                  progressColor="#dc3232"
+                  value={0}
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c33"
+                    max={600}
+                    value={0}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
+              >
+                <Shared__SimulatedLabel
+                  id="snippet-editor-field-12-slug"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="c30"
+                    id="snippet-editor-field-12-slug"
+                    onClick={[Function]}
+                  >
+                    Slug
+                  </div>
+                </Shared__SimulatedLabel>
                 <Shared__InputContainer
                   isActive={false}
                   isHovered={false}
                   onClick={[Function]}
                 >
                   <div
-                    className="c32"
+                    className="c34"
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="13"
-                      content="Test title"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      replacementVariables={Array []}
-                    >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c33"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <Shared__SimulatedLabel
-                id="snippet-editor-field-12-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c30"
-                  id="snippet-editor-field-12-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </Shared__SimulatedLabel>
-              <Shared__InputContainer
-                isActive={false}
-                isHovered={false}
-                onClick={[Function]}
-              >
-                <div
-                  className="c34"
-                  onClick={[Function]}
-                >
-                  <SnippetEditorFields__SlugInput
-                    aria-labelledby="snippet-editor-field-12-slug"
-                    innerRef={[Function]}
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    value="test-slug"
-                  >
-                    <input
+                    <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-12-slug"
-                      className="c35"
+                      innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
                       value="test-slug"
-                    />
-                  </SnippetEditorFields__SlugInput>
-                </div>
-              </Shared__InputContainer>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test description, %%replacement_variable%%"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="Meta description"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder="Modify your meta description by editing it right here"
-                replacementVariables={Array []}
-                styleForMobile={true}
-                type="description"
-                withCaret={true}
+                    >
+                      <input
+                        aria-labelledby="snippet-editor-field-12-slug"
+                        className="c35"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        value="test-slug"
+                      />
+                    </SnippetEditorFields__SlugInput>
+                  </div>
+                </Shared__InputContainer>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="14"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test description, %%replacement_variable%%"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="Meta description"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder="Modify your meta description by editing it right here"
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  type="description"
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="14"
                     onClick={[Function]}
                   >
-                    Meta description
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="14"
+                      onClick={[Function]}
+                    >
+                      Meta description
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -7752,7 +7749,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -7762,106 +7759,117 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
-                <Shared__InputContainer
-                  isActive={false}
-                  isHovered={false}
-                  onClick={[Function]}
-                >
-                  <div
-                    className="c36"
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="14"
-                      content="Test description, %%replacement_variable%%"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Modify your meta description by editing it right here"
-                      replacementVariables={Array []}
+                    <div
+                      className="c36"
+                      onClick={[Function]}
                     >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={156}
-                progressColor="#ee7c1b"
-                value={42}
-              >
-                <progress
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="14"
+                        content="Test description, %%replacement_variable%%"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="Modify your meta description by editing it right here"
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
                   aria-hidden="true"
-                  className="c37"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
                   max={156}
+                  progressColor="#ee7c1b"
                   value={42}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-        </section>
-      </Shared__StyledEditor>
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c37"
+                    max={156}
+                    value={42}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+          </section>
+        </Shared__StyledEditor>
+      </ErrorBoundary>
     </SnippetEditorFields>
     <Button
       onClick={[Function]}
@@ -10412,66 +10420,57 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         }
       }
     >
-      <Shared__StyledEditor
-        innerRef={[Function]}
-      >
-        <section
-          className="c28"
+      <ErrorBoundary>
+        <Shared__StyledEditor
+          innerRef={[Function]}
         >
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test title"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="SEO title"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                replacementVariables={Array []}
-                styleForMobile={true}
-                withCaret={true}
+          <section
+            className="c28"
+          >
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="46"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test title"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="SEO title"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="46"
                     onClick={[Function]}
                   >
-                    SEO title
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="46"
+                      onClick={[Function]}
+                    >
+                      SEO title
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -10481,7 +10480,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -10491,205 +10490,205 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="c32"
+                      onClick={[Function]}
+                    >
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="46"
+                        content="Test title"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
+                  aria-hidden="true"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
+                  max={600}
+                  progressColor="#dc3232"
+                  value={0}
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c33"
+                    max={600}
+                    value={0}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
+              >
+                <Shared__SimulatedLabel
+                  id="snippet-editor-field-45-slug"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="c30"
+                    id="snippet-editor-field-45-slug"
+                    onClick={[Function]}
+                  >
+                    Slug
+                  </div>
+                </Shared__SimulatedLabel>
                 <Shared__InputContainer
                   isActive={false}
                   isHovered={false}
                   onClick={[Function]}
                 >
                   <div
-                    className="c32"
+                    className="c34"
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="46"
-                      content="Test title"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      replacementVariables={Array []}
-                    >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c33"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <Shared__SimulatedLabel
-                id="snippet-editor-field-45-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c30"
-                  id="snippet-editor-field-45-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </Shared__SimulatedLabel>
-              <Shared__InputContainer
-                isActive={false}
-                isHovered={false}
-                onClick={[Function]}
-              >
-                <div
-                  className="c34"
-                  onClick={[Function]}
-                >
-                  <SnippetEditorFields__SlugInput
-                    aria-labelledby="snippet-editor-field-45-slug"
-                    innerRef={[Function]}
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    value="test-slug"
-                  >
-                    <input
+                    <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-45-slug"
-                      className="c35"
+                      innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
                       value="test-slug"
-                    />
-                  </SnippetEditorFields__SlugInput>
-                </div>
-              </Shared__InputContainer>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test description, %%replacement_variable%%"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="Meta description"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder="Modify your meta description by editing it right here"
-                replacementVariables={Array []}
-                styleForMobile={true}
-                type="description"
-                withCaret={true}
+                    >
+                      <input
+                        aria-labelledby="snippet-editor-field-45-slug"
+                        className="c35"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        value="test-slug"
+                      />
+                    </SnippetEditorFields__SlugInput>
+                  </div>
+                </Shared__InputContainer>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="47"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test description, %%replacement_variable%%"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="Meta description"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder="Modify your meta description by editing it right here"
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  type="description"
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="47"
                     onClick={[Function]}
                   >
-                    Meta description
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="47"
+                      onClick={[Function]}
+                    >
+                      Meta description
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -10699,7 +10698,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -10709,106 +10708,117 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
-                <Shared__InputContainer
-                  isActive={false}
-                  isHovered={false}
-                  onClick={[Function]}
-                >
-                  <div
-                    className="c36"
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="47"
-                      content="Test description, %%replacement_variable%%"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Modify your meta description by editing it right here"
-                      replacementVariables={Array []}
+                    <div
+                      className="c36"
+                      onClick={[Function]}
                     >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={156}
-                progressColor="#ee7c1b"
-                value={42}
-              >
-                <progress
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="47"
+                        content="Test description, %%replacement_variable%%"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="Modify your meta description by editing it right here"
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
                   aria-hidden="true"
-                  className="c37"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
                   max={156}
+                  progressColor="#ee7c1b"
                   value={42}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-        </section>
-      </Shared__StyledEditor>
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c37"
+                    max={156}
+                    value={42}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+          </section>
+        </Shared__StyledEditor>
+      </ErrorBoundary>
     </SnippetEditorFields>
     <Button
       onClick={[Function]}
@@ -12239,66 +12249,57 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         }
       }
     >
-      <Shared__StyledEditor
-        innerRef={[Function]}
-      >
-        <section
-          className="c28"
+      <ErrorBoundary>
+        <Shared__StyledEditor
+          innerRef={[Function]}
         >
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test title"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="SEO title"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                replacementVariables={Array []}
-                styleForMobile={true}
-                withCaret={true}
+          <section
+            className="c28"
+          >
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="42"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test title"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="SEO title"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="42"
                     onClick={[Function]}
                   >
-                    SEO title
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="42"
+                      onClick={[Function]}
+                    >
+                      SEO title
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -12308,7 +12309,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -12318,205 +12319,205 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="c32"
+                      onClick={[Function]}
+                    >
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="42"
+                        content="Test title"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
+                  aria-hidden="true"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
+                  max={600}
+                  progressColor="#dc3232"
+                  value={0}
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c33"
+                    max={600}
+                    value={0}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
+              >
+                <Shared__SimulatedLabel
+                  id="snippet-editor-field-41-slug"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="c30"
+                    id="snippet-editor-field-41-slug"
+                    onClick={[Function]}
+                  >
+                    Slug
+                  </div>
+                </Shared__SimulatedLabel>
                 <Shared__InputContainer
                   isActive={false}
                   isHovered={false}
                   onClick={[Function]}
                 >
                   <div
-                    className="c32"
+                    className="c34"
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="42"
-                      content="Test title"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      replacementVariables={Array []}
-                    >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c33"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <Shared__SimulatedLabel
-                id="snippet-editor-field-41-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c30"
-                  id="snippet-editor-field-41-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </Shared__SimulatedLabel>
-              <Shared__InputContainer
-                isActive={false}
-                isHovered={false}
-                onClick={[Function]}
-              >
-                <div
-                  className="c34"
-                  onClick={[Function]}
-                >
-                  <SnippetEditorFields__SlugInput
-                    aria-labelledby="snippet-editor-field-41-slug"
-                    innerRef={[Function]}
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    value="test-slug"
-                  >
-                    <input
+                    <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-41-slug"
-                      className="c35"
+                      innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
                       value="test-slug"
-                    />
-                  </SnippetEditorFields__SlugInput>
-                </div>
-              </Shared__InputContainer>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test description, %%replacement_variable%%"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="Meta description"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder="Modify your meta description by editing it right here"
-                replacementVariables={Array []}
-                styleForMobile={true}
-                type="description"
-                withCaret={true}
+                    >
+                      <input
+                        aria-labelledby="snippet-editor-field-41-slug"
+                        className="c35"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        value="test-slug"
+                      />
+                    </SnippetEditorFields__SlugInput>
+                  </div>
+                </Shared__InputContainer>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="43"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test description, %%replacement_variable%%"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="Meta description"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder="Modify your meta description by editing it right here"
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  type="description"
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="43"
                     onClick={[Function]}
                   >
-                    Meta description
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="43"
+                      onClick={[Function]}
+                    >
+                      Meta description
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -12526,7 +12527,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -12536,106 +12537,117 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
-                <Shared__InputContainer
-                  isActive={false}
-                  isHovered={false}
-                  onClick={[Function]}
-                >
-                  <div
-                    className="c36"
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="43"
-                      content="Test description, %%replacement_variable%%"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Modify your meta description by editing it right here"
-                      replacementVariables={Array []}
+                    <div
+                      className="c36"
+                      onClick={[Function]}
                     >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={156}
-                progressColor="#ee7c1b"
-                value={42}
-              >
-                <progress
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="43"
+                        content="Test description, %%replacement_variable%%"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="Modify your meta description by editing it right here"
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
                   aria-hidden="true"
-                  className="c37"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
                   max={156}
+                  progressColor="#ee7c1b"
                   value={42}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-        </section>
-      </Shared__StyledEditor>
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c37"
+                    max={156}
+                    value={42}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+          </section>
+        </Shared__StyledEditor>
+      </ErrorBoundary>
     </SnippetEditorFields>
     <Button
       onClick={[Function]}
@@ -15176,66 +15188,57 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
         }
       }
     >
-      <Shared__StyledEditor
-        innerRef={[Function]}
-      >
-        <section
-          className="c29"
+      <ErrorBoundary>
+        <Shared__StyledEditor
+          innerRef={[Function]}
         >
-          <Shared__FormSection>
-            <div
-              className="c30"
-            >
-              <ReplacementVariableEditor
-                content="Test title"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="SEO title"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                replacementVariables={Array []}
-                styleForMobile={true}
-                withCaret={true}
+          <section
+            className="c29"
+          >
+            <Shared__FormSection>
+              <div
+                className="c30"
               >
-                <Shared__SimulatedLabel
-                  id="21"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test title"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="SEO title"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  withCaret={true}
                 >
-                  <div
-                    className="c31"
+                  <Shared__SimulatedLabel
                     id="21"
                     onClick={[Function]}
                   >
-                    SEO title
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c32"
+                    <div
+                      className="c31"
+                      id="21"
+                      onClick={[Function]}
+                    >
+                      SEO title
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c32 c2"
+                      className="c32"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c32 c2 Button-kDSBcD c3"
+                        className="c32 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -15245,7 +15248,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c32 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -15255,205 +15258,205 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="c33"
+                      onClick={[Function]}
+                    >
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="21"
+                        content="Test title"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
+                  aria-hidden="true"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
+                  max={600}
+                  progressColor="#dc3232"
+                  value={0}
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c34"
+                    max={600}
+                    value={0}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c30"
+              >
+                <Shared__SimulatedLabel
+                  id="snippet-editor-field-20-slug"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="c31"
+                    id="snippet-editor-field-20-slug"
+                    onClick={[Function]}
+                  >
+                    Slug
+                  </div>
+                </Shared__SimulatedLabel>
                 <Shared__InputContainer
                   isActive={false}
                   isHovered={false}
                   onClick={[Function]}
                 >
                   <div
-                    className="c33"
+                    className="c35"
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="21"
-                      content="Test title"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      replacementVariables={Array []}
-                    >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c34"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c30"
-            >
-              <Shared__SimulatedLabel
-                id="snippet-editor-field-20-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c31"
-                  id="snippet-editor-field-20-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </Shared__SimulatedLabel>
-              <Shared__InputContainer
-                isActive={false}
-                isHovered={false}
-                onClick={[Function]}
-              >
-                <div
-                  className="c35"
-                  onClick={[Function]}
-                >
-                  <SnippetEditorFields__SlugInput
-                    aria-labelledby="snippet-editor-field-20-slug"
-                    innerRef={[Function]}
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    value="test-slug"
-                  >
-                    <input
+                    <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-20-slug"
-                      className="c36"
+                      innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
                       value="test-slug"
-                    />
-                  </SnippetEditorFields__SlugInput>
-                </div>
-              </Shared__InputContainer>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c30"
-            >
-              <ReplacementVariableEditor
-                content="Test description, %%replacement_variable%%"
-                editorRef={[Function]}
-                isActive={true}
-                isHovered={false}
-                label="Meta description"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder="Modify your meta description by editing it right here"
-                replacementVariables={Array []}
-                styleForMobile={true}
-                type="description"
-                withCaret={true}
+                    >
+                      <input
+                        aria-labelledby="snippet-editor-field-20-slug"
+                        className="c36"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        value="test-slug"
+                      />
+                    </SnippetEditorFields__SlugInput>
+                  </div>
+                </Shared__InputContainer>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c30"
               >
-                <Shared__SimulatedLabel
-                  id="22"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test description, %%replacement_variable%%"
+                  editorRef={[Function]}
+                  isActive={true}
+                  isHovered={false}
+                  label="Meta description"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder="Modify your meta description by editing it right here"
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  type="description"
+                  withCaret={true}
                 >
-                  <div
-                    className="c31"
+                  <Shared__SimulatedLabel
                     id="22"
                     onClick={[Function]}
                   >
-                    Meta description
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c32"
+                    <div
+                      className="c31"
+                      id="22"
+                      onClick={[Function]}
+                    >
+                      Meta description
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c32 c2"
+                      className="c32"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c32 c2 Button-kDSBcD c3"
+                        className="c32 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -15463,7 +15466,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c32 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -15473,106 +15476,117 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
-                <Shared__InputContainer
-                  isActive={true}
-                  isHovered={false}
-                  onClick={[Function]}
-                >
-                  <div
-                    className="c37"
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={true}
+                    isHovered={false}
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="22"
-                      content="Test description, %%replacement_variable%%"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Modify your meta description by editing it right here"
-                      replacementVariables={Array []}
+                    <div
+                      className="c37"
+                      onClick={[Function]}
                     >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={156}
-                progressColor="#ee7c1b"
-                value={42}
-              >
-                <progress
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="22"
+                        content="Test description, %%replacement_variable%%"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="Modify your meta description by editing it right here"
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
                   aria-hidden="true"
-                  className="c38"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
                   max={156}
+                  progressColor="#ee7c1b"
                   value={42}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-        </section>
-      </Shared__StyledEditor>
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c38"
+                    max={156}
+                    value={42}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+          </section>
+        </Shared__StyledEditor>
+      </ErrorBoundary>
     </SnippetEditorFields>
     <Button
       onClick={[Function]}
@@ -17023,66 +17037,57 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
         }
       }
     >
-      <Shared__StyledEditor
-        innerRef={[Function]}
-      >
-        <section
-          className="c29"
+      <ErrorBoundary>
+        <Shared__StyledEditor
+          innerRef={[Function]}
         >
-          <Shared__FormSection>
-            <div
-              className="c30"
-            >
-              <ReplacementVariableEditor
-                content="Test title"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="SEO title"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                replacementVariables={Array []}
-                styleForMobile={true}
-                withCaret={true}
+          <section
+            className="c29"
+          >
+            <Shared__FormSection>
+              <div
+                className="c30"
               >
-                <Shared__SimulatedLabel
-                  id="17"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test title"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="SEO title"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  withCaret={true}
                 >
-                  <div
-                    className="c31"
+                  <Shared__SimulatedLabel
                     id="17"
                     onClick={[Function]}
                   >
-                    SEO title
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c32"
+                    <div
+                      className="c31"
+                      id="17"
+                      onClick={[Function]}
+                    >
+                      SEO title
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c32 c2"
+                      className="c32"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c32 c2 Button-kDSBcD c3"
+                        className="c32 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -17092,7 +17097,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c32 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -17102,205 +17107,205 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="c33"
+                      onClick={[Function]}
+                    >
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="17"
+                        content="Test title"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
+                  aria-hidden="true"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
+                  max={600}
+                  progressColor="#dc3232"
+                  value={0}
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c34"
+                    max={600}
+                    value={0}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c30"
+              >
+                <Shared__SimulatedLabel
+                  id="snippet-editor-field-16-slug"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="c31"
+                    id="snippet-editor-field-16-slug"
+                    onClick={[Function]}
+                  >
+                    Slug
+                  </div>
+                </Shared__SimulatedLabel>
                 <Shared__InputContainer
                   isActive={false}
                   isHovered={false}
                   onClick={[Function]}
                 >
                   <div
-                    className="c33"
+                    className="c35"
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="17"
-                      content="Test title"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      replacementVariables={Array []}
-                    >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c34"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c30"
-            >
-              <Shared__SimulatedLabel
-                id="snippet-editor-field-16-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c31"
-                  id="snippet-editor-field-16-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </Shared__SimulatedLabel>
-              <Shared__InputContainer
-                isActive={false}
-                isHovered={false}
-                onClick={[Function]}
-              >
-                <div
-                  className="c35"
-                  onClick={[Function]}
-                >
-                  <SnippetEditorFields__SlugInput
-                    aria-labelledby="snippet-editor-field-16-slug"
-                    innerRef={[Function]}
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    value="test-slug"
-                  >
-                    <input
+                    <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-16-slug"
-                      className="c36"
+                      innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
                       value="test-slug"
-                    />
-                  </SnippetEditorFields__SlugInput>
-                </div>
-              </Shared__InputContainer>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c30"
-            >
-              <ReplacementVariableEditor
-                content="Test description, %%replacement_variable%%"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={true}
-                label="Meta description"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder="Modify your meta description by editing it right here"
-                replacementVariables={Array []}
-                styleForMobile={true}
-                type="description"
-                withCaret={true}
+                    >
+                      <input
+                        aria-labelledby="snippet-editor-field-16-slug"
+                        className="c36"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        value="test-slug"
+                      />
+                    </SnippetEditorFields__SlugInput>
+                  </div>
+                </Shared__InputContainer>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c30"
               >
-                <Shared__SimulatedLabel
-                  id="18"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test description, %%replacement_variable%%"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={true}
+                  label="Meta description"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder="Modify your meta description by editing it right here"
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  type="description"
+                  withCaret={true}
                 >
-                  <div
-                    className="c31"
+                  <Shared__SimulatedLabel
                     id="18"
                     onClick={[Function]}
                   >
-                    Meta description
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c32"
+                    <div
+                      className="c31"
+                      id="18"
+                      onClick={[Function]}
+                    >
+                      Meta description
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c32 c2"
+                      className="c32"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c32 c2 Button-kDSBcD c3"
+                        className="c32 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -17310,7 +17315,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c32 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -17320,106 +17325,117 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
-                <Shared__InputContainer
-                  isActive={false}
-                  isHovered={true}
-                  onClick={[Function]}
-                >
-                  <div
-                    className="c37"
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={true}
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="18"
-                      content="Test description, %%replacement_variable%%"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Modify your meta description by editing it right here"
-                      replacementVariables={Array []}
+                    <div
+                      className="c37"
+                      onClick={[Function]}
                     >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={156}
-                progressColor="#ee7c1b"
-                value={42}
-              >
-                <progress
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="18"
+                        content="Test description, %%replacement_variable%%"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="Modify your meta description by editing it right here"
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
                   aria-hidden="true"
-                  className="c38"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
                   max={156}
+                  progressColor="#ee7c1b"
                   value={42}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-        </section>
-      </Shared__StyledEditor>
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c38"
+                    max={156}
+                    value={42}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+          </section>
+        </Shared__StyledEditor>
+      </ErrorBoundary>
     </SnippetEditorFields>
     <Button
       onClick={[Function]}
@@ -18850,66 +18866,57 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         }
       }
     >
-      <Shared__StyledEditor
-        innerRef={[Function]}
-      >
-        <section
-          className="c28"
+      <ErrorBoundary>
+        <Shared__StyledEditor
+          innerRef={[Function]}
         >
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test title"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="SEO title"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                replacementVariables={Array []}
-                styleForMobile={true}
-                withCaret={true}
+          <section
+            className="c28"
+          >
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="9"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test title"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="SEO title"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="9"
                     onClick={[Function]}
                   >
-                    SEO title
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="9"
+                      onClick={[Function]}
+                    >
+                      SEO title
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -18919,7 +18926,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -18929,205 +18936,205 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="c32"
+                      onClick={[Function]}
+                    >
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="9"
+                        content="Test title"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
+                  aria-hidden="true"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
+                  max={600}
+                  progressColor="#dc3232"
+                  value={0}
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c33"
+                    max={600}
+                    value={0}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
+              >
+                <Shared__SimulatedLabel
+                  id="snippet-editor-field-8-slug"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="c30"
+                    id="snippet-editor-field-8-slug"
+                    onClick={[Function]}
+                  >
+                    Slug
+                  </div>
+                </Shared__SimulatedLabel>
                 <Shared__InputContainer
                   isActive={false}
                   isHovered={false}
                   onClick={[Function]}
                 >
                   <div
-                    className="c32"
+                    className="c34"
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="9"
-                      content="Test title"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      replacementVariables={Array []}
-                    >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c33"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <Shared__SimulatedLabel
-                id="snippet-editor-field-8-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c30"
-                  id="snippet-editor-field-8-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </Shared__SimulatedLabel>
-              <Shared__InputContainer
-                isActive={false}
-                isHovered={false}
-                onClick={[Function]}
-              >
-                <div
-                  className="c34"
-                  onClick={[Function]}
-                >
-                  <SnippetEditorFields__SlugInput
-                    aria-labelledby="snippet-editor-field-8-slug"
-                    innerRef={[Function]}
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    value="test-slug"
-                  >
-                    <input
+                    <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-8-slug"
-                      className="c35"
+                      innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
                       value="test-slug"
-                    />
-                  </SnippetEditorFields__SlugInput>
-                </div>
-              </Shared__InputContainer>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test description, %%replacement_variable%%"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="Meta description"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder="Modify your meta description by editing it right here"
-                replacementVariables={Array []}
-                styleForMobile={true}
-                type="description"
-                withCaret={true}
+                    >
+                      <input
+                        aria-labelledby="snippet-editor-field-8-slug"
+                        className="c35"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        value="test-slug"
+                      />
+                    </SnippetEditorFields__SlugInput>
+                  </div>
+                </Shared__InputContainer>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="10"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test description, %%replacement_variable%%"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="Meta description"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder="Modify your meta description by editing it right here"
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  type="description"
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="10"
                     onClick={[Function]}
                   >
-                    Meta description
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="10"
+                      onClick={[Function]}
+                    >
+                      Meta description
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -19137,7 +19144,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -19147,106 +19154,117 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
-                <Shared__InputContainer
-                  isActive={false}
-                  isHovered={false}
-                  onClick={[Function]}
-                >
-                  <div
-                    className="c36"
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="10"
-                      content="Test description, %%replacement_variable%%"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Modify your meta description by editing it right here"
-                      replacementVariables={Array []}
+                    <div
+                      className="c36"
+                      onClick={[Function]}
                     >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={156}
-                progressColor="#ee7c1b"
-                value={42}
-              >
-                <progress
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="10"
+                        content="Test description, %%replacement_variable%%"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="Modify your meta description by editing it right here"
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
                   aria-hidden="true"
-                  className="c37"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
                   max={156}
+                  progressColor="#ee7c1b"
                   value={42}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-        </section>
-      </Shared__StyledEditor>
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c37"
+                    max={156}
+                    value={42}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+          </section>
+        </Shared__StyledEditor>
+      </ErrorBoundary>
     </SnippetEditorFields>
     <Button
       onClick={[Function]}
@@ -20699,77 +20717,68 @@ exports[`SnippetEditor passes replacement variables to the title and description
         }
       }
     >
-      <Shared__StyledEditor
-        innerRef={[Function]}
-      >
-        <section
-          className="c28"
+      <ErrorBoundary>
+        <Shared__StyledEditor
+          innerRef={[Function]}
         >
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test title"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="SEO title"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                replacementVariables={
-                  Array [
-                    Object {
-                      "name": "title",
-                      "value": "Title!!!",
-                    },
-                    Object {
-                      "name": "excerpt",
-                      "value": "Excerpt!!!",
-                    },
-                  ]
-                }
-                styleForMobile={true}
-                withCaret={true}
+          <section
+            className="c28"
+          >
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="34"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test title"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="SEO title"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  replacementVariables={
+                    Array [
+                      Object {
+                        "name": "title",
+                        "value": "Title!!!",
+                      },
+                      Object {
+                        "name": "excerpt",
+                        "value": "Excerpt!!!",
+                      },
+                    ]
+                  }
+                  styleForMobile={true}
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="34"
                     onClick={[Function]}
                   >
-                    SEO title
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="34"
+                      onClick={[Function]}
+                    >
+                      SEO title
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -20779,7 +20788,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -20789,227 +20798,227 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="c32"
+                      onClick={[Function]}
+                    >
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="34"
+                        content="Test title"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        replacementVariables={
+                          Array [
+                            Object {
+                              "name": "title",
+                              "value": "Title!!!",
+                            },
+                            Object {
+                              "name": "excerpt",
+                              "value": "Excerpt!!!",
+                            },
+                          ]
+                        }
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
+                  aria-hidden="true"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
+                  max={600}
+                  progressColor="#dc3232"
+                  value={0}
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c33"
+                    max={600}
+                    value={0}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
+              >
+                <Shared__SimulatedLabel
+                  id="snippet-editor-field-33-slug"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="c30"
+                    id="snippet-editor-field-33-slug"
+                    onClick={[Function]}
+                  >
+                    Slug
+                  </div>
+                </Shared__SimulatedLabel>
                 <Shared__InputContainer
                   isActive={false}
                   isHovered={false}
                   onClick={[Function]}
                 >
                   <div
-                    className="c32"
+                    className="c34"
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="34"
-                      content="Test title"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      replacementVariables={
-                        Array [
-                          Object {
-                            "name": "title",
-                            "value": "Title!!!",
-                          },
-                          Object {
-                            "name": "excerpt",
-                            "value": "Excerpt!!!",
-                          },
-                        ]
-                      }
-                    >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c33"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <Shared__SimulatedLabel
-                id="snippet-editor-field-33-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c30"
-                  id="snippet-editor-field-33-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </Shared__SimulatedLabel>
-              <Shared__InputContainer
-                isActive={false}
-                isHovered={false}
-                onClick={[Function]}
-              >
-                <div
-                  className="c34"
-                  onClick={[Function]}
-                >
-                  <SnippetEditorFields__SlugInput
-                    aria-labelledby="snippet-editor-field-33-slug"
-                    innerRef={[Function]}
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    value="test-slug"
-                  >
-                    <input
+                    <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-33-slug"
-                      className="c35"
+                      innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
                       value="test-slug"
-                    />
-                  </SnippetEditorFields__SlugInput>
-                </div>
-              </Shared__InputContainer>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test description, %%replacement_variable%%"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="Meta description"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder="Modify your meta description by editing it right here"
-                replacementVariables={
-                  Array [
-                    Object {
-                      "name": "title",
-                      "value": "Title!!!",
-                    },
-                    Object {
-                      "name": "excerpt",
-                      "value": "Excerpt!!!",
-                    },
-                  ]
-                }
-                styleForMobile={true}
-                type="description"
-                withCaret={true}
+                    >
+                      <input
+                        aria-labelledby="snippet-editor-field-33-slug"
+                        className="c35"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        value="test-slug"
+                      />
+                    </SnippetEditorFields__SlugInput>
+                  </div>
+                </Shared__InputContainer>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="35"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test description, %%replacement_variable%%"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="Meta description"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder="Modify your meta description by editing it right here"
+                  replacementVariables={
+                    Array [
+                      Object {
+                        "name": "title",
+                        "value": "Title!!!",
+                      },
+                      Object {
+                        "name": "excerpt",
+                        "value": "Excerpt!!!",
+                      },
+                    ]
+                  }
+                  styleForMobile={true}
+                  type="description"
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="35"
                     onClick={[Function]}
                   >
-                    Meta description
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="35"
+                      onClick={[Function]}
+                    >
+                      Meta description
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -21019,7 +21028,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -21029,117 +21038,128 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
-                <Shared__InputContainer
-                  isActive={false}
-                  isHovered={false}
-                  onClick={[Function]}
-                >
-                  <div
-                    className="c36"
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="35"
-                      content="Test description, %%replacement_variable%%"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Modify your meta description by editing it right here"
-                      replacementVariables={
-                        Array [
-                          Object {
-                            "name": "title",
-                            "value": "Title!!!",
-                          },
-                          Object {
-                            "name": "excerpt",
-                            "value": "Excerpt!!!",
-                          },
-                        ]
-                      }
+                    <div
+                      className="c36"
+                      onClick={[Function]}
                     >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={156}
-                progressColor="#ee7c1b"
-                value={42}
-              >
-                <progress
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="35"
+                        content="Test description, %%replacement_variable%%"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="Modify your meta description by editing it right here"
+                        replacementVariables={
+                          Array [
+                            Object {
+                              "name": "title",
+                              "value": "Title!!!",
+                            },
+                            Object {
+                              "name": "excerpt",
+                              "value": "Excerpt!!!",
+                            },
+                          ]
+                        }
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
                   aria-hidden="true"
-                  className="c37"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
                   max={156}
+                  progressColor="#ee7c1b"
                   value={42}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-        </section>
-      </Shared__StyledEditor>
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c37"
+                    max={156}
+                    value={42}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+          </section>
+        </Shared__StyledEditor>
+      </ErrorBoundary>
     </SnippetEditorFields>
     <Button
       onClick={[Function]}
@@ -23200,66 +23220,57 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
         }
       }
     >
-      <Shared__StyledEditor
-        innerRef={[Function]}
-      >
-        <section
-          className="c28"
+      <ErrorBoundary>
+        <Shared__StyledEditor
+          innerRef={[Function]}
         >
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test title"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="SEO title"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                replacementVariables={Array []}
-                styleForMobile={true}
-                withCaret={true}
+          <section
+            className="c28"
+          >
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="25"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test title"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="SEO title"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="25"
                     onClick={[Function]}
                   >
-                    SEO title
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="25"
+                      onClick={[Function]}
+                    >
+                      SEO title
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -23269,7 +23280,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -23279,205 +23290,205 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="c32"
+                      onClick={[Function]}
+                    >
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="25"
+                        content="Test title"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
+                  aria-hidden="true"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
+                  max={600}
+                  progressColor="#dc3232"
+                  value={0}
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c33"
+                    max={600}
+                    value={0}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
+              >
+                <Shared__SimulatedLabel
+                  id="snippet-editor-field-24-slug"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="c30"
+                    id="snippet-editor-field-24-slug"
+                    onClick={[Function]}
+                  >
+                    Slug
+                  </div>
+                </Shared__SimulatedLabel>
                 <Shared__InputContainer
                   isActive={false}
                   isHovered={false}
                   onClick={[Function]}
                 >
                   <div
-                    className="c32"
+                    className="c34"
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="25"
-                      content="Test title"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      replacementVariables={Array []}
-                    >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={600}
-                progressColor="#dc3232"
-                value={0}
-              >
-                <progress
-                  aria-hidden="true"
-                  className="c33"
-                  max={600}
-                  value={0}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <Shared__SimulatedLabel
-                id="snippet-editor-field-24-slug"
-                onClick={[Function]}
-              >
-                <div
-                  className="c30"
-                  id="snippet-editor-field-24-slug"
-                  onClick={[Function]}
-                >
-                  Slug
-                </div>
-              </Shared__SimulatedLabel>
-              <Shared__InputContainer
-                isActive={false}
-                isHovered={false}
-                onClick={[Function]}
-              >
-                <div
-                  className="c34"
-                  onClick={[Function]}
-                >
-                  <SnippetEditorFields__SlugInput
-                    aria-labelledby="snippet-editor-field-24-slug"
-                    innerRef={[Function]}
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    value="test-slug"
-                  >
-                    <input
+                    <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-24-slug"
-                      className="c35"
+                      innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
                       value="test-slug"
-                    />
-                  </SnippetEditorFields__SlugInput>
-                </div>
-              </Shared__InputContainer>
-            </div>
-          </Shared__FormSection>
-          <Shared__FormSection>
-            <div
-              className="c29"
-            >
-              <ReplacementVariableEditor
-                content="Test description, %%replacement_variable%%"
-                editorRef={[Function]}
-                isActive={false}
-                isHovered={false}
-                label="Meta description"
-                mobileWidth={356}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder="Modify your meta description by editing it right here"
-                replacementVariables={Array []}
-                styleForMobile={true}
-                type="description"
-                withCaret={true}
+                    >
+                      <input
+                        aria-labelledby="snippet-editor-field-24-slug"
+                        className="c35"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        value="test-slug"
+                      />
+                    </SnippetEditorFields__SlugInput>
+                  </div>
+                </Shared__InputContainer>
+              </div>
+            </Shared__FormSection>
+            <Shared__FormSection>
+              <div
+                className="c29"
               >
-                <Shared__SimulatedLabel
-                  id="26"
-                  onClick={[Function]}
+                <ReplacementVariableEditor
+                  content="Test description, %%replacement_variable%%"
+                  editorRef={[Function]}
+                  isActive={false}
+                  isHovered={false}
+                  label="Meta description"
+                  mobileWidth={356}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder="Modify your meta description by editing it right here"
+                  replacementVariables={Array []}
+                  styleForMobile={true}
+                  type="description"
+                  withCaret={true}
                 >
-                  <div
-                    className="c30"
+                  <Shared__SimulatedLabel
                     id="26"
                     onClick={[Function]}
                   >
-                    Meta description
-                  </div>
-                </Shared__SimulatedLabel>
-                <Shared__TriggerReplacementVariableSuggestionsButton
-                  isSmallerThanMobileWidth={true}
-                  onClick={[Function]}
-                >
-                  <Button
-                    className="c31"
+                    <div
+                      className="c30"
+                      id="26"
+                      onClick={[Function]}
+                    >
+                      Meta description
+                    </div>
+                  </Shared__SimulatedLabel>
+                  <Shared__TriggerReplacementVariableSuggestionsButton
                     isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
-                      backgroundColor="#f7f7f7"
-                      borderColor="#ccc"
-                      boxShadowColor="#ccc"
-                      className="c31 c2"
+                      className="c31"
                       isSmallerThanMobileWidth={true}
                       onClick={[Function]}
-                      textColor="#555"
-                      type="button"
                     >
                       <Button
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2 Button-kDSBcD c3"
+                        className="c31 c2"
                         isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
@@ -23487,7 +23498,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                          className="c31 c2 Button-kDSBcD c3"
                           isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
@@ -23497,106 +23508,117 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
                             isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
                           >
-                            <Button__BaseButton
+                            <Button
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
                               isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
                             >
-                              <button
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                              <Button__BaseButton
+                                backgroundColor="#f7f7f7"
+                                borderColor="#ccc"
+                                boxShadowColor="#ccc"
+                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
+                                textColor="#555"
                                 type="button"
                               >
-                                <SvgIcon
-                                  icon="plus-circle"
-                                  size="16px"
+                                <button
+                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <SvgIcon__StyledSvg
-                                    aria-hidden={true}
-                                    className="yoast-svg-icon yoast-svg-icon-plus-circle"
-                                    focusable="false"
-                                    role="img"
+                                  <SvgIcon
+                                    icon="plus-circle"
                                     size="16px"
-                                    viewBox="0 0 1792 1792"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <svg
+                                    <SvgIcon__StyledSvg
                                       aria-hidden={true}
-                                      className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                      className="yoast-svg-icon yoast-svg-icon-plus-circle"
                                       focusable="false"
                                       role="img"
                                       size="16px"
                                       viewBox="0 0 1792 1792"
                                       xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <path
-                                        d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                      />
-                                    </svg>
-                                  </SvgIcon__StyledSvg>
-                                </SvgIcon>
-                                Insert snippet variable
-                              </button>
-                            </Button__BaseButton>
+                                      <svg
+                                        aria-hidden={true}
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        focusable="false"
+                                        role="img"
+                                        size="16px"
+                                        viewBox="0 0 1792 1792"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M1344 960v-128q0-26-19-45t-45-19h-256v-256q0-26-19-45t-45-19h-128q-26 0-45 19t-19 45v256h-256q-26 0-45 19t-19 45v128q0 26 19 45t45 19h256v256q0 26 19 45t45 19h128q26 0 45-19t19-45v-256h256q26 0 45-19t19-45zm320-64q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
+                                        />
+                                      </svg>
+                                    </SvgIcon__StyledSvg>
+                                  </SvgIcon>
+                                  Insert snippet variable
+                                </button>
+                              </Button__BaseButton>
+                            </Button>
                           </Button>
                         </Button>
                       </Button>
                     </Button>
-                  </Button>
-                </Shared__TriggerReplacementVariableSuggestionsButton>
-                <Shared__InputContainer
-                  isActive={false}
-                  isHovered={false}
-                  onClick={[Function]}
-                >
-                  <div
-                    className="c36"
+                  </Shared__TriggerReplacementVariableSuggestionsButton>
+                  <Shared__InputContainer
+                    isActive={false}
+                    isHovered={false}
                     onClick={[Function]}
                   >
-                    <ReplacementVariableEditorStandalone
-                      ariaLabelledBy="26"
-                      content="Test description, %%replacement_variable%%"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Modify your meta description by editing it right here"
-                      replacementVariables={Array []}
+                    <div
+                      className="c36"
+                      onClick={[Function]}
                     >
-                      <div />
-                    </ReplacementVariableEditorStandalone>
-                  </div>
-                </Shared__InputContainer>
-              </ReplacementVariableEditor>
-              <ProgressBar
-                aria-hidden="true"
-                backgroundColor="#f7f7f7"
-                borderColor="#ddd"
-                max={156}
-                progressColor="#ee7c1b"
-                value={42}
-              >
-                <progress
+                      <ReplacementVariableEditorStandalone
+                        ariaLabelledBy="26"
+                        content="Test description, %%replacement_variable%%"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="Modify your meta description by editing it right here"
+                        replacementVariables={Array []}
+                      >
+                        <div />
+                      </ReplacementVariableEditorStandalone>
+                    </div>
+                  </Shared__InputContainer>
+                </ReplacementVariableEditor>
+                <ProgressBar
                   aria-hidden="true"
-                  className="c37"
+                  backgroundColor="#f7f7f7"
+                  borderColor="#ddd"
                   max={156}
+                  progressColor="#ee7c1b"
                   value={42}
-                />
-              </ProgressBar>
-            </div>
-          </Shared__FormSection>
-        </section>
-      </Shared__StyledEditor>
+                >
+                  <progress
+                    aria-hidden="true"
+                    className="c37"
+                    max={156}
+                    value={42}
+                  />
+                </ProgressBar>
+              </div>
+            </Shared__FormSection>
+          </section>
+        </Shared__StyledEditor>
+      </ErrorBoundary>
     </SnippetEditorFields>
     <Button
       onClick={[Function]}

--- a/composites/basic/ErrorBoundary.js
+++ b/composites/basic/ErrorBoundary.js
@@ -46,7 +46,7 @@ export default class ErrorBoundary extends React.Component {
 	render() {
 		if ( this.state.hasError ) {
 			// Render any custom fallback UI.
-			const errorMessage = __( "Something went wrong, please reload the page.", "yoast-components" );
+			const errorMessage = __( "Something went wrong. Please reload the page.", "yoast-components" );
 			a11ySpeak( errorMessage, "assertive" );
 
 			return <ErrorContainer>{ errorMessage }</ErrorContainer>;

--- a/composites/basic/ErrorBoundary.js
+++ b/composites/basic/ErrorBoundary.js
@@ -1,0 +1,61 @@
+// External dependencies.
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { __ } from "@wordpress/i18n";
+import { speak as a11ySpeak } from "@wordpress/a11y";
+
+/* Internal dependencies */
+import colors from "../../style-guide/colors";
+
+const ErrorContainer = styled.p`
+	text-align: center;
+	margin: 0 0 16px;
+	padding: 16px 16px 8px 16px;
+	border-bottom: 4px solid ${ colors.$color_bad };
+	background: ${ colors.$color_white };
+`;
+
+
+export default class ErrorBoundary extends React.Component {
+	/**
+	 * Constructs the component.
+	 *
+	 * @param {Object} props The props for the component.
+	 */
+	constructor( props ) {
+		super( props );
+
+		this.state = { hasError: false };
+	}
+
+	/**
+	 * Catches errors in a components tree.
+	 *
+	 * @returns {void}
+	 */
+	componentDidCatch() {
+		this.setState( { hasError: true } );
+	}
+
+	/**
+	 * Renders the Error Boundary.
+	 *
+	 * @returns {ReactElement} The Error Boundary or its children.
+	 */
+	render() {
+		if ( this.state.hasError ) {
+			// Render any custom fallback UI.
+			const errorMessage = __( "Something went wrong, please reload the page.", "yoast-components" );
+			a11ySpeak( errorMessage, "assertive" );
+
+			return <ErrorContainer>{ errorMessage }</ErrorContainer>;
+		}
+
+		return this.props.children;
+	}
+}
+
+ErrorBoundary.propTypes = {
+	children: PropTypes.any,
+};


### PR DESCRIPTION
## Summary

* Introduce an ErrorBoundary component to be used for the Snippet Editor.

## Relevant technical choices:

- for now, the error boundary wraps the SnippetEditorFields component
- it can be changed to wrap any other components tree, if desired
- uses `a11ySpeak` to deliver an audible message to screen reader users

Design feedback needed /Cc @hedgefield 

We can't predict where we'll need to re-use this component and show errors, so we can't set arbitrary paddings / margins. For this reason, I've aligned the text to the centre and used a bottom border, as it seemed the most pragmatical solution to me. Of course, this can be changed if desired, just let me know. Personally, I'd add `moar` white space. Screenshot:

<img width="816" alt="screen shot 2018-06-19 at 17 32 52" src="https://user-images.githubusercontent.com/1682452/41609088-4aad4a70-73ea-11e8-8b81-e23205a9f06d.png">

## Test instructions
You can test the standalone version or yarn-link to the plugin:

- with Microsoft Edge on Windows: select the title field content using Ctrl+A
- with the content still selected, press any character key to trigger the Edge error
- check the error message is correctly displayed
- an audible message is sent to the ARIA live region

If you can't test with Edge, you have to change the error boundary initial state to `true`, then open the snippet editor to see the error message.

Fixes #591 
