### PR TITLE
Move margin bottom of the form section to the close editor snippet button

### DIFF
--- a/composites/Plugin/SnippetEditor/components/Shared.js
+++ b/composites/Plugin/SnippetEditor/components/Shared.js
@@ -92,7 +92,7 @@ export const DescriptionInputContainer = InputContainer.extend`
 `;
 
 export const FormSection = styled.div`
-	margin: 24px 0;
+	margin: 24px 0 0 0;
 `;
 
 export const StyledEditor = styled.section`

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -40,6 +40,7 @@ const EditSnippetButton = SnippetEditorButton.extend`
 `;
 
 const CloseEditorButton = SnippetEditorButton.extend`
+	margin-top: 24px;
 	margin-left: 20px;
 `;
 

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -709,6 +709,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border: 1px solid #dbdbdb;
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-top: 24px;
   margin-left: 20px;
 }
 
@@ -951,7 +952,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 .c29 {
-  margin: 24px 0;
+  margin: 24px 0 0 0;
 }
 
 .c28 {
@@ -2541,6 +2542,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border: 1px solid #dbdbdb;
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-top: 24px;
   margin-left: 20px;
 }
 
@@ -2783,7 +2785,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 .c29 {
-  margin: 24px 0;
+  margin: 24px 0 0 0;
 }
 
 .c28 {
@@ -4373,6 +4375,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border: 1px solid #dbdbdb;
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-top: 24px;
   margin-left: 20px;
 }
 
@@ -4615,7 +4618,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 .c29 {
-  margin: 24px 0;
+  margin: 24px 0 0 0;
 }
 
 .c28 {
@@ -6205,6 +6208,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border: 1px solid #dbdbdb;
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-top: 24px;
   margin-left: 20px;
 }
 
@@ -6447,7 +6451,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 .c29 {
-  margin: 24px 0;
+  margin: 24px 0 0 0;
 }
 
 .c28 {
@@ -9160,6 +9164,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border: 1px solid #dbdbdb;
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-top: 24px;
   margin-left: 20px;
 }
 
@@ -9402,7 +9407,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c29 {
-  margin: 24px 0;
+  margin: 24px 0 0 0;
 }
 
 .c28 {
@@ -10992,6 +10997,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border: 1px solid #dbdbdb;
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-top: 24px;
   margin-left: 20px;
 }
 
@@ -11234,7 +11240,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c29 {
-  margin: 24px 0;
+  margin: 24px 0 0 0;
 }
 
 .c28 {
@@ -13914,6 +13920,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   border: 1px solid #dbdbdb;
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-top: 24px;
   margin-left: 20px;
 }
 
@@ -14156,7 +14163,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 }
 
 .c30 {
-  margin: 24px 0;
+  margin: 24px 0 0 0;
 }
 
 .c29 {
@@ -15766,6 +15773,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   border: 1px solid #dbdbdb;
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-top: 24px;
   margin-left: 20px;
 }
 
@@ -16008,7 +16016,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 }
 
 .c30 {
-  margin: 24px 0;
+  margin: 24px 0 0 0;
 }
 
 .c29 {
@@ -17618,6 +17626,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border: 1px solid #dbdbdb;
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-top: 24px;
   margin-left: 20px;
 }
 
@@ -17860,7 +17869,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 .c29 {
-  margin: 24px 0;
+  margin: 24px 0 0 0;
 }
 
 .c28 {
@@ -19450,6 +19459,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border: 1px solid #dbdbdb;
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-top: 24px;
   margin-left: 20px;
 }
 
@@ -19692,7 +19702,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 .c29 {
-  margin: 24px 0;
+  margin: 24px 0 0 0;
 }
 
 .c28 {
@@ -21981,6 +21991,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   border: 1px solid #dbdbdb;
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin-top: 24px;
   margin-left: 20px;
 }
 
@@ -22223,7 +22234,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 }
 
 .c29 {
-  margin: 24px 0;
+  margin: 24px 0 0 0;
 }
 
 .c28 {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Moves the margin bottom from the FormSections to the CloseSnippetEditor button.

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Ensure the snippet editor margins / paddings look the same on the metabox.
* On the settings pages this will solve a to-much-margin-at-the-bottom error from @jcomack 
