### PR TITLE
Pass updated replacementvariables when measuring progress

### DIFF
--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -7,6 +7,7 @@ import PageTitleWidthAssesment from "yoastseo/js/assessments/seo/pageTitleWidthA
 import { measureTextWidth } from "yoastseo/js/helpers/createMeasurementElement";
 import stripSpaces from "yoastseo/js/stringProcessing/stripSpaces";
 import noop from "lodash/noop";
+import toJSON from "lodash/toJSON";
 
 // Internal dependencies.
 import SnippetPreview from "../../SnippetPreview/components/SnippetPreview";
@@ -162,8 +163,11 @@ class SnippetEditor extends React.Component {
 			isDirty = true;
 		}
 
-		// If any of the replacement variables have changed, the preview progress needs to be reanalysed.
-		if ( prev.replacementVariables !== next.replacementVariables ) {
+		/* If any of the replacement variables have changed, the preview progress needs to be reanalysed.
+		   The replacement variables are converted from an array of objects to a string for easier and more consistent
+		   comparison.
+		 */
+		if ( JSON.stringify( prev.replacementVariables ) !== JSON.stringify( next.replacementVariables ) ) {
 			isDirty = true;
 		}
 

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -159,13 +159,11 @@ class SnippetEditor extends React.Component {
 			prev.data.slug !== next.data.slug ||
 			prev.data.title !== next.data.title
 		) {
-			console.log( "data", prev.data, next.data );
 			isDirty = true;
 		}
 
 		// If any of the replacement variables have changed, the preview progress needs to be reanalysed.
 		if ( prev.replacementVariables !== next.replacementVariables ) {
-			console.log( "repvars", prev.replacementVariables, next.replacementVariables );
 			isDirty = true;
 		}
 

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -7,7 +7,6 @@ import PageTitleWidthAssesment from "yoastseo/js/assessments/seo/pageTitleWidthA
 import { measureTextWidth } from "yoastseo/js/helpers/createMeasurementElement";
 import stripSpaces from "yoastseo/js/stringProcessing/stripSpaces";
 import noop from "lodash/noop";
-import toJSON from "lodash/toJSON";
 
 // Internal dependencies.
 import SnippetPreview from "../../SnippetPreview/components/SnippetPreview";
@@ -149,16 +148,16 @@ class SnippetEditor extends React.Component {
 	/**
 	 * Returns whether the old and the new data or replacement variables are different.
 	 *
-	 * @param {Object} prev The old props.
-	 * @param {Object} next The new props.
+	 * @param {Object} prevProps The old props.
+	 * @param {Object} nextProps The new props.
 	 * @returns {boolean} True if any of the data points has changed.
 	 */
-	shallowCompareData( prev, next ) {
+	shallowCompareData( prevProps, nextProps ) {
 		let isDirty = false;
 		if (
-			prev.data.description !== next.data.description ||
-			prev.data.slug !== next.data.slug ||
-			prev.data.title !== next.data.title
+			prevProps.data.description !== nextProps.data.description ||
+			prevProps.data.slug !== nextProps.data.slug ||
+			prevProps.data.title !== nextProps.data.title
 		) {
 			isDirty = true;
 		}
@@ -167,7 +166,7 @@ class SnippetEditor extends React.Component {
 		   The replacement variables are converted from an array of objects to a string for easier and more consistent
 		   comparison.
 		 */
-		if ( JSON.stringify( prev.replacementVariables ) !== JSON.stringify( next.replacementVariables ) ) {
+		if ( JSON.stringify( prevProps.replacementVariables ) !== JSON.stringify( nextProps.replacementVariables ) ) {
 			isDirty = true;
 		}
 

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -146,7 +146,7 @@ class SnippetEditor extends React.Component {
 	}
 
 	/**
-	 * Returns whether the old and the new data are different.
+	 * Returns whether the old and the new data or replacement variables are different.
 	 *
 	 * @param {Object} prev The old props.
 	 * @param {Object} next The new props.

--- a/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
@@ -309,18 +309,27 @@ describe( "SnippetEditor", () => {
 		it( "returns false when there is no new data", () => {
 			const editor = mountWithArgs( {} );
 
-			const oldData = {
-				title: "old title",
-				description: "old description",
-				slug: "old slug",
-			};
-			const newData = {
-				title: "old title",
-				description: "old description",
-				slug: "old slug",
+			const data = {
+				data: {
+					title: "old title",
+					description: "old description",
+					slug: "old slug",
+				},
+				replacementVariables: [
+					{
+						name: "test1",
+						label: "Test1",
+						value: "first",
+					},
+					{
+						name: "test2",
+						label: "Test2",
+						value: "second",
+					},
+				],
 			};
 
-			const isDirty = editor.instance().shallowCompareData( oldData, newData );
+			const isDirty = editor.instance().shallowCompareData( data, data );
 
 			expect( isDirty ).toBe( false );
 		} );
@@ -328,18 +337,93 @@ describe( "SnippetEditor", () => {
 		it( "returns true when one data point has changed", () => {
 			const editor = mountWithArgs( {} );
 
-			const oldData = {
-				title: "old title",
-				description: "old description",
-				slug: "old slug",
+			const prev = {
+				data: {
+					title: "old title",
+					description: "old description",
+					slug: "old slug",
+				},
+				replacementVariables: [
+					{
+						name: "test1",
+						label: "Test1",
+						value: "first",
+					},
+					{
+						name: "test2",
+						label: "Test2",
+						value: "second",
+					},
+				],
 			};
-			const newData = {
-				title: "new title",
-				description: "old description",
-				slug: "old slug",
+			const next = {
+				data: {
+					title: "new title",
+					description: "old description",
+					slug: "old slug",
+				},
+				replacementVariables: [
+					{
+						name: "test1",
+						label: "Test1",
+						value: "first",
+					},
+					{
+						name: "test2",
+						label: "Test2",
+						value: "second",
+					},
+				],
 			};
 
-			const isDirty = editor.instance().shallowCompareData( oldData, newData );
+			const isDirty = editor.instance().shallowCompareData( prev, next );
+
+			expect( isDirty ).toBe( true );
+		} );
+
+		it( "returns true when one replacement variable has changed", () => {
+			const editor = mountWithArgs( {} );
+
+			const prev = {
+				data: {
+					title: "old title",
+					description: "old description",
+					slug: "old slug",
+				},
+				replacementVariables: [
+					{
+						name: "test1",
+						label: "Test1",
+						value: "first",
+					},
+					{
+						name: "test2",
+						label: "Test2",
+						value: "second",
+					},
+				],
+			};
+			const next = {
+				data: {
+					title: "new title",
+					description: "old description",
+					slug: "old slug",
+				},
+				replacementVariables: [
+					{
+						name: "test1",
+						label: "Test1",
+						value: "first to change",
+					},
+					{
+						name: "test2",
+						label: "Test2",
+						value: "second",
+					},
+				],
+			};
+
+			const isDirty = editor.instance().shallowCompareData( prev, next );
 
 			expect( isDirty ).toBe( true );
 		} );
@@ -347,18 +431,46 @@ describe( "SnippetEditor", () => {
 		it( "returns true when multiple data points have changed", () => {
 			const editor = mountWithArgs( {} );
 
-			const oldData = {
-				title: "old title",
-				description: "old description",
-				slug: "old slug",
+			const prev = {
+				data: {
+					title: "old title",
+					description: "old description",
+					slug: "old slug",
+				},
+				replacementVariables: [
+					{
+						name: "test1",
+						label: "Test1",
+						value: "first",
+					},
+					{
+						name: "test2",
+						label: "Test2",
+						value: "second",
+					},
+				],
 			};
-			const newData = {
-				title: "new title",
-				description: "new description",
-				slug: "old slug",
+			const next = {
+				data: {
+					title: "new title",
+					description: "new description",
+					slug: "old slug",
+				},
+				replacementVariables: [
+					{
+						name: "test1",
+						label: "Test1",
+						value: "first",
+					},
+					{
+						name: "test2",
+						label: "Test2",
+						value: "second but now third",
+					},
+				],
 			};
 
-			const isDirty = editor.instance().shallowCompareData( oldData, newData );
+			const isDirty = editor.instance().shallowCompareData( prev, next );
 
 			expect( isDirty ).toBe( true );
 		} );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes in replacevariables now cause progress in SEO Title and description to be measured with the new replacevariable values.

## Relevant technical choices:

* I chose to optionally pass replacementVariables to `mapDataToMeasurements` (and eventually `processReplacementVariables`), so that when mapDataToMeasurements is accessed from the `componentWillReceiveProps` function, the "next" replacementVariables can be used.

## Test instructions

This PR can be tested by following these steps:

* Put `%%title%%` in the SEO Title input field.
* Change the title of the post. See that the progress changes accordingly.
* Do the same for the description (put `%%title%%` in it and change the title).
* It should work for any replacement variable that you change, and that is placed in the title or description field.

Fixes https://github.com/Yoast/wordpress-seo/issues/10047
