### PR TITLE
Add serialized content to copy and cut

### DIFF
--- a/composites/OnboardingWizard/components/Choice.js
+++ b/composites/OnboardingWizard/components/Choice.js
@@ -50,23 +50,23 @@ const Choice = ( props ) => {
 			/* eslint-enable jsx-a11y/no-onchange */
 		}
 		return <fieldset className={"yoast-wizard-input-radio-" + fieldName}>
-				{fieldKeys.map( ( choiceName, index ) => {
-					let choice = choices[ choiceName ];
-					let id = `${fieldName}-${index}`;
-					// If the value for the choice field equals the name for this choice, the choice is checked.
-					let checked = ( props.value === choiceName );
+			{fieldKeys.map( ( choiceName, index ) => {
+				let choice = choices[ choiceName ];
+				let id = `${fieldName}-${index}`;
+				// If the value for the choice field equals the name for this choice, the choice is checked.
+				let checked = ( props.value === choiceName );
 
-					return (
-						<div className={props.optionClassName + " " + choiceName} key={index}>
-							<Input name={fieldName} type="radio" label={choice.label} onChange={props.onChange}
-								   value={choiceName} optionalAttributes={ { id, checked } }
-							/>
-							<Label for={id}
-								   optionalAttributes={ { "aria-label": choice.screenReaderText } }>{htmlDecoder( choice.label )}</Label>
-						</div>
-					);
-				} )}
-			</fieldset>
+				return (
+					<div className={props.optionClassName + " " + choiceName} key={index}>
+						<Input name={fieldName} type="radio" label={choice.label} onChange={props.onChange}
+							   value={choiceName} optionalAttributes={ { id, checked } }
+						/>
+						<Label for={id}
+							   optionalAttributes={ { "aria-label": choice.screenReaderText } }>{htmlDecoder( choice.label )}</Label>
+					</div>
+				);
+			} )}
+		</fieldset>
 		;
 	};
 

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
@@ -1,10 +1,8 @@
 // External dependencies.
 import React from "react";
-import { convertToRaw } from "draft-js";
 import Editor from "draft-js-plugins-editor";
 import createMentionPlugin from "draft-js-mention-plugin";
 import createSingleLinePlugin from "draft-js-single-line-plugin";
-import flow from "lodash/flow";
 import debounce from "lodash/debounce";
 import PropTypes from "prop-types";
 import { speak as a11ySpeak } from "@wordpress/a11y";
