### PR TITLE
Fix RTL suggestions by increasing the z-index

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
@@ -39,17 +39,18 @@ import {
 } from "../selection";
 
 /**
-/**
  * Needed to avoid styling issues on the settings pages with the
  * suggestions dropdown, because the button labels have a z-index of 3.
  * Added an extra 1000 because with a lot of replacement variables it should
  * stay on top of the #wp-content-editor-tools element, which has a z-index
  * of 1000.
- *
+ * When a user has an RTL language the popup suggestion disappears behind the
+ * WordPress admin menu. The admin menu has a z-index of 9990. Therefor we add
+ * an extra 9990 to our z-index value.
  */
 const ZIndexOverride = styled.div`
 	div {
-		z-index: 1005;
+		z-index: 10995;
 	}
 `;
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where, when using a RTL language, the snippet variable suggestions would disappear behind the admin menu.

## Relevant technical choices:

* Increase z-index of the suggestions container by 9990.

## Test instructions

This PR can be tested by following these steps:

* In combination with the plugin, set an RTL language in WordPress.
* Open the snippet editor and insert `%` to open the suggestions (see screenshot of issue).
* Verify the suggestions are on top of the admin menu.

Quickly fixes #10179
