### PR TITLE
Sets static ids on elements close to the input fields

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -73,7 +73,7 @@ class ReplacementVariableEditor extends React.Component {
 			recommendedReplacementVariables,
 			editorRef,
 			placeholder,
-			uniqueID,
+			fieldId,
 		} = this.props;
 
 		const InputContainer = this.InputContainer;
@@ -95,7 +95,7 @@ class ReplacementVariableEditor extends React.Component {
 					onClick={ onFocus }
 					isActive={ isActive }
 					isHovered={ isHovered }
-					id={ uniqueID }>
+					id={ fieldId }>
 					<ReplacementVariableEditorStandalone
 						placeholder={ placeholder }
 						content={ content }
@@ -109,7 +109,6 @@ class ReplacementVariableEditor extends React.Component {
 							editorRef( ref );
 						} }
 						ariaLabelledBy={ this.uniqueId }
-					    uniqueID={ uniqueID }
 					/>
 				</InputContainer>
 			</React.Fragment>
@@ -131,7 +130,7 @@ ReplacementVariableEditor.propTypes = {
 	label: PropTypes.string,
 	placeholder: PropTypes.string,
 	type: PropTypes.oneOf( [ "title", "description" ] ),
-	uniqueID: PropTypes.string,
+	fieldId: PropTypes.string,
 };
 
 ReplacementVariableEditor.defaultProps = {

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -74,6 +74,7 @@ class ReplacementVariableEditor extends React.Component {
 			styleForMobile,
 			editorRef,
 			placeholder,
+			uniqueID,
 		} = this.props;
 
 		const InputContainer = this.InputContainer;
@@ -95,7 +96,8 @@ class ReplacementVariableEditor extends React.Component {
 				<InputContainer
 					onClick={ onFocus }
 					isActive={ isActive }
-					isHovered={ isHovered }>
+					isHovered={ isHovered }
+					id={ uniqueID }>
 					<ReplacementVariableEditorStandalone
 						placeholder={ placeholder }
 						content={ content }
@@ -109,6 +111,7 @@ class ReplacementVariableEditor extends React.Component {
 							editorRef( ref );
 						} }
 						ariaLabelledBy={ this.uniqueId }
+					    uniqueID={ uniqueID }
 					/>
 				</InputContainer>
 			</React.Fragment>
@@ -131,6 +134,7 @@ ReplacementVariableEditor.propTypes = {
 	label: PropTypes.string,
 	placeholder: PropTypes.string,
 	type: PropTypes.oneOf( [ "title", "description" ] ),
+	uniqueID: PropTypes.string,
 };
 
 ReplacementVariableEditor.defaultProps = {

--- a/composites/Plugin/SnippetEditor/components/SettingsSnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SettingsSnippetEditor.js
@@ -52,6 +52,7 @@ class SettingsSnippetEditor extends React.Component {
 		this.setFieldFocus = this.setFieldFocus.bind( this );
 		this.handleChange = this.handleChange.bind( this );
 		this.onClick = this.onClick.bind( this );
+		this.onBlur = this.onBlur.bind( this );
 	}
 
 	/**
@@ -83,6 +84,17 @@ class SettingsSnippetEditor extends React.Component {
 	}
 
 	/**
+	 * Removes focus from the fields.
+	 *
+	 * @returns {void}
+	 */
+	onBlur() {
+		this.setState( {
+			activeField: null,
+		} );
+	}
+
+	/**
 	 * Handles click event on a certain field in the snippet preview.
 	 *
 	 * @param {string} field The field that was clicked on.
@@ -105,6 +117,7 @@ class SettingsSnippetEditor extends React.Component {
 			recommendedReplacementVariables,
 			descriptionEditorFieldPlaceholder,
 			hasPaperStyle,
+			fieldIds,
 		} = this.props;
 
 		const { activeField, hoveredField } = this.state;
@@ -118,9 +131,11 @@ class SettingsSnippetEditor extends React.Component {
 					hoveredField={ hoveredField }
 					onChange={ this.handleChange }
 					onFocus={ this.setFieldFocus }
+					onBlur={ this.onBlur }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					containerPadding={ hasPaperStyle ? "0 20px" : "0" }
+					fieldIds={ fieldIds }
 				/>
 			</ErrorBoundary>
 		);
@@ -137,6 +152,10 @@ SettingsSnippetEditor.propTypes = {
 	onChange: PropTypes.func.isRequired,
 	descriptionEditorFieldPlaceholder: PropTypes.string,
 	hasPaperStyle: PropTypes.bool,
+	fieldIds: PropTypes.shape( {
+		title: PropTypes.string.isRequired,
+		description: PropTypes.string.isRequired,
+	} ).isRequired,
 };
 
 SettingsSnippetEditor.defaultProps = {

--- a/composites/Plugin/SnippetEditor/components/SettingsSnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SettingsSnippetEditorFields.js
@@ -116,12 +116,14 @@ class SettingsSnippetEditorFields extends React.Component {
 			replacementVariables,
 			recommendedReplacementVariables,
 			onFocus,
+			onBlur,
 			onChange,
 			data: {
 				title,
 				description,
 			},
 			containerPadding,
+			fieldIds,
 		} = this.props;
 
 		return (
@@ -132,6 +134,7 @@ class SettingsSnippetEditorFields extends React.Component {
 					<ReplacementVariableEditor
 						label={ __( "SEO title", "yoast-components" ) }
 						onFocus={ () => onFocus( "title" ) }
+						onBlur={ onBlur }
 						isActive={ activeField === "title" }
 						isHovered={ hoveredField === "title" }
 						editorRef={ ref => this.setRef( "title", ref ) }
@@ -139,6 +142,7 @@ class SettingsSnippetEditorFields extends React.Component {
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						content={ title }
 						onChange={ content => onChange( "title", content ) }
+						fieldId={ fieldIds.title }
 					/>
 				</FormSection>
 				<FormSection>
@@ -147,6 +151,7 @@ class SettingsSnippetEditorFields extends React.Component {
 						placeholder={ descriptionEditorFieldPlaceholder }
 						label={ __( "Meta description", "yoast-components" ) }
 						onFocus={ () => onFocus( "description" ) }
+						onBlur={ onBlur }
 						isActive={ activeField === "description" }
 						isHovered={ hoveredField === "description" }
 						editorRef={ ref => this.setRef( "description", ref ) }
@@ -154,6 +159,7 @@ class SettingsSnippetEditorFields extends React.Component {
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						content={ description }
 						onChange={ content => onChange( "description", content ) }
+						fieldId={ fieldIds.description }
 					/>
 				</FormSection>
 			</StyledEditor>
@@ -166,6 +172,7 @@ SettingsSnippetEditorFields.propTypes = {
 	recommendedReplacementVariables: recommendedReplacementVariablesShape,
 	onChange: PropTypes.func.isRequired,
 	onFocus: PropTypes.func,
+	onBlur: PropTypes.func,
 	data: PropTypes.shape( {
 		title: PropTypes.string,
 		description: PropTypes.string,
@@ -174,11 +181,16 @@ SettingsSnippetEditorFields.propTypes = {
 	hoveredField: PropTypes.oneOf( [ "title", "description" ] ),
 	descriptionEditorFieldPlaceholder: PropTypes.string,
 	containerPadding: PropTypes.string,
+	fieldIds: PropTypes.shape( {
+		title: PropTypes.string.isRequired,
+		description: PropTypes.string.isRequired,
+	} ).isRequired,
 };
 
 SettingsSnippetEditorFields.defaultProps = {
 	replacementVariables: [],
 	onFocus: () => {},
+	onBlur: () => {},
 	containerPadding: "0 20px",
 };
 

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -184,7 +184,7 @@ class SnippetEditorFields extends React.Component {
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						content={ title }
 						onChange={ content => onChange( "title", content ) }
-					    uniqueID="snippet-editor-field-title"
+					    fieldId="snippet-editor-field-title"
 					/>
 					<ProgressBar
 						max={ titleLengthProgress.max }
@@ -230,7 +230,7 @@ class SnippetEditorFields extends React.Component {
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						content={ description }
 						onChange={ content => onChange( "description", content ) }
-					    uniqueID={ "snippet-editor-field-description" }
+					    fieldId={ "snippet-editor-field-description" }
 					/>
 					<ProgressBar
 						max={ descriptionLengthProgress.max }

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -184,7 +184,7 @@ class SnippetEditorFields extends React.Component {
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						content={ title }
 						onChange={ content => onChange( "title", content ) }
-					    fieldId="snippet-editor-field-title"
+						fieldId="snippet-editor-field-title"
 					/>
 					<ProgressBar
 						max={ titleLengthProgress.max }
@@ -230,7 +230,7 @@ class SnippetEditorFields extends React.Component {
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						content={ description }
 						onChange={ content => onChange( "description", content ) }
-					    fieldId={ "snippet-editor-field-description" }
+						fieldId={ "snippet-editor-field-description" }
 					/>
 					<ProgressBar
 						max={ descriptionLengthProgress.max }

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -211,7 +211,7 @@ class SnippetEditorFields extends React.Component {
 							onBlur={ () => onBlur() }
 							innerRef={ ref => this.setRef( "slug", ref ) }
 							aria-labelledby={ this.uniqueId + "-slug" }
-							id={ "snippet-editor-field-slug" }
+							id="snippet-editor-field-slug"
 						/>
 					</InputContainerWithCaretStyles>
 				</FormSection>
@@ -230,7 +230,7 @@ class SnippetEditorFields extends React.Component {
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						content={ description }
 						onChange={ content => onChange( "description", content ) }
-						fieldId={ "snippet-editor-field-description" }
+						fieldId="snippet-editor-field-description"
 					/>
 					<ProgressBar
 						max={ descriptionLengthProgress.max }

--- a/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditorFields.js
@@ -245,6 +245,7 @@ class SnippetEditorFields extends React.Component {
 						content={ title }
 						onChange={ content => onChange( "title", content ) }
 						styleForMobile={ isSmallerThanMobileWidth }
+					    uniqueID="snippet-editor-field-title"
 					/>
 					<ProgressBar
 						max={ titleLengthProgress.max }
@@ -271,6 +272,7 @@ class SnippetEditorFields extends React.Component {
 							onBlur={ () => onBlur() }
 							innerRef={ ref => this.setRef( "slug", ref ) }
 							aria-labelledby={ this.uniqueId + "-slug" }
+							id={ "snippet-editor-field-slug" }
 						/>
 					</InputContainerWithCaretStyles>
 				</FormSection>
@@ -290,6 +292,7 @@ class SnippetEditorFields extends React.Component {
 						content={ description }
 						onChange={ content => onChange( "description", content ) }
 						styleForMobile={ isSmallerThanMobileWidth }
+					    uniqueID={ "snippet-editor-field-description" }
 					/>
 					<ProgressBar
 						max={ descriptionLengthProgress.max }

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -2031,6 +2031,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 <ReplacementVariableEditor
                   content="Test title"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-title"
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
@@ -2039,7 +2040,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -2167,7 +2167,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -2246,6 +2245,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-description"
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
@@ -2256,7 +2256,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   type="description"
-                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -2385,7 +2384,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -3886,6 +3884,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 <ReplacementVariableEditor
                   content="Test title"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-title"
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
@@ -3894,7 +3893,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -4022,7 +4020,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -4101,6 +4098,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-description"
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
@@ -4111,7 +4109,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   type="description"
-                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -4240,7 +4237,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -5741,6 +5737,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 <ReplacementVariableEditor
                   content="Test title"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-title"
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
@@ -5749,7 +5746,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -5877,7 +5873,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -5956,6 +5951,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-description"
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
@@ -5966,7 +5962,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   type="description"
-                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -6095,7 +6090,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -7596,6 +7590,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 <ReplacementVariableEditor
                   content="Test title"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-title"
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
@@ -7604,7 +7599,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -7732,7 +7726,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -7811,6 +7804,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-description"
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
@@ -7821,7 +7815,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   type="description"
-                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -7950,7 +7943,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -10575,6 +10567,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 <ReplacementVariableEditor
                   content="Test title"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-title"
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
@@ -10583,7 +10576,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -10711,7 +10703,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -10790,6 +10781,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-description"
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
@@ -10800,7 +10792,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   type="description"
-                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -10929,7 +10920,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -12430,6 +12420,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 <ReplacementVariableEditor
                   content="Test title"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-title"
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
@@ -12438,7 +12429,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -12566,7 +12556,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -12645,6 +12634,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-description"
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
@@ -12655,7 +12645,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   type="description"
-                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -12784,7 +12773,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -15395,6 +15383,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 <ReplacementVariableEditor
                   content="Test title"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-title"
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
@@ -15403,7 +15392,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -15531,7 +15519,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -15610,6 +15597,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-description"
                   isActive={true}
                   isHovered={false}
                   label="Meta description"
@@ -15620,7 +15608,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   type="description"
-                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -15749,7 +15736,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -17270,6 +17256,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                 <ReplacementVariableEditor
                   content="Test title"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-title"
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
@@ -17278,7 +17265,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -17406,7 +17392,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -17485,6 +17470,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-description"
                   isActive={false}
                   isHovered={true}
                   label="Meta description"
@@ -17495,7 +17481,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   type="description"
-                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -17624,7 +17609,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -19125,6 +19109,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 <ReplacementVariableEditor
                   content="Test title"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-title"
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
@@ -19133,7 +19118,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -19261,7 +19245,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -19340,6 +19323,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-description"
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
@@ -19350,7 +19334,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   type="description"
-                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -19479,7 +19462,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -21002,6 +20984,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 <ReplacementVariableEditor
                   content="Test title"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-title"
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
@@ -21021,7 +21004,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       },
                     ]
                   }
-                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -21160,7 +21142,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             },
                           ]
                         }
-                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -21239,6 +21220,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-description"
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
@@ -21260,7 +21242,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     ]
                   }
                   type="description"
-                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -21400,7 +21381,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             },
                           ]
                         }
-                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -23534,6 +23514,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                 <ReplacementVariableEditor
                   content="Test title"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-title"
                   isActive={false}
                   isHovered={false}
                   label="SEO title"
@@ -23542,7 +23523,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   onFocus={[Function]}
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
-                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -23670,7 +23650,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -23749,6 +23728,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
                   editorRef={[Function]}
+                  fieldId="snippet-editor-field-description"
                   isActive={false}
                   isHovered={false}
                   label="Meta description"
@@ -23759,7 +23739,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   type="description"
-                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -23888,7 +23867,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
-                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -2018,6 +2018,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   styleForMobile={true}
+                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -2134,12 +2135,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-title"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c32"
+                      id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -2150,6 +2153,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -2200,6 +2204,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   >
                     <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-29-slug"
+                      id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -2209,6 +2214,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       <input
                         aria-labelledby="snippet-editor-field-29-slug"
                         className="c35"
+                        id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -2238,6 +2244,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   replacementVariables={Array []}
                   styleForMobile={true}
                   type="description"
+                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -2354,12 +2361,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-description"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c36"
+                      id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -2371,6 +2380,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -3857,6 +3867,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   styleForMobile={true}
+                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -3973,12 +3984,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-title"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c32"
+                      id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -3989,6 +4002,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -4039,6 +4053,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   >
                     <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-29-slug"
+                      id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -4048,6 +4063,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       <input
                         aria-labelledby="snippet-editor-field-29-slug"
                         className="c35"
+                        id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -4077,6 +4093,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   replacementVariables={Array []}
                   styleForMobile={true}
                   type="description"
+                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -4193,12 +4210,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-description"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c36"
+                      id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -4210,6 +4229,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -5696,6 +5716,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   styleForMobile={true}
+                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -5812,12 +5833,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-title"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c32"
+                      id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -5828,6 +5851,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -5878,6 +5902,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   >
                     <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-29-slug"
+                      id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -5887,6 +5912,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       <input
                         aria-labelledby="snippet-editor-field-29-slug"
                         className="c35"
+                        id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -5916,6 +5942,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   replacementVariables={Array []}
                   styleForMobile={true}
                   type="description"
+                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -6032,12 +6059,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-description"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c36"
+                      id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -6049,6 +6078,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -7535,6 +7565,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   styleForMobile={true}
+                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -7651,12 +7682,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-title"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c32"
+                      id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -7667,6 +7700,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -7717,6 +7751,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   >
                     <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-12-slug"
+                      id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -7726,6 +7761,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       <input
                         aria-labelledby="snippet-editor-field-12-slug"
                         className="c35"
+                        id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -7755,6 +7791,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   replacementVariables={Array []}
                   styleForMobile={true}
                   type="description"
+                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -7871,12 +7908,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-description"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c36"
+                      id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -7888,6 +7927,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -10498,6 +10538,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   styleForMobile={true}
+                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -10614,12 +10655,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-title"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c32"
+                      id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -10630,6 +10673,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -10680,6 +10724,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   >
                     <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-45-slug"
+                      id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -10689,6 +10734,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       <input
                         aria-labelledby="snippet-editor-field-45-slug"
                         className="c35"
+                        id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -10718,6 +10764,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   replacementVariables={Array []}
                   styleForMobile={true}
                   type="description"
+                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -10834,12 +10881,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-description"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c36"
+                      id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -10851,6 +10900,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -12337,6 +12387,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   styleForMobile={true}
+                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -12453,12 +12504,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-title"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c32"
+                      id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -12469,6 +12522,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -12519,6 +12573,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   >
                     <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-41-slug"
+                      id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -12528,6 +12583,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       <input
                         aria-labelledby="snippet-editor-field-41-slug"
                         className="c35"
+                        id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -12557,6 +12613,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   replacementVariables={Array []}
                   styleForMobile={true}
                   type="description"
+                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -12673,12 +12730,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-description"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c36"
+                      id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -12690,6 +12749,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -15286,6 +15346,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   styleForMobile={true}
+                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -15402,12 +15463,14 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-title"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c33"
+                      id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -15418,6 +15481,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -15468,6 +15532,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   >
                     <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-20-slug"
+                      id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -15477,6 +15542,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       <input
                         aria-labelledby="snippet-editor-field-20-slug"
                         className="c36"
+                        id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -15506,6 +15572,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   replacementVariables={Array []}
                   styleForMobile={true}
                   type="description"
+                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -15622,12 +15689,14 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-description"
                     isActive={true}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c37"
+                      id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -15639,6 +15708,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -17145,6 +17215,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   styleForMobile={true}
+                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -17261,12 +17332,14 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-title"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c33"
+                      id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -17277,6 +17350,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -17327,6 +17401,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   >
                     <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-16-slug"
+                      id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -17336,6 +17411,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                       <input
                         aria-labelledby="snippet-editor-field-16-slug"
                         className="c36"
+                        id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -17365,6 +17441,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   replacementVariables={Array []}
                   styleForMobile={true}
                   type="description"
+                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -17481,12 +17558,14 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-description"
                     isActive={false}
                     isHovered={true}
                     onClick={[Function]}
                   >
                     <div
                       className="c37"
+                      id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -17498,6 +17577,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -18984,6 +19064,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   styleForMobile={true}
+                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -19100,12 +19181,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-title"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c32"
+                      id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -19116,6 +19199,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -19166,6 +19250,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   >
                     <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-8-slug"
+                      id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -19175,6 +19260,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       <input
                         aria-labelledby="snippet-editor-field-8-slug"
                         className="c35"
+                        id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -19204,6 +19290,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   replacementVariables={Array []}
                   styleForMobile={true}
                   type="description"
+                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -19320,12 +19407,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-description"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c36"
+                      id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -19337,6 +19426,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -20856,6 +20946,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     ]
                   }
                   styleForMobile={true}
+                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -20972,12 +21063,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-title"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c32"
+                      id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -20999,6 +21092,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             },
                           ]
                         }
+                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -21049,6 +21143,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   >
                     <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-33-slug"
+                      id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -21058,6 +21153,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       <input
                         aria-labelledby="snippet-editor-field-33-slug"
                         className="c35"
+                        id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -21098,6 +21194,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   }
                   styleForMobile={true}
                   type="description"
+                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -21214,12 +21311,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-description"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c36"
+                      id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -21242,6 +21341,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             },
                           ]
                         }
+                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -23362,6 +23462,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   recommendedReplacementVariables={Array []}
                   replacementVariables={Array []}
                   styleForMobile={true}
+                  uniqueID="snippet-editor-field-title"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -23478,12 +23579,14 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-title"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c32"
+                      id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -23494,6 +23597,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         onFocus={[Function]}
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-title"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>
@@ -23544,6 +23648,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   >
                     <SnippetEditorFields__SlugInput
                       aria-labelledby="snippet-editor-field-24-slug"
+                      id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -23553,6 +23658,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                       <input
                         aria-labelledby="snippet-editor-field-24-slug"
                         className="c35"
+                        id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -23582,6 +23688,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   replacementVariables={Array []}
                   styleForMobile={true}
                   type="description"
+                  uniqueID="snippet-editor-field-description"
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
@@ -23698,12 +23805,14 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     </Button>
                   </Shared__TriggerReplacementVariableSuggestionsButton>
                   <Shared__InputContainer
+                    id="snippet-editor-field-description"
                     isActive={false}
                     isHovered={false}
                     onClick={[Function]}
                   >
                     <div
                       className="c36"
+                      id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <ReplacementVariableEditorStandalone
@@ -23715,6 +23824,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         placeholder="Modify your meta description by editing it right here"
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
+                        uniqueID="snippet-editor-field-description"
                       >
                         <div />
                       </ReplacementVariableEditorStandalone>


### PR DESCRIPTION
## Summary

Adds ID's to elements. For the purpose of testing via puppeteer.

* Adds the id "snippet-editor-field-title" to the inputcontainer, before draft.js is used.
* Adds the id "snippet-editor-field-slug" to the input element the slug is in.
* Adds the id "snippet-editor-field-description" to the inputcontainer, before draft.js is used.

**Branched from release/7.7, we should wait until the release of 7.7 before merging this one**

This PR can be summarized in the following changelog entry:

* N/A.

## Relevant technical choices:

* Sets the id for the slug at the input field of the slug.
* Sets the id "snippet-editor-field-title" and the id  on the inputContainer component, before draft.js is used.
* Edit Maarten: came across an oversight with the onBlur functionality which caused some weird behavior with clicking a focused field. Fixed by implementing the onBlur, and thereby accidentally fixing https://github.com/Yoast/yoast-components/issues/619 halfway.

## Test instructions

This PR can be tested by following these steps:
*NOTE* test together with https://github.com/Yoast/wordpress-seo/pull/10168
* Open a post page/ the standalone editor.
* Open the inspector.
* Check the input fields for the snippet editor. 
  * Check if the input fields for the title and description have their respective id's where the classname of the element contains: `Shared__InputContainer`
  * Check if the input field for the slug has his respective id.

Fixes https://github.com/Yoast/wordpress-seo/issues/10090
Fixes https://github.com/Yoast/yoast-components/issues/619

**Note that this fixes #619 only partially. Split out remaining issues** to https://github.com/Yoast/yoast-components/issues/624

Requires https://github.com/Yoast/wordpress-seo/issues/10091