@@ -19,6 +17,7 @@ import {
 	serializeEditor,
 	unserializeEditor,
 	replaceReplacementVariables,
+	serializeSelection,
 } from "../serialization";
 import {
 	hasWhitespaceAt,
@@ -30,17 +29,6 @@ import {
 } from "../replaceText";
 
 /**
- * Serializes the Draft.js editor state into a string.
- *
- * @param {EditorState} The current editor state.
- *
- * @returns {string} The serialized editor state.
- */
-const serializeEditorState = flow( [
-	convertToRaw,
-	serializeEditor,
-] );
-
 /**
  * Needed to avoid styling issues on the settings pages with the
  * suggestions dropdown, because the button labels have a z-index of 3.
@@ -128,6 +116,7 @@ class ReplacementVariableEditorStandalone extends React.Component {
 		this.onSearchChange = this.onSearchChange.bind( this );
 		this.setEditorRef = this.setEditorRef.bind( this );
 		this.setMentionSuggestionsRef = this.setMentionSuggestionsRef.bind( this );
+		this.handleCopyCutEvent = this.handleCopyCutEvent.bind( this );
 		this.debouncedA11ySpeak = debounce( a11ySpeak.bind( this ), 500 );
 		this.debouncedUpdateMentionSuggestions = debounce( this.updateMentionSuggestions.bind( this ), 100 );
 
@@ -156,7 +145,7 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	 * @returns {void}
 	 */
 	serializeContent( editorState ) {
-		const serializedContent = serializeEditorState( editorState.getCurrentContent() );
+		const serializedContent = serializeEditor( editorState.getCurrentContent() );
 
 		if ( this._serializedContent !== serializedContent ) {
 			this._serializedContent = serializedContent;
@@ -354,12 +343,52 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	}
 
 	/**
-	 * Update the mention suggestions to trigger the repositioning of the popover.
+	 * Handles browser copy and cut events.
+	 *
+	 * This method makes sure that the clipboard has the correct content if a user
+	 * copies from this DraftJS editor.
+	 *
+	 * @param {ClipboardEvent} event The triggered clipboard event.
+	 * @returns {void}
+	 */
+	handleCopyCutEvent( event ) {
+		const { editorState } = this.state;
+		const selection = editorState.getSelection();
+
+		// If this editor is not focused we don't do anything.
+		if ( ! selection.getHasFocus() ) {
+			return;
+		}
+
+		// Use a try-catch to make this fail gracefully on older browsers.
+		try {
+			const clipboardData = event.clipboardData;
+			const contentState = editorState.getCurrentContent();
+
+			const text = serializeSelection( contentState, selection );
+
+			clipboardData.setData( "text/plain", text );
+
+			/*
+			 * This is at the end because we only want to prevent the default if we
+			 * succeeded in altering the clipboard contents.
+			 */
+			event.preventDefault();
+		} catch ( error ) {
+			console.error( "Couldn't copy content of editor to clipboard, defaulting to browser copy behavior." );
+			console.error( "Original error: ", error );
+		}
+	}
+
+	/**
+	 * Sets up event listeners this component needs.
 	 *
 	 * @returns {void}
 	 */
 	componentDidMount() {
 		window.addEventListener( "scroll", this.debouncedUpdateMentionSuggestions );
+		document.addEventListener( "copy", this.handleCopyCutEvent );
+		document.addEventListener( "cut", this.handleCopyCutEvent );
 	}
 
 	/**
@@ -370,6 +399,8 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	componentWillUnmount() {
 		this.debouncedA11ySpeak.cancel();
 		window.removeEventListener( "scroll", this.debouncedUpdateMentionSuggestions );
+		document.removeEventListener( "copy", this.handleCopyCutEvent );
+		document.removeEventListener( "cut", this.handleCopyCutEvent );
 	}
 
 	/**

--- a/composites/Plugin/SnippetEditor/serialization.js
+++ b/composites/Plugin/SnippetEditor/serialization.js
@@ -1,5 +1,3 @@
-import reduce from "lodash/reduce";
-import sortBy from "lodash/sortBy";
 import { EditorState, Modifier, SelectionState, ContentState } from "draft-js";
 
 const CIRCUMFIX = "%%";
@@ -20,48 +18,143 @@ export function serializeVariable( name ) {
 }
 
 /**
- * Serializes a Draft.js block into a string.
+ * Replaces pieces of text by using positions.
  *
- * @param {Object} entityMap Contains all the entities in the Draft.js editor.
- * @param {Object} block The block to serialize.
- *
- * @returns {string} The serialized block.
+ * @param {string} text The text to replace in.
+ * @param {Array} replacements The replacements to execute.
+ * @returns {string} The text with the replacements replaced.
  */
-export function serializeBlock( entityMap, block ) {
-	const { text, entityRanges } = block;
-	let previousEntityEnd = 0;
+export function replaceByPosition( text, replacements = [] ) {
+	/*
+	 * Start from the last replacement to prevent having to track changes in the
+	 * string.
+	 */
+	[ ...replacements ].reverse().forEach( ( replacement ) => {
+		const { start, end, replacementText } = replacement;
 
-	// Ensure the entityRanges are in order from low to high offset.
-	const sortedEntityRanges = sortBy( entityRanges, "offset" );
-	let serialized = reduce( sortedEntityRanges, ( serialized, entityRange ) => {
-		const { key, length, offset } = entityRange;
-		const beforeEntityLength = offset - previousEntityEnd;
+		const before =       text.slice( 0, start );
+		const after =        text.slice( end, text.length );
 
-		const beforeEntity = text.substr( previousEntityEnd, beforeEntityLength );
-		const serializedEntity = serializeVariable( entityMap[ key ].data.mention.name );
+		text = before + replacementText + after;
+	} );
 
-		previousEntityEnd = offset + length;
+	return text;
+}
 
-		return serialized + beforeEntity + serializedEntity;
-	}, "" );
+/**
+ * Returns whether a given position is in the given range.
+ *
+ * @param {number} position The position to check.
+ * @param {number} start    The start of the range.
+ * @param {number} end      The end of the range.
+ * @returns {boolean} Whether the given position is inside the range.
+ */
+function inRange( position, start, end ) {
+	return position >= start && position <= end;
+}
 
-	serialized += text.substr( previousEntityEnd );
+/**
+ * Serializes a block into a string.
+ *
+ * @param {ContentBlock} block            The DraftJS block to serialize.
+ * @param {Function}     getEntity        A function which is used to get the
+ *                                        entity object from the entity key.
+ * @param {Object?}      delimiters       Optional delimiters which can be
+ *                                        passed to only serialize that part of
+ *                                        the block.
+ * @param {number}       delimiters.start The start of the selection to
+ *                                        serialize.
+ * @param {number}       delimiters.end   The end of the selection to serialize.
+ * @returns {string} The content of the block serialized into a string.
+ */
+export function serializeBlock( block, getEntity, { start = 0, end = block.getText().length } = {} ) {
+	let text = block.getText().slice( start, end );
 
-	return serialized;
+	const replacements = [];
+
+	// Find all the entities and replace them if necessary.
+	block.findEntityRanges(
+		character => !! character.getEntity(),
+		( entityStart, entityEnd ) => {
+			/*
+			 * Only if the entity is contained within start and end do we want to replace it
+			 * by its serialized value.
+			 */
+			if ( inRange( entityStart, start, end ) && inRange( entityEnd, start, end ) ) {
+				const entityData = getEntity( block.getEntityAt( entityStart ) );
+
+				replacements.push( {
+					start: entityStart - start,
+					end: entityEnd - start,
+					replacementText: serializeVariable( entityData.data.mention.name ),
+				} );
+			}
+		}
+	);
+
+	return replaceByPosition( text, replacements );
 }
 
 /**
  * Serializes the content inside a Draft.js editor.
  *
- * @param {Object} rawContent The content as returned by convertToRaw.
- *
+ * @param {ContentState} contentState The content state of DraftJS.
+ * @param {string} blockDelimiter The string with which to delimit the blocks.
  * @returns {string} The serialized content.
  */
-export function serializeEditor( rawContent ) {
-	const { blocks, entityMap } = rawContent;
+export function serializeEditor( contentState, blockDelimiter = " " ) {
+	const blocks = contentState.getBlockMap();
 
-	// Every line is a block. Join the lines with a space between them.
-	return blocks.map( block => serializeBlock( entityMap, block ) ).join( " " );
+	return blocks
+		.map( ( block ) => serializeBlock( block, key => contentState.getEntity( key ) ) )
+		.join( blockDelimiter );
+}
+
+/**
+ * Serializes a piece of the content state into text.
+ *
+ * @param  {ContentState}   contentState          The current content state.
+ * @param  {SelectionState} selection             The current selection
+ * @param  {string}         [blockDelimiter=" "] With which to separate the
+ *                                                blocks.
+ * @returns {string} The selected text.
+ */
+export function serializeSelection( contentState, selection, blockDelimiter = " " ) {
+	const startKey   = selection.getStartKey();
+	const endKey     = selection.getEndKey();
+	const blocks     = contentState.getBlockMap();
+
+	let lastWasEnd = false;
+	const selectedBlock = blocks
+		.skipUntil( function( block ) {
+			return block.getKey() === startKey;
+		} )
+		.takeUntil( function( block ) {
+			const result = lastWasEnd;
+
+			if ( block.getKey() === endKey ) {
+				lastWasEnd = true;
+			}
+
+			return result;
+		} );
+
+	return selectedBlock
+		.map( function( block ) {
+			const key = block.getKey();
+
+			const delimiters = {};
+
+			if ( key === startKey ) {
+				delimiters.start = selection.getStartOffset();
+			}
+			if ( key === endKey ) {
+				delimiters.end = selection.getEndOffset();
+			}
+
+			return serializeBlock( block, key => contentState.getEntity( key ), delimiters );
+		} )
+		.join( blockDelimiter );
 }
 
 /**

--- a/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
@@ -17,7 +17,6 @@ jest.mock( "draft-js/lib/generateRandomKey", () => () => {
 
 describe( "ReplacementVariableEditor", () => {
 	it( "wraps a Draft.js editor instance", () => {
-
 		const editor = shallow(
 			<ReplacementVariableEditorStandalone
 				replacementVariables={ [] }

--- a/composites/Plugin/SnippetEditor/tests/serializationTest.js
+++ b/composites/Plugin/SnippetEditor/tests/serializationTest.js
@@ -256,7 +256,6 @@ describe( "serializeBlock", () => {
 describe( "serializeSelection", () => {
 	it( "only serializes a selected part of the content state", () => {
 		const text = "Text %%entity%% %%entity%% Text";
-		// const beforeText = "[Text entity entity Text]";
 		const editorState = unserializeEditor( text, [ { name: "entity", value: "EntityValue" } ] );
 		const key = editorState.getCurrentContent().getFirstBlock().getKey();
 		const selection = new SelectionState( {

--- a/composites/basic/Loader.js
+++ b/composites/basic/Loader.js
@@ -10,49 +10,49 @@ const Loader = ( { className } ) => {
 
 	return (
 		<svg version="1.1" id="Y__x2B__bg" x="0px" y="0px" viewBox="0 0 500 500" className={className} >
-		<g>
 			<g>
-				<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="250" y1="428.6121" x2="250" y2="77.122">
-					<stop  offset="0" style={ { stopColor: "#570732" } } />
-					<stop  offset="2.377558e-02" style={{ stopColor: "#5D0936" }} />
-					<stop  offset="0.1559" style={ { stopColor: "#771549" } } />
-					<stop  offset="0.3019" style={ { stopColor: "#8B1D58" } } />
-					<stop  offset="0.4669" style={ { stopColor: "#992362" } } />
-					<stop  offset="0.6671" style={ { stopColor: "#A12768" } } />
-					<stop  offset="1" style={ { stopColor: "#A4286A" } } />
-				</linearGradient>
-				<path fill="url(#SVGID_1_)" d="M454.7,428.6H118.4c-40.2,0-73.2-32.9-73.2-73.2V150.3c0-40.2,32.9-73.2,73.2-73.2h263.1
-					c40.2,0,73.2,32.9,73.2,73.2V428.6z"/>
-			</g>
-			<g>
+				<g>
+					<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="250" y1="428.6121" x2="250" y2="77.122">
+						<stop  offset="0" style={ { stopColor: "#570732" } } />
+						<stop  offset="2.377558e-02" style={{ stopColor: "#5D0936" }} />
+						<stop  offset="0.1559" style={ { stopColor: "#771549" } } />
+						<stop  offset="0.3019" style={ { stopColor: "#8B1D58" } } />
+						<stop  offset="0.4669" style={ { stopColor: "#992362" } } />
+						<stop  offset="0.6671" style={ { stopColor: "#A12768" } } />
+						<stop  offset="1" style={ { stopColor: "#A4286A" } } />
+					</linearGradient>
+					<path fill="url(#SVGID_1_)" d="M454.7,428.6H118.4c-40.2,0-73.2-32.9-73.2-73.2V150.3c0-40.2,32.9-73.2,73.2-73.2h263.1
+						c40.2,0,73.2,32.9,73.2,73.2V428.6z"/>
+				</g>
 				<g>
 					<g>
 						<g>
-							<path fill="#A4286A" d="M357.1,102.4l-43.8,9.4L239.9,277l-47.2-147.8h-70.2l78.6,201.9c6.7,17.2,6.7,36.3,0,53.5
-								c-6.7,17.2,45.1-84.1,24.7-75.7c0,0,34.9,97.6,36.4,94.5c7-14.3,13.7-30.3,20.2-48.5L387.4,72
-								C387.4,72,358.4,102.4,357.1,102.4z"/>
+							<g>
+								<path fill="#A4286A" d="M357.1,102.4l-43.8,9.4L239.9,277l-47.2-147.8h-70.2l78.6,201.9c6.7,17.2,6.7,36.3,0,53.5
+									c-6.7,17.2,45.1-84.1,24.7-75.7c0,0,34.9,97.6,36.4,94.5c7-14.3,13.7-30.3,20.2-48.5L387.4,72
+									C387.4,72,358.4,102.4,357.1,102.4z"/>
+							</g>
 						</g>
 					</g>
 				</g>
+				<g>
+					<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="266.5665" y1="-6.9686" x2="266.5665" y2="378.4586">
+						<stop  offset="0" style={ { stopColor: "#77B227" } } />
+						<stop  offset="0.4669" style={ { stopColor: "#75B027" } } />
+						<stop  offset="0.635" style={ { stopColor: "#6EAB27" } } />
+						<stop  offset="0.7549" style={ { stopColor: "#63A027" } } />
+						<stop  offset="0.8518" style={ { stopColor: "#529228" } } />
+						<stop  offset="0.9339" style={ { stopColor: "#3C7F28" } } />
+						<stop  offset="1" style={ { stopColor: "#246B29" } } />
+					</linearGradient>
+					<path fill="url(#SVGID_2_)" d="M337,6.1l-98.6,273.8l-47.2-147.8H121L199.6,334c6.7,17.2,6.7,36.3,0,53.5
+						c-8.8,22.5-23.4,41.8-59,46.6v59.9c69.4,0,106.9-42.6,140.3-136.1L412.1,6.1H337z"/>
+					<path fill="#FFFFFF" d="M140.6,500h-6.1v-71.4l5.3-0.7c34.8-4.7,46.9-24.2,54.1-42.7c6.2-15.8,6.2-33.2,0-49l-81.9-210.3h83.7
+						l43.1,134.9L332.7,0h88.3L286.7,359.9c-17.9,50-36.4,83.4-58.1,105.3C205,488.9,177,500,140.6,500z M146.7,439.2v48.3
+						c29.9-1.2,53.3-11.1,73.1-31.1c20.4-20.5,38-52.6,55.3-100.9L403.2,12.3h-61.9L238.1,299l-51.3-160.8H130l75.3,193.5
+						c7.3,18.7,7.3,39.2,0,57.9C197.7,409.3,184.1,432.4,146.7,439.2z"/>
+				</g>
 			</g>
-			<g>
-				<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="266.5665" y1="-6.9686" x2="266.5665" y2="378.4586">
-					<stop  offset="0" style={ { stopColor: "#77B227" } } />
-					<stop  offset="0.4669" style={ { stopColor: "#75B027" } } />
-					<stop  offset="0.635" style={ { stopColor: "#6EAB27" } } />
-					<stop  offset="0.7549" style={ { stopColor: "#63A027" } } />
-					<stop  offset="0.8518" style={ { stopColor: "#529228" } } />
-					<stop  offset="0.9339" style={ { stopColor: "#3C7F28" } } />
-					<stop  offset="1" style={ { stopColor: "#246B29" } } />
-				</linearGradient>
-				<path fill="url(#SVGID_2_)" d="M337,6.1l-98.6,273.8l-47.2-147.8H121L199.6,334c6.7,17.2,6.7,36.3,0,53.5
-					c-8.8,22.5-23.4,41.8-59,46.6v59.9c69.4,0,106.9-42.6,140.3-136.1L412.1,6.1H337z"/>
-				<path fill="#FFFFFF" d="M140.6,500h-6.1v-71.4l5.3-0.7c34.8-4.7,46.9-24.2,54.1-42.7c6.2-15.8,6.2-33.2,0-49l-81.9-210.3h83.7
-					l43.1,134.9L332.7,0h88.3L286.7,359.9c-17.9,50-36.4,83.4-58.1,105.3C205,488.9,177,500,140.6,500z M146.7,439.2v48.3
-					c29.9-1.2,53.3-11.1,73.1-31.1c20.4-20.5,38-52.6,55.3-100.9L403.2,12.3h-61.9L238.1,299l-51.3-160.8H130l75.3,193.5
-					c7.3,18.7,7.3,39.2,0,57.9C197.7,409.3,184.1,432.4,146.7,439.2z"/>
-			</g>
-		</g>
 		</svg>
 	);
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [ReplacementVariableEditor] Handle cut and copy behavior in the replacement variable editor.

## Relevant technical choices:

This change hooks into the browser copy and cut events. We then
serialize the part of editor that is currently selected if the editor is
focused. We try to put this serialized text into the clipboard data.

This means we can now copy and cut replacement variables from a
replacement variable editor.

## Test instructions

This PR can be tested by following these steps:

* Open the editor
* Copy a piece of text that includes replacement variables.
* Paste this into another replacement variable editor.
* You should now have the same replacement variables.
* Paste this into a text editor or the URL input.
* You should now have the text with the variables replaced with their `%%variable%%` equivalent.

Fixes https://github.com/Yoast/wordpress-seo/issues/10046