### PR TITLE
Fix snippet preview padding

### DIFF
--- a/composites/Plugin/SnippetEditor/components/SettingsSnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SettingsSnippetEditorFields.js
@@ -18,7 +18,7 @@ const FormSection = styled.div`
 `;
 
 const StyledEditor = styled.div`
-	padding: 0 20px;
+	padding: 12px 20px 2px;
 `;
 
 class SettingsSnippetEditorFields extends React.Component {

--- a/forms/StyledSection/StyledSection.js
+++ b/forms/StyledSection/StyledSection.js
@@ -15,7 +15,10 @@ export const StyledIcon = styled( SvgIcon )``;
 export const StyledSectionBase = styled( Section )`
 	box-shadow: 0 1px 2px ${ rgba( colors.$color_black, 0.2 ) };
 	background-color: ${ colors.$color_white };
-	padding: 0 20px 16px;
+	padding-right: 20px
+	padding-left: 20px
+	padding-bottom: ${ props => props.headingText ? "0" : "10px" } 
+	padding-top: ${ props => props.headingText ? "0" : "10px" } 
 
 	*, & {
 		box-sizing: border-box;

--- a/forms/StyledSection/tests/__snapshots__/styledSectionTest.js.snap
+++ b/forms/StyledSection/tests/__snapshots__/styledSectionTest.js.snap
@@ -4,17 +4,16 @@ exports[`StyledSection can change the heading level 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -87,17 +86,16 @@ exports[`StyledSection can change the icon to angle-down 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -168,17 +166,16 @@ exports[`StyledSection can change the icon to angle-left 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -249,17 +246,16 @@ exports[`StyledSection can change the icon to angle-right 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -330,17 +326,16 @@ exports[`StyledSection can change the icon to angle-up 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -411,17 +406,16 @@ exports[`StyledSection can change the icon to circle 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -492,17 +486,16 @@ exports[`StyledSection can change the icon to edit 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -573,17 +566,16 @@ exports[`StyledSection can change the icon to eye 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -654,17 +646,16 @@ exports[`StyledSection can change the icon to file-text 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -735,17 +726,16 @@ exports[`StyledSection can change the icon to key 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -816,17 +806,16 @@ exports[`StyledSection can change the icon to list 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -897,17 +886,16 @@ exports[`StyledSection can change the icon to question-circle 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -978,17 +966,16 @@ exports[`StyledSection can change the icon to search 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -1059,17 +1046,16 @@ exports[`StyledSection can change the icon to times 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -1140,17 +1126,16 @@ exports[`StyledSection have a red icon 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }
@@ -1220,17 +1205,16 @@ exports[`StyledSection match the snapshot 1`] = `
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
-  padding: 0 20px 16px;
 }
 
-.c0 *,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *,
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 *:before,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:before,
 .c0:before,
-.c0 *:after,
+.c0 padding-right:20px padding-left:20px padding-bottom:10px padding-top:10px *:after,
 .c0:after {
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

*  Let the padding on the `styleddSection` depend on whether the section has a title.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* See https://github.com/Yoast/wordpress-seo/pull/10080

Fixes https://github.com/Yoast/wordpress-seo/issues/10079
