### PR TITLE
Simplify replacement variable insert button alignment.

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -132,7 +132,6 @@ ReplacementVariableEditor.propTypes = {
 
 ReplacementVariableEditor.defaultProps = {
 	replacementVariables: [],
-	mobileWidth: 356,
 };
 
 export default ReplacementVariableEditor;

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -71,7 +71,6 @@ class ReplacementVariableEditor extends React.Component {
 			isHovered,
 			replacementVariables,
 			recommendedReplacementVariables,
-			styleForMobile,
 			editorRef,
 			placeholder,
 		} = this.props;
@@ -87,7 +86,6 @@ class ReplacementVariableEditor extends React.Component {
 				</SimulatedLabel>
 				<TriggerReplacementVariableSuggestionsButton
 					onClick={ () => this.triggerReplacementVariableSuggestions() }
-					isSmallerThanMobileWidth={ styleForMobile }
 				>
 					<SvgIcon icon="plus-circle" />
 					{ __( "Insert snippet variable", "yoast-components" ) }
@@ -127,7 +125,6 @@ ReplacementVariableEditor.propTypes = {
 	isHovered: PropTypes.bool,
 	withCaret: PropTypes.bool,
 	onFocus: PropTypes.func,
-	styleForMobile: PropTypes.bool,
 	label: PropTypes.string,
 	placeholder: PropTypes.string,
 	type: PropTypes.oneOf( [ "title", "description" ] ),

--- a/composites/Plugin/SnippetEditor/components/SettingsSnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SettingsSnippetEditorFields.js
@@ -2,7 +2,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import uniqueId from "lodash/uniqueId";
-import debounce from "lodash/debounce";
 import { __ } from "@wordpress/i18n";
 
 /* Internal dependencies */
@@ -46,16 +45,11 @@ class SettingsSnippetEditorFields extends React.Component {
 			description: null,
 		};
 
-		this.state = {
-			isSmallerThanMobileWidth: false,
-		};
-
 		this.uniqueId = uniqueId( "snippet-editor-field-" );
 
 		this.setRef = this.setRef.bind( this );
 		this.setEditorRef = this.setEditorRef.bind( this );
 		this.triggerReplacementVariableSuggestions = this.triggerReplacementVariableSuggestions.bind( this );
-		this.debouncedUpdateIsSmallerThanMobileWidth = debounce( this.updateIsSmallerThanMobileWidth.bind( this ), 200 );
 	}
 
 	/**
@@ -79,34 +73,6 @@ class SettingsSnippetEditorFields extends React.Component {
 	 */
 	setRef( field, ref ) {
 		this.elements[ field ] = ref;
-	}
-
-	/**
-	 * Ensures isSmallerThanMobileWidth is accurate.
-	 *
-	 * By running it once and binding it to the window resize event.
-	 *
-	 * @returns {void}
-	 */
-	componentDidMount() {
-		/**
-		 * Temporary fix to make sure the initial styling is applied correctly,
-		 * because we manually calculate whether the editor should be styled for
-		 * mobile or not.
-		 */
-		setTimeout( () => {
-			this.updateIsSmallerThanMobileWidth();
-		}, 300 );
-		window.addEventListener( "resize", this.debouncedUpdateIsSmallerThanMobileWidth );
-	}
-
-	/**
-	 * Removes the window resize event listener.
-	 *
-	 * @returns {void}
-	 */
-	componentWillUnmount() {
-		window.removeEventListener( "resize", this.debouncedUpdateIsSmallerThanMobileWidth );
 	}
 
 	/**
@@ -150,20 +116,6 @@ class SettingsSnippetEditorFields extends React.Component {
 	}
 
 	/**
-	 * Updates isSmallerThanMobileWidth when changed.
-	 *
-	 * isSmallerThanMobileWidth is true if the editor's client width is smaller than the mobile width prop.
-	 *
-	 * @returns {void}
-	 */
-	updateIsSmallerThanMobileWidth() {
-		const isSmallerThanMobileWidth = this.editor.clientWidth < this.props.mobileWidth;
-		if ( this.state.isSmallerThanMobileWidth !== isSmallerThanMobileWidth ) {
-			this.setState( { isSmallerThanMobileWidth } );
-		}
-	}
-
-	/**
 	 * Renders the snippet editor.
 	 *
 	 * @returns {ReactElement} The snippet editor element.
@@ -184,8 +136,6 @@ class SettingsSnippetEditorFields extends React.Component {
 			containerPadding,
 		} = this.props;
 
-		const isSmallerThanMobileWidth = this.state.isSmallerThanMobileWidth;
-
 		return (
 			<StyledEditor
 				innerRef={ this.setEditorRef }
@@ -202,7 +152,6 @@ class SettingsSnippetEditorFields extends React.Component {
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						content={ title }
 						onChange={ content => onChange( "title", content ) }
-						styleForMobile={ isSmallerThanMobileWidth }
 					/>
 				</FormSection>
 				<FormSection>
@@ -218,7 +167,6 @@ class SettingsSnippetEditorFields extends React.Component {
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						content={ description }
 						onChange={ content => onChange( "description", content ) }
-						styleForMobile={ isSmallerThanMobileWidth }
 					/>
 				</FormSection>
 			</StyledEditor>

--- a/composites/Plugin/SnippetEditor/components/SettingsSnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SettingsSnippetEditorFields.js
@@ -186,14 +186,12 @@ SettingsSnippetEditorFields.propTypes = {
 	activeField: PropTypes.oneOf( [ "title", "description" ] ),
 	hoveredField: PropTypes.oneOf( [ "title", "description" ] ),
 	descriptionEditorFieldPlaceholder: PropTypes.string,
-	mobileWidth: PropTypes.number,
 	containerPadding: PropTypes.string,
 };
 
 SettingsSnippetEditorFields.defaultProps = {
 	replacementVariables: [],
 	onFocus: () => {},
-	mobileWidth: 356,
 	containerPadding: "0 20px",
 };
 

--- a/composites/Plugin/SnippetEditor/components/SettingsSnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SettingsSnippetEditorFields.js
@@ -48,19 +48,7 @@ class SettingsSnippetEditorFields extends React.Component {
 		this.uniqueId = uniqueId( "snippet-editor-field-" );
 
 		this.setRef = this.setRef.bind( this );
-		this.setEditorRef = this.setEditorRef.bind( this );
 		this.triggerReplacementVariableSuggestions = this.triggerReplacementVariableSuggestions.bind( this );
-	}
-
-	/**
-	 * Sets the ref for the editor.
-	 *
-	 * @param {Object} editor The editor React reference.
-	 *
-	 * @returns {void}
-	 */
-	setEditorRef( editor ) {
-		this.editor = editor;
 	}
 
 	/**
@@ -138,7 +126,6 @@ class SettingsSnippetEditorFields extends React.Component {
 
 		return (
 			<StyledEditor
-				innerRef={ this.setEditorRef }
 				padding={ containerPadding }
 			>
 				<FormSection>

--- a/composites/Plugin/SnippetEditor/components/Shared.js
+++ b/composites/Plugin/SnippetEditor/components/Shared.js
@@ -41,8 +41,11 @@ function getCaretColor( props ) {
  */
 export const InputContainer = styled.div.attrs( {
 } )`
-	padding: 3px 5px;
+	flex: 0 1 100%;
 	border: 1px solid ${ ( props ) => props.isActive ? "#5b9dd9" : "#ddd" };
+	margin-top: 8px;
+	padding: 3px 5px;
+	box-sizing: border-box;
 	box-shadow: ${ ( props ) => props.isActive ? "0 0 2px rgba(30,140,190,.8);" : "inset 0 1px 2px rgba(0,0,0,.07)" };
 	background-color: #fff;
 	color: #32373c;
@@ -92,6 +95,10 @@ export const DescriptionInputContainer = InputContainer.extend`
 `;
 
 export const FormSection = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
 	margin: 24px 0 0 0;
 `;
 
@@ -103,30 +110,24 @@ export const StyledEditor = styled.section`
  * A div element that looks like it can be interacted with like a label.
  */
 export const SimulatedLabel = styled.div`
+	flex: 0 1 200px;
+	min-width: 200px;
 	cursor: pointer;
 	font-size: 16px;
 	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
-	margin-bottom: 9px;
+	margin: 4px 0;
 `;
 
 export const TriggerReplacementVariableSuggestionsButton = styled( Button )`
 	box-shadow: none;
 	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
-	fill: ${ colors.$color_grey_dark };
 	padding-left: 8px;
-	float: right;
-	margin-top: -33px; // negative height
 	height: 33px;
 	border: 1px solid #dbdbdb;
 	font-size: 13px;
 
-	${ props => props.isSmallerThanMobileWidth && `
-		float: none;
-		margin-top: 0;
-		margin-bottom: 2px;
-	` }
-
 	& svg {
 		margin-right: 7px;
+		fill: ${ colors.$color_grey_dark };
 	}
 `;

--- a/composites/Plugin/SnippetEditor/components/Shared.js
+++ b/composites/Plugin/SnippetEditor/components/Shared.js
@@ -43,7 +43,6 @@ export const InputContainer = styled.div.attrs( {
 } )`
 	flex: 0 1 100%;
 	border: 1px solid ${ ( props ) => props.isActive ? "#5b9dd9" : "#ddd" };
-	margin-top: 8px;
 	padding: 3px 5px;
 	box-sizing: border-box;
 	box-shadow: ${ ( props ) => props.isActive ? "0 0 2px rgba(30,140,190,.8);" : "inset 0 1px 2px rgba(0,0,0,.07)" };

--- a/composites/Plugin/SnippetEditor/components/Shared.js
+++ b/composites/Plugin/SnippetEditor/components/Shared.js
@@ -110,7 +110,7 @@ export const StyledEditor = styled.section`
  * A div element that looks like it can be interacted with like a label.
  */
 export const SimulatedLabel = styled.div`
-	flex: 0 1 200px;
+	flex: 1 1 200px;
 	min-width: 200px;
 	cursor: pointer;
 	font-size: 16px;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -288,7 +288,6 @@ SnippetEditorFields.propTypes = {
 	titleLengthProgress: lengthProgressShape,
 	descriptionLengthProgress: lengthProgressShape,
 	descriptionEditorFieldPlaceholder: PropTypes.string,
-	mobileWidth: PropTypes.number,
 	containerPadding: PropTypes.string,
 };
 
@@ -306,7 +305,6 @@ SnippetEditorFields.defaultProps = {
 		actual: 0,
 		score: 0,
 	},
-	mobileWidth: 356,
 	containerPadding: "0 20px",
 };
 

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -2,7 +2,6 @@
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
-import debounce from "lodash/debounce";
 import uniqueId from "lodash/uniqueId";
 import { __ } from "@wordpress/i18n";
 
@@ -80,14 +79,9 @@ class SnippetEditorFields extends React.Component {
 
 		this.uniqueId = uniqueId( "snippet-editor-field-" );
 
-		this.state = {
-			isSmallerThanMobileWidth: false,
-		};
-
 		this.setRef = this.setRef.bind( this );
 		this.setEditorRef = this.setEditorRef.bind( this );
 		this.triggerReplacementVariableSuggestions = this.triggerReplacementVariableSuggestions.bind( this );
-		this.debouncedUpdateIsSmallerThanMobileWidth = debounce( this.updateIsSmallerThanMobileWidth.bind( this ), 200 );
 	}
 
 	/**
@@ -129,27 +123,6 @@ class SnippetEditorFields extends React.Component {
 	}
 
 	/**
-	 * Ensures isSmallerThanMobileWidth is accurate.
-	 *
-	 * By running it once and binding it to the window resize event.
-	 *
-	 * @returns {void}
-	 */
-	componentDidMount() {
-		this.updateIsSmallerThanMobileWidth();
-		window.addEventListener( "resize", this.debouncedUpdateIsSmallerThanMobileWidth );
-	}
-
-	/**
-	 * Removes the window resize event listener.
-	 *
-	 * @returns {void}
-	 */
-	componentWillUnmount() {
-		window.removeEventListener( "resize", this.debouncedUpdateIsSmallerThanMobileWidth );
-	}
-
-	/**
 	 * Focuses the currently active field if it wasn't previously active.
 	 *
 	 * @returns {void}
@@ -180,25 +153,6 @@ class SnippetEditorFields extends React.Component {
 	}
 
 	/**
-	 * Updates isSmallerThanMobileWidth when changed.
-	 *
-	 * isSmallerThanMobileWidth is true if the editor's client width is smaller than the mobile width prop.
-	 *
-	 * @returns {void}
-	 */
-	updateIsSmallerThanMobileWidth() {
-		if ( ! this.editor ) {
-			// The editor might not render if any previous error occurs.
-			return;
-		}
-
-		const isSmallerThanMobileWidth = this.editor.clientWidth < this.props.mobileWidth;
-		if ( this.state.isSmallerThanMobileWidth !== isSmallerThanMobileWidth ) {
-			this.setState( { isSmallerThanMobileWidth } );
-		}
-	}
-
-	/**
 	 * Renders the snippet editor.
 	 *
 	 * @returns {ReactElement} The snippet editor element.
@@ -222,7 +176,6 @@ class SnippetEditorFields extends React.Component {
 			},
 			containerPadding,
 		} = this.props;
-		const { isSmallerThanMobileWidth } = this.state;
 
 		const slugLabelId = `${ this.uniqueId }-slug`;
 
@@ -244,7 +197,6 @@ class SnippetEditorFields extends React.Component {
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						content={ title }
 						onChange={ content => onChange( "title", content ) }
-						styleForMobile={ isSmallerThanMobileWidth }
 					/>
 					<ProgressBar
 						max={ titleLengthProgress.max }
@@ -289,7 +241,6 @@ class SnippetEditorFields extends React.Component {
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						content={ description }
 						onChange={ content => onChange( "description", content ) }
-						styleForMobile={ isSmallerThanMobileWidth }
 					/>
 					<ProgressBar
 						max={ descriptionLengthProgress.max }

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -80,19 +80,7 @@ class SnippetEditorFields extends React.Component {
 		this.uniqueId = uniqueId( "snippet-editor-field-" );
 
 		this.setRef = this.setRef.bind( this );
-		this.setEditorRef = this.setEditorRef.bind( this );
 		this.triggerReplacementVariableSuggestions = this.triggerReplacementVariableSuggestions.bind( this );
-	}
-
-	/**
-	 * Sets the ref for the editor.
-	 *
-	 * @param {Object} editor The editor React reference.
-	 *
-	 * @returns {void}
-	 */
-	setEditorRef( editor ) {
-		this.editor = editor;
 	}
 
 	/**
@@ -181,7 +169,6 @@ class SnippetEditorFields extends React.Component {
 
 		return (
 			<StyledEditor
-				innerRef={ this.setEditorRef }
 				padding={ containerPadding }
 			>
 				<FormSection>

--- a/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
@@ -254,20 +254,6 @@ describe( "SnippetEditor", () => {
 		expect( editor ).toMatchSnapshot();
 	} );
 
-	it( "detects mobile view width", () => {
-		const editor = mountWithArgs( {} );
-
-		editor.instance().open();
-		editor.update();
-
-		const fields = editor.find( "SnippetEditorFields" ).instance();
-
-		// 356 is the default mobileWidth value.
-		expect( fields.props.mobileWidth ).toBe( 356 );
-		// Because the client innerWidth is 0 it is expected that isSmallerThanMobileWidth is true.
-		expect( fields.state.isSmallerThanMobileWidth ).toBe( true );
-	} );
-
 	describe( "colored progress bars", () => {
 		it( "can handle scores of 3 and 9", () => {
 			const editor = mountWithArgs( {

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -861,7 +861,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -897,7 +896,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -929,7 +927,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -2713,7 +2710,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -2749,7 +2745,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -2781,7 +2776,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -4565,7 +4559,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -4601,7 +4594,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -4633,7 +4625,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -6417,7 +6408,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -6453,7 +6443,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -6485,7 +6474,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -9393,7 +9381,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -9429,7 +9416,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -9461,7 +9447,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -11245,7 +11230,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -11281,7 +11265,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -11313,7 +11296,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -14187,7 +14169,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -14223,7 +14204,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -14255,7 +14235,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #5b9dd9;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: 0 0 2px rgba(30,140,190,.8);
@@ -16059,7 +16038,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -16095,7 +16073,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -16127,7 +16104,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -17931,7 +17907,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -17967,7 +17942,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -17999,7 +17973,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -19783,7 +19756,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -19819,7 +19791,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -19851,7 +19822,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -22335,7 +22305,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -22371,7 +22340,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
@@ -22403,7 +22371,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
   border: 1px solid #ddd;
-  margin-top: 8px;
   padding: 3px 5px;
   box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -600,7 +600,6 @@ exports[`SnippetEditor activates a field on onMouseUp() and opens the editor 1`]
           }
         }
         hoveredField={null}
-        mobileWidth={356}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -2006,7 +2005,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           }
         }
         hoveredField={null}
-        mobileWidth={356}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -2037,7 +2035,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -2247,7 +2244,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -3855,7 +3851,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           }
         }
         hoveredField={null}
-        mobileWidth={356}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -3886,7 +3881,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -4096,7 +4090,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -5704,7 +5697,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           }
         }
         hoveredField={null}
-        mobileWidth={356}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -5735,7 +5727,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -5945,7 +5936,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -7553,7 +7543,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           }
         }
         hoveredField={null}
-        mobileWidth={356}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -7584,7 +7573,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -7794,7 +7782,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -10526,7 +10513,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           }
         }
         hoveredField={null}
-        mobileWidth={356}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -10557,7 +10543,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -10767,7 +10752,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -12375,7 +12359,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           }
         }
         hoveredField={null}
-        mobileWidth={356}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -12406,7 +12389,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -12616,7 +12598,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -15334,7 +15315,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           }
         }
         hoveredField={null}
-        mobileWidth={356}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -15365,7 +15345,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -15575,7 +15554,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   isActive={true}
                   isHovered={false}
                   label="Meta description"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -17203,7 +17181,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
           }
         }
         hoveredField="description"
-        mobileWidth={356}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -17234,7 +17211,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -17444,7 +17420,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   isActive={false}
                   isHovered={true}
                   label="Meta description"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -19052,7 +19027,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           }
         }
         hoveredField={null}
-        mobileWidth={356}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -19083,7 +19057,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -19293,7 +19266,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -20912,7 +20884,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
           }
         }
         hoveredField={null}
-        mobileWidth={356}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -20954,7 +20925,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -21186,7 +21156,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -22044,7 +22013,6 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
           }
         }
         hoveredField={null}
-        mobileWidth={356}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -23450,7 +23418,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
           }
         }
         hoveredField={null}
-        mobileWidth={356}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -23481,7 +23448,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -23691,7 +23657,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
-                  mobileWidth={356}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -2019,7 +2019,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
         }
       >
         <Shared__StyledEditor
-          innerRef={[Function]}
           padding="0 20px"
         >
           <section
@@ -3865,7 +3864,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
         }
       >
         <Shared__StyledEditor
-          innerRef={[Function]}
           padding="0 20px"
         >
           <section
@@ -5711,7 +5709,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
         }
       >
         <Shared__StyledEditor
-          innerRef={[Function]}
           padding="0 20px"
         >
           <section
@@ -7557,7 +7554,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         }
       >
         <Shared__StyledEditor
-          innerRef={[Function]}
           padding="0 20px"
         >
           <section
@@ -10527,7 +10523,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         }
       >
         <Shared__StyledEditor
-          innerRef={[Function]}
           padding="0 20px"
         >
           <section
@@ -12373,7 +12368,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         }
       >
         <Shared__StyledEditor
-          innerRef={[Function]}
           padding="0 20px"
         >
           <section
@@ -15329,7 +15323,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
         }
       >
         <Shared__StyledEditor
-          innerRef={[Function]}
           padding="0 20px"
         >
           <section
@@ -17195,7 +17188,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
         }
       >
         <Shared__StyledEditor
-          innerRef={[Function]}
           padding="0 20px"
         >
           <section
@@ -19041,7 +19033,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         }
       >
         <Shared__StyledEditor
-          innerRef={[Function]}
           padding="0 20px"
         >
           <section
@@ -20909,7 +20900,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
         }
       >
         <Shared__StyledEditor
-          innerRef={[Function]}
           padding="0 20px"
         >
           <section
@@ -23432,7 +23422,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
         }
       >
         <Shared__StyledEditor
-          innerRef={[Function]}
           padding="0 20px"
         >
           <section

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -857,8 +857,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 .c32 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -888,8 +893,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 .c34 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -915,8 +925,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 .c36 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -953,6 +968,21 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 .c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   margin: 24px 0 0 0;
 }
 
@@ -961,29 +991,28 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 .c30 {
+  -webkit-flex: 0 1 200px;
+  -ms-flex: 0 1 200px;
+  flex: 0 1 200px;
+  min-width: 200px;
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 9px;
+  margin: 4px 0;
 }
 
 .c31 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  fill: #555;
   padding-left: 8px;
-  float: right;
-  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
-  float: none;
-  margin-top: 0;
-  margin-bottom: 2px;
 }
 
 .c31 svg {
   margin-right: 7px;
+  fill: #555;
 }
 
 .c33 {
@@ -2017,7 +2046,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -2033,12 +2061,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -2046,7 +2072,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -2056,7 +2081,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -2066,7 +2090,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -2076,7 +2099,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -2086,7 +2108,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -2236,7 +2257,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   placeholder="Modify your meta description by editing it right here"
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   type="description"
                   withCaret={true}
                 >
@@ -2253,12 +2273,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -2266,7 +2284,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -2276,7 +2293,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -2286,7 +2302,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -2296,7 +2311,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -2306,7 +2320,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -2696,8 +2709,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 .c32 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -2727,8 +2745,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 .c34 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -2754,8 +2777,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 .c36 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -2792,6 +2820,21 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 .c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   margin: 24px 0 0 0;
 }
 
@@ -2800,29 +2843,28 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 .c30 {
+  -webkit-flex: 0 1 200px;
+  -ms-flex: 0 1 200px;
+  flex: 0 1 200px;
+  min-width: 200px;
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 9px;
+  margin: 4px 0;
 }
 
 .c31 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  fill: #555;
   padding-left: 8px;
-  float: right;
-  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
-  float: none;
-  margin-top: 0;
-  margin-bottom: 2px;
 }
 
 .c31 svg {
   margin-right: 7px;
+  fill: #555;
 }
 
 .c33 {
@@ -3856,7 +3898,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -3872,12 +3913,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -3885,7 +3924,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -3895,7 +3933,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -3905,7 +3942,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -3915,7 +3951,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -3925,7 +3960,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -4075,7 +4109,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   placeholder="Modify your meta description by editing it right here"
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   type="description"
                   withCaret={true}
                 >
@@ -4092,12 +4125,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -4105,7 +4136,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -4115,7 +4145,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -4125,7 +4154,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -4135,7 +4163,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -4145,7 +4172,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -4535,8 +4561,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 .c32 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -4566,8 +4597,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 .c34 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -4593,8 +4629,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 .c36 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -4631,6 +4672,21 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 .c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   margin: 24px 0 0 0;
 }
 
@@ -4639,29 +4695,28 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 .c30 {
+  -webkit-flex: 0 1 200px;
+  -ms-flex: 0 1 200px;
+  flex: 0 1 200px;
+  min-width: 200px;
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 9px;
+  margin: 4px 0;
 }
 
 .c31 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  fill: #555;
   padding-left: 8px;
-  float: right;
-  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
-  float: none;
-  margin-top: 0;
-  margin-bottom: 2px;
 }
 
 .c31 svg {
   margin-right: 7px;
+  fill: #555;
 }
 
 .c33 {
@@ -5695,7 +5750,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -5711,12 +5765,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -5724,7 +5776,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -5734,7 +5785,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -5744,7 +5794,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -5754,7 +5803,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -5764,7 +5812,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -5914,7 +5961,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   placeholder="Modify your meta description by editing it right here"
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   type="description"
                   withCaret={true}
                 >
@@ -5931,12 +5977,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -5944,7 +5988,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -5954,7 +5997,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -5964,7 +6006,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -5974,7 +6015,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -5984,7 +6024,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -6374,8 +6413,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 .c32 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -6405,8 +6449,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 .c34 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -6432,8 +6481,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 .c36 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -6470,6 +6524,21 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 .c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   margin: 24px 0 0 0;
 }
 
@@ -6478,29 +6547,28 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 .c30 {
+  -webkit-flex: 0 1 200px;
+  -ms-flex: 0 1 200px;
+  flex: 0 1 200px;
+  min-width: 200px;
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 9px;
+  margin: 4px 0;
 }
 
 .c31 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  fill: #555;
   padding-left: 8px;
-  float: right;
-  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
-  float: none;
-  margin-top: 0;
-  margin-bottom: 2px;
 }
 
 .c31 svg {
   margin-right: 7px;
+  fill: #555;
 }
 
 .c33 {
@@ -7534,7 +7602,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -7550,12 +7617,10 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -7563,7 +7628,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -7573,7 +7637,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -7583,7 +7646,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -7593,7 +7655,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -7603,7 +7664,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -7753,7 +7813,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   placeholder="Modify your meta description by editing it right here"
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   type="description"
                   withCaret={true}
                 >
@@ -7770,12 +7829,10 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -7783,7 +7840,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -7793,7 +7849,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -7803,7 +7858,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -7813,7 +7867,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -7823,7 +7876,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -9337,8 +9389,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c32 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -9368,8 +9425,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c34 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -9395,8 +9457,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c36 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -9433,6 +9500,21 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   margin: 24px 0 0 0;
 }
 
@@ -9441,29 +9523,28 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c30 {
+  -webkit-flex: 0 1 200px;
+  -ms-flex: 0 1 200px;
+  flex: 0 1 200px;
+  min-width: 200px;
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 9px;
+  margin: 4px 0;
 }
 
 .c31 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  fill: #555;
   padding-left: 8px;
-  float: right;
-  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
-  float: none;
-  margin-top: 0;
-  margin-bottom: 2px;
 }
 
 .c31 svg {
   margin-right: 7px;
+  fill: #555;
 }
 
 .c33 {
@@ -10497,28 +10578,25 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="46"
+                    id="42"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="46"
+                      id="42"
                       onClick={[Function]}
                     >
                       SEO title
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -10526,7 +10604,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -10536,7 +10613,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -10546,7 +10622,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -10556,7 +10631,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -10566,7 +10640,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -10623,7 +10696,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="46"
+                        ariaLabelledBy="42"
                         content="Test title"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -10658,12 +10731,12 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 className="c29"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-45-slug"
+                  id="snippet-editor-field-41-slug"
                   onClick={[Function]}
                 >
                   <div
                     className="c30"
-                    id="snippet-editor-field-45-slug"
+                    id="snippet-editor-field-41-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -10679,7 +10752,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-45-slug"
+                      aria-labelledby="snippet-editor-field-41-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -10687,7 +10760,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-45-slug"
+                        aria-labelledby="snippet-editor-field-41-slug"
                         className="c35"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -10716,29 +10789,26 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   placeholder="Modify your meta description by editing it right here"
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   type="description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="47"
+                    id="43"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="47"
+                      id="43"
                       onClick={[Function]}
                     >
                       Meta description
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -10746,7 +10816,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -10756,7 +10825,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -10766,7 +10834,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -10776,7 +10843,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -10786,7 +10852,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -10843,7 +10908,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="47"
+                        ariaLabelledBy="43"
                         content="Test description, %%replacement_variable%%"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -11176,8 +11241,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c32 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -11207,8 +11277,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c34 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -11234,8 +11309,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c36 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -11272,6 +11352,21 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   margin: 24px 0 0 0;
 }
 
@@ -11280,29 +11375,28 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c30 {
+  -webkit-flex: 0 1 200px;
+  -ms-flex: 0 1 200px;
+  flex: 0 1 200px;
+  min-width: 200px;
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 9px;
+  margin: 4px 0;
 }
 
 .c31 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  fill: #555;
   padding-left: 8px;
-  float: right;
-  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
-  float: none;
-  margin-top: 0;
-  margin-bottom: 2px;
 }
 
 .c31 svg {
   margin-right: 7px;
+  fill: #555;
 }
 
 .c33 {
@@ -12336,28 +12430,25 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="42"
+                    id="38"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="42"
+                      id="38"
                       onClick={[Function]}
                     >
                       SEO title
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -12365,7 +12456,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -12375,7 +12465,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -12385,7 +12474,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -12395,7 +12483,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -12405,7 +12492,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -12462,7 +12548,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="42"
+                        ariaLabelledBy="38"
                         content="Test title"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -12497,12 +12583,12 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 className="c29"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-41-slug"
+                  id="snippet-editor-field-37-slug"
                   onClick={[Function]}
                 >
                   <div
                     className="c30"
-                    id="snippet-editor-field-41-slug"
+                    id="snippet-editor-field-37-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -12518,7 +12604,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-41-slug"
+                      aria-labelledby="snippet-editor-field-37-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -12526,7 +12612,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-41-slug"
+                        aria-labelledby="snippet-editor-field-37-slug"
                         className="c35"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -12555,29 +12641,26 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   placeholder="Modify your meta description by editing it right here"
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   type="description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="43"
+                    id="39"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="43"
+                      id="39"
                       onClick={[Function]}
                     >
                       Meta description
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -12585,7 +12668,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -12595,7 +12677,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -12605,7 +12686,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -12615,7 +12695,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -12625,7 +12704,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -12682,7 +12760,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="43"
+                        ariaLabelledBy="39"
                         content="Test description, %%replacement_variable%%"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -14105,8 +14183,13 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 }
 
 .c33 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -14136,8 +14219,13 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 }
 
 .c35 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -14163,8 +14251,13 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 }
 
 .c37 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #5b9dd9;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: 0 0 2px rgba(30,140,190,.8);
   background-color: #fff;
   color: #32373c;
@@ -14201,6 +14294,21 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 }
 
 .c30 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   margin: 24px 0 0 0;
 }
 
@@ -14209,29 +14317,28 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 }
 
 .c31 {
+  -webkit-flex: 0 1 200px;
+  -ms-flex: 0 1 200px;
+  flex: 0 1 200px;
+  min-width: 200px;
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 9px;
+  margin: 4px 0;
 }
 
 .c32 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  fill: #555;
   padding-left: 8px;
-  float: right;
-  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
-  float: none;
-  margin-top: 0;
-  margin-bottom: 2px;
 }
 
 .c32 svg {
   margin-right: 7px;
+  fill: #555;
 }
 
 .c34 {
@@ -15285,7 +15392,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -15301,12 +15407,10 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c32"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -15314,7 +15418,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c32 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -15324,7 +15427,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c32 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -15334,7 +15436,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -15344,7 +15445,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -15354,7 +15454,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -15504,7 +15603,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   placeholder="Modify your meta description by editing it right here"
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   type="description"
                   withCaret={true}
                 >
@@ -15521,12 +15619,10 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c32"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -15534,7 +15630,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c32 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -15544,7 +15639,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c32 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -15554,7 +15648,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -15564,7 +15657,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -15574,7 +15666,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -15964,8 +16055,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 }
 
 .c33 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -15995,8 +16091,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 }
 
 .c35 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -16022,8 +16123,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 }
 
 .c37 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -16060,6 +16166,21 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 }
 
 .c30 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   margin: 24px 0 0 0;
 }
 
@@ -16068,29 +16189,28 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 }
 
 .c31 {
+  -webkit-flex: 0 1 200px;
+  -ms-flex: 0 1 200px;
+  flex: 0 1 200px;
+  min-width: 200px;
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 9px;
+  margin: 4px 0;
 }
 
 .c32 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  fill: #555;
   padding-left: 8px;
-  float: right;
-  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
-  float: none;
-  margin-top: 0;
-  margin-bottom: 2px;
 }
 
 .c32 svg {
   margin-right: 7px;
+  fill: #555;
 }
 
 .c34 {
@@ -17144,7 +17264,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -17160,12 +17279,10 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c32"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -17173,7 +17290,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c32 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -17183,7 +17299,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c32 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -17193,7 +17308,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -17203,7 +17317,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -17213,7 +17326,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -17363,7 +17475,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   placeholder="Modify your meta description by editing it right here"
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   type="description"
                   withCaret={true}
                 >
@@ -17380,12 +17491,10 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c32"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -17393,7 +17502,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c32 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -17403,7 +17511,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c32 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -17413,7 +17520,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -17423,7 +17529,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -17433,7 +17538,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -17823,8 +17927,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 .c32 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -17854,8 +17963,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 .c34 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -17881,8 +17995,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 .c36 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -17919,6 +18038,21 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 .c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   margin: 24px 0 0 0;
 }
 
@@ -17927,29 +18061,28 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 .c30 {
+  -webkit-flex: 0 1 200px;
+  -ms-flex: 0 1 200px;
+  flex: 0 1 200px;
+  min-width: 200px;
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 9px;
+  margin: 4px 0;
 }
 
 .c31 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  fill: #555;
   padding-left: 8px;
-  float: right;
-  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
-  float: none;
-  margin-top: 0;
-  margin-bottom: 2px;
 }
 
 .c31 svg {
   margin-right: 7px;
+  fill: #555;
 }
 
 .c33 {
@@ -18983,7 +19116,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -18999,12 +19131,10 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -19012,7 +19142,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -19022,7 +19151,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -19032,7 +19160,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -19042,7 +19169,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -19052,7 +19178,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -19202,7 +19327,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   placeholder="Modify your meta description by editing it right here"
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   type="description"
                   withCaret={true}
                 >
@@ -19219,12 +19343,10 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -19232,7 +19354,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -19242,7 +19363,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -19252,7 +19372,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -19262,7 +19381,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -19272,7 +19390,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -19662,8 +19779,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 .c32 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -19693,8 +19815,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 .c34 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -19720,8 +19847,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 .c36 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -19758,6 +19890,21 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 .c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   margin: 24px 0 0 0;
 }
 
@@ -19766,29 +19913,28 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 .c30 {
+  -webkit-flex: 0 1 200px;
+  -ms-flex: 0 1 200px;
+  flex: 0 1 200px;
+  min-width: 200px;
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 9px;
+  margin: 4px 0;
 }
 
 .c31 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  fill: #555;
   padding-left: 8px;
-  float: right;
-  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
-  float: none;
-  margin-top: 0;
-  margin-bottom: 2px;
 }
 
 .c31 svg {
   margin-right: 7px;
+  fill: #555;
 }
 
 .c33 {
@@ -20855,7 +21001,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       },
                     ]
                   }
-                  styleForMobile={true}
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -20871,12 +21016,10 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -20884,7 +21027,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -20894,7 +21036,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -20904,7 +21045,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -20914,7 +21054,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -20924,7 +21063,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -21096,7 +21234,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       },
                     ]
                   }
-                  styleForMobile={true}
                   type="description"
                   withCaret={true}
                 >
@@ -21113,12 +21250,10 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -21126,7 +21261,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -21136,7 +21270,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -21146,7 +21279,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -21156,7 +21288,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -21166,7 +21297,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -22201,8 +22331,13 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 }
 
 .c32 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -22232,8 +22367,13 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 }
 
 .c34 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -22259,8 +22399,13 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 }
 
 .c36 {
-  padding: 3px 5px;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   border: 1px solid #ddd;
+  margin-top: 8px;
+  padding: 3px 5px;
+  box-sizing: border-box;
   box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
   background-color: #fff;
   color: #32373c;
@@ -22297,6 +22442,21 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 }
 
 .c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   margin: 24px 0 0 0;
 }
 
@@ -22305,29 +22465,28 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 }
 
 .c30 {
+  -webkit-flex: 0 1 200px;
+  -ms-flex: 0 1 200px;
+  flex: 0 1 200px;
+  min-width: 200px;
   cursor: pointer;
   font-size: 16px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin-bottom: 9px;
+  margin: 4px 0;
 }
 
 .c31 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  fill: #555;
   padding-left: 8px;
-  float: right;
-  margin-top: -33px;
   height: 33px;
   border: 1px solid #dbdbdb;
   font-size: 13px;
-  float: none;
-  margin-top: 0;
-  margin-bottom: 2px;
 }
 
 .c31 svg {
   margin-right: 7px;
+  fill: #555;
 }
 
 .c33 {
@@ -23361,7 +23520,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -23377,12 +23535,10 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -23390,7 +23546,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -23400,7 +23555,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -23410,7 +23564,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -23420,7 +23573,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -23430,7 +23582,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"
@@ -23580,7 +23731,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   placeholder="Modify your meta description by editing it right here"
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  styleForMobile={true}
                   type="description"
                   withCaret={true}
                 >
@@ -23597,12 +23747,10 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     </div>
                   </Shared__SimulatedLabel>
                   <Shared__TriggerReplacementVariableSuggestionsButton
-                    isSmallerThanMobileWidth={true}
                     onClick={[Function]}
                   >
                     <Button
                       className="c31"
-                      isSmallerThanMobileWidth={true}
                       onClick={[Function]}
                     >
                       <Button
@@ -23610,7 +23758,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
                         className="c31 c2"
-                        isSmallerThanMobileWidth={true}
                         onClick={[Function]}
                         textColor="#555"
                         type="button"
@@ -23620,7 +23767,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
                           className="c31 c2 Button-kDSBcD c3"
-                          isSmallerThanMobileWidth={true}
                           onClick={[Function]}
                           textColor="#555"
                           type="button"
@@ -23630,7 +23776,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
                             className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            isSmallerThanMobileWidth={true}
                             onClick={[Function]}
                             textColor="#555"
                             type="button"
@@ -23640,7 +23785,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
                               className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              isSmallerThanMobileWidth={true}
                               onClick={[Function]}
                               textColor="#555"
                               type="button"
@@ -23650,7 +23794,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
                                 className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                isSmallerThanMobileWidth={true}
                                 onClick={[Function]}
                                 textColor="#555"
                                 type="button"

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -991,9 +991,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 .c30 {
-  -webkit-flex: 0 1 200px;
-  -ms-flex: 0 1 200px;
-  flex: 0 1 200px;
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
   min-width: 200px;
   cursor: pointer;
   font-size: 16px;
@@ -2843,9 +2843,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 .c30 {
-  -webkit-flex: 0 1 200px;
-  -ms-flex: 0 1 200px;
-  flex: 0 1 200px;
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
   min-width: 200px;
   cursor: pointer;
   font-size: 16px;
@@ -4695,9 +4695,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 .c30 {
-  -webkit-flex: 0 1 200px;
-  -ms-flex: 0 1 200px;
-  flex: 0 1 200px;
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
   min-width: 200px;
   cursor: pointer;
   font-size: 16px;
@@ -6547,9 +6547,9 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 .c30 {
-  -webkit-flex: 0 1 200px;
-  -ms-flex: 0 1 200px;
-  flex: 0 1 200px;
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
   min-width: 200px;
   cursor: pointer;
   font-size: 16px;
@@ -9523,9 +9523,9 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c30 {
-  -webkit-flex: 0 1 200px;
-  -ms-flex: 0 1 200px;
-  flex: 0 1 200px;
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
   min-width: 200px;
   cursor: pointer;
   font-size: 16px;
@@ -11375,9 +11375,9 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c30 {
-  -webkit-flex: 0 1 200px;
-  -ms-flex: 0 1 200px;
-  flex: 0 1 200px;
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
   min-width: 200px;
   cursor: pointer;
   font-size: 16px;
@@ -14317,9 +14317,9 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 }
 
 .c31 {
-  -webkit-flex: 0 1 200px;
-  -ms-flex: 0 1 200px;
-  flex: 0 1 200px;
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
   min-width: 200px;
   cursor: pointer;
   font-size: 16px;
@@ -16189,9 +16189,9 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 }
 
 .c31 {
-  -webkit-flex: 0 1 200px;
-  -ms-flex: 0 1 200px;
-  flex: 0 1 200px;
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
   min-width: 200px;
   cursor: pointer;
   font-size: 16px;
@@ -18061,9 +18061,9 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 .c30 {
-  -webkit-flex: 0 1 200px;
-  -ms-flex: 0 1 200px;
-  flex: 0 1 200px;
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
   min-width: 200px;
   cursor: pointer;
   font-size: 16px;
@@ -19913,9 +19913,9 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 .c30 {
-  -webkit-flex: 0 1 200px;
-  -ms-flex: 0 1 200px;
-  flex: 0 1 200px;
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
   min-width: 200px;
   cursor: pointer;
   font-size: 16px;
@@ -22465,9 +22465,9 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 }
 
 .c30 {
-  -webkit-flex: 0 1 200px;
-  -ms-flex: 0 1 200px;
-  flex: 0 1 200px;
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
   min-width: 200px;
   cursor: pointer;
   font-size: 16px;


### PR DESCRIPTION
## Summary

Fixes the “insert snippet variable” button alignment by using only CSS and removing any JS widths calculation.

## Relevant technical choices:

- Flexbox
- the "labels" have a min-width of 200 pixels, this should give enough room for longer translations on narrow screens; on large screens, the labels are allowed to grow

## Test instructions

- in the standalone version you can test just the meta box snippet editor
- in order to test also the Settings pages variables editor, you need to yarn-link to the plugin branch `release/7.7` and test in the plugin
- test the button is aligned horizontally with the labels on large screens
- on small screens the button should go below the label
- note: currently there's an issue with the "Archives > Special pages" section, we'll see if there's a way to fix it

Fixes #594 
Fixes #583
