### PR TITLE
Fix components styling for RTL languages

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
+++ b/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
@@ -43,18 +43,17 @@ const SwitcherButton = styled( Button )`
 	}
 `;
 
-export const MobileButton = SwitcherButton.extend`
+const MobileButton = SwitcherButton.extend`
 	border-radius: 3px 0 0 3px;
 `;
 
-export const DesktopButton = SwitcherButton.extend`
+const DesktopButton = SwitcherButton.extend`
 	border-radius: 0 3px 3px 0;
 `;
 
-export const Switcher = styled.div`
+const Switcher = styled.div`
 	display: inline-block;
 	margin-top: 10px;
-	margin-left: 20px;
 	margin-right: ${ getRtlStyle( "0px", "20px" ) };
 	margin-left: ${ getRtlStyle( "20px", "4px" ) };
 	border: 1px solid #dbdbdb;

--- a/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
+++ b/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
@@ -10,6 +10,7 @@ import { MODE_DESKTOP, MODE_MOBILE, MODES } from "../../SnippetPreview/constants
 import ScreenReaderText from "../../../../a11y/ScreenReaderText";
 import SvgIcon from "../../Shared/components/SvgIcon";
 import PropTypes from "prop-types";
+import { getRtlStyle } from "../../../../utils/helpers/styled-components";
 
 /**
  * Renders a switcher button.
@@ -42,18 +43,20 @@ const SwitcherButton = styled( Button )`
 	}
 `;
 
-const MobileButton = SwitcherButton.extend`
+export const MobileButton = SwitcherButton.extend`
 	border-radius: 3px 0 0 3px;
 `;
 
-const DesktopButton = SwitcherButton.extend`
+export const DesktopButton = SwitcherButton.extend`
 	border-radius: 0 3px 3px 0;
 `;
 
-const Switcher = styled.div`
+export const Switcher = styled.div`
 	display: inline-block;
 	margin-top: 10px;
 	margin-left: 20px;
+	margin-right: ${ getRtlStyle( "0px", "20px" ) };
+	margin-left: ${ getRtlStyle( "20px", "4px" ) };
 	border: 1px solid #dbdbdb;
 	border-radius: 4px;
 	background-color: #f7f7f7;

--- a/composites/Plugin/SnippetEditor/components/Shared.js
+++ b/composites/Plugin/SnippetEditor/components/Shared.js
@@ -64,6 +64,13 @@ export const InputContainer = styled.div.attrs( {
 	cursor: text;
 `;
 
+/**
+ * Gets the background image based on the color from the props and the language direction.
+ *
+ * @param {Object} props The component's props.
+ *
+ * @returns {string} The background image.
+ */
 function getBackgroundImage( props ) {
 	let rtlStyle = getRtlStyle(
 		angleRight( getCaretColor( props ) ),

--- a/composites/Plugin/SnippetEditor/components/Shared.js
+++ b/composites/Plugin/SnippetEditor/components/Shared.js
@@ -4,10 +4,18 @@ import styled from "styled-components";
 /* Internal dependencies */
 import colors from "../../../../style-guide/colors";
 import { Button } from "../../Shared/components/Button";
+import { getRtlStyle } from "../../../../utils/helpers/styled-components";
 
-const angleRight = ( color ) => "data:image/svg+xml;charset=utf8," + encodeURIComponent(
+export const angleRight = ( color ) => "data:image/svg+xml;charset=utf8," + encodeURIComponent(
 	'<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg">' +
 	'<path fill="' + color + '" d="M1152 896q0 26-19 45l-448 448q-19 19-45 19t-45-19-19-45v-896q0-26 19-45t45-19 45 19l448 448q19 19 19 45z" />' +
+	"</svg>"
+);
+
+export const angleLeft = ( color ) => "data:image/svg+xml;charset=utf8," + encodeURIComponent(
+	'<svg width="1792" height="1792" viewBox="0 0 192 512" xmlns="http://www.w3.org/2000/svg">' +
+	'<path fill="' + color + '" d="M192 127.338v257.324c0 17.818-21.543 26.741-34.142 14.142L29.196 ' +
+	'270.142c-7.81-7.81-7.81-20.474 0-28.284l128.662-128.662c12.599-12.6 34.142-3.676 34.142 14.142z"/>' +
 	"</svg>"
 );
 
@@ -56,16 +64,25 @@ export const InputContainer = styled.div.attrs( {
 	cursor: text;
 `;
 
+function getBackgroundImage( props ) {
+	let rtlStyle = getRtlStyle(
+		angleRight( getCaretColor( props ) ),
+		angleLeft( getCaretColor( props ) )
+	);
+
+	return rtlStyle( props );
+}
+
 export const withCaretStyles = Component => {
 	return Component.extend`
 		&::before {
 			display: block;
 			position: absolute;
 			top: -1px;
-			left: -25px;
+			${ getRtlStyle( "left", "right" ) }: -25px;
 			width: 24px;
 			height: 24px;
-			background-image: url( ${ ( props ) => angleRight( getCaretColor( props ) ) });
+			background-image: url( ${ getBackgroundImage } );
 			background-size: 25px;
 			content: "";
 		}
@@ -126,7 +143,7 @@ export const TriggerReplacementVariableSuggestionsButton = styled( Button )`
 	font-size: 13px;
 
 	& svg {
-		margin-right: 7px;
+		${ getRtlStyle( "margin-right", "margin-left" ) }: 7px;
 		fill: ${ colors.$color_grey_dark };
 	}
 `;

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -269,7 +269,7 @@ class SnippetEditor extends React.Component {
 					titleLengthProgress={ titleLengthProgress }
 					descriptionLengthProgress={ descriptionLengthProgress }
 					descriptionEditorFieldPlaceholder={ descriptionEditorFieldPlaceholder }
-					containerPadding={ hasPaperStyle ? "0 20px": "0" }
+					containerPadding={ hasPaperStyle ? "0 20px" : "0" }
 				/>
 				<CloseEditorButton onClick={ this.close }>
 					{ __( "Close snippet editor", "yoast-components" ) }

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -25,6 +25,7 @@ import {
 import ModeSwitcher from "./ModeSwitcher";
 import colors from "../../../../style-guide/colors";
 import ErrorBoundary from "../../../basic/ErrorBoundary";
+import { getRtlStyle } from "../../../../utils/helpers/styled-components";
 
 const SnippetEditorButton = Button.extend`
 	height: 33px;
@@ -39,13 +40,13 @@ const EditSnippetButton = SnippetEditorButton.extend`
 	padding-left: 8px;
 
 	& svg {
-		margin-right: 7px;
+		${ getRtlStyle( "margin-right", "margin-left" ) }: 7px;
 	}
 `;
 
 const CloseEditorButton = SnippetEditorButton.extend`
 	margin-top: 24px;
-	margin-left: 20px;
+	${ getRtlStyle( "margin-left", "margin-right" ) }: 20px;
 `;
 
 /**

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -273,7 +273,6 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -1142,7 +1141,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -2989,7 +2987,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -4836,7 +4833,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -6683,7 +6679,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -8286,7 +8281,6 @@ exports[`SnippetEditor closes when calling close() 2`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -9656,7 +9650,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -11503,7 +11496,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -13106,7 +13098,6 @@ exports[`SnippetEditor highlights a focused field 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -13653,7 +13644,6 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -14444,7 +14434,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 .c23 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -16311,7 +16300,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 .c23 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -18178,7 +18166,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -20025,7 +20012,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -21698,7 +21684,6 @@ exports[`SnippetEditor passes the date prop 1`] = `
 .c23 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -22573,7 +22558,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -24173,7 +24157,6 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
@@ -24720,7 +24703,6 @@ exports[`SnippetEditor shows the editor 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-left: 20px;
   margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -274,6 +274,8 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
+  margin-right: 0px;
+  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -763,6 +765,162 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   fill: #0066cd;
 }
 
+.c32 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+}
+
+.c32::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c34 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+  min-height: 72px;
+  padding: 2px 6px;
+  line-height: 24px;
+}
+
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
+.c36::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 24px 0 0 0;
+}
+
+.c28 {
+  padding: 0 20px;
+}
+
+.c30 {
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
+  min-width: 200px;
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 4px 0;
+}
+
+.c31 {
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  padding-left: 8px;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  font-size: 13px;
+}
+
+.c31 svg {
+  margin-right: 7px;
+  fill: #555;
+}
+
 .c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -853,162 +1011,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c32 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c32 .public-DraftStyleDefault-block {
-  line-height: 24px;
-}
-
-.c32::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c34 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c34::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c36 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-  min-height: 72px;
-  padding: 2px 6px;
-  line-height: 24px;
-}
-
-.c36 .public-DraftEditorPlaceholder-root {
-  color: #646464;
-}
-
-.c36 .public-DraftEditorPlaceholder-hasFocus {
-  color: #646464;
-}
-
-.c36::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin: 24px 0 0 0;
-}
-
-.c28 {
-  padding: 0 20px;
-}
-
-.c30 {
-  -webkit-flex: 1 1 200px;
-  -ms-flex: 1 1 200px;
-  flex: 1 1 200px;
-  min-width: 200px;
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 4px 0;
-}
-
-.c31 {
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  padding-left: 8px;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  font-size: 13px;
-}
-
-.c31 svg {
-  margin-right: 7px;
-  fill: #555;
 }
 
 .c33 {
@@ -1140,6 +1142,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 .c22 {
   display: inline-block;
   margin-top: 10px;
+  margin-left: 20px;
+  margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
@@ -2608,6 +2612,162 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   fill: #0066cd;
 }
 
+.c32 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+}
+
+.c32::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c34 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+  min-height: 72px;
+  padding: 2px 6px;
+  line-height: 24px;
+}
+
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
+.c36::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 24px 0 0 0;
+}
+
+.c28 {
+  padding: 0 20px;
+}
+
+.c30 {
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
+  min-width: 200px;
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 4px 0;
+}
+
+.c31 {
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  padding-left: 8px;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  font-size: 13px;
+}
+
+.c31 svg {
+  margin-right: 7px;
+  fill: #555;
+}
+
 .c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -2698,162 +2858,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c32 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c32 .public-DraftStyleDefault-block {
-  line-height: 24px;
-}
-
-.c32::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c34 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c34::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c36 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-  min-height: 72px;
-  padding: 2px 6px;
-  line-height: 24px;
-}
-
-.c36 .public-DraftEditorPlaceholder-root {
-  color: #646464;
-}
-
-.c36 .public-DraftEditorPlaceholder-hasFocus {
-  color: #646464;
-}
-
-.c36::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin: 24px 0 0 0;
-}
-
-.c28 {
-  padding: 0 20px;
-}
-
-.c30 {
-  -webkit-flex: 1 1 200px;
-  -ms-flex: 1 1 200px;
-  flex: 1 1 200px;
-  min-width: 200px;
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 4px 0;
-}
-
-.c31 {
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  padding-left: 8px;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  font-size: 13px;
-}
-
-.c31 svg {
-  margin-right: 7px;
-  fill: #555;
 }
 
 .c33 {
@@ -2985,6 +2989,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 .c22 {
   display: inline-block;
   margin-top: 10px;
+  margin-left: 20px;
+  margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
@@ -4453,6 +4459,162 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   fill: #0066cd;
 }
 
+.c32 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+}
+
+.c32::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c34 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+  min-height: 72px;
+  padding: 2px 6px;
+  line-height: 24px;
+}
+
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
+.c36::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 24px 0 0 0;
+}
+
+.c28 {
+  padding: 0 20px;
+}
+
+.c30 {
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
+  min-width: 200px;
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 4px 0;
+}
+
+.c31 {
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  padding-left: 8px;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  font-size: 13px;
+}
+
+.c31 svg {
+  margin-right: 7px;
+  fill: #555;
+}
+
 .c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -4543,162 +4705,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c32 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c32 .public-DraftStyleDefault-block {
-  line-height: 24px;
-}
-
-.c32::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c34 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c34::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c36 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-  min-height: 72px;
-  padding: 2px 6px;
-  line-height: 24px;
-}
-
-.c36 .public-DraftEditorPlaceholder-root {
-  color: #646464;
-}
-
-.c36 .public-DraftEditorPlaceholder-hasFocus {
-  color: #646464;
-}
-
-.c36::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin: 24px 0 0 0;
-}
-
-.c28 {
-  padding: 0 20px;
-}
-
-.c30 {
-  -webkit-flex: 1 1 200px;
-  -ms-flex: 1 1 200px;
-  flex: 1 1 200px;
-  min-width: 200px;
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 4px 0;
-}
-
-.c31 {
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  padding-left: 8px;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  font-size: 13px;
-}
-
-.c31 svg {
-  margin-right: 7px;
-  fill: #555;
 }
 
 .c33 {
@@ -4830,6 +4836,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 .c22 {
   display: inline-block;
   margin-top: 10px;
+  margin-left: 20px;
+  margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
@@ -6298,6 +6306,162 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   fill: #0066cd;
 }
 
+.c32 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+}
+
+.c32::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c34 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+  min-height: 72px;
+  padding: 2px 6px;
+  line-height: 24px;
+}
+
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
+.c36::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 24px 0 0 0;
+}
+
+.c28 {
+  padding: 0 20px;
+}
+
+.c30 {
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
+  min-width: 200px;
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 4px 0;
+}
+
+.c31 {
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  padding-left: 8px;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  font-size: 13px;
+}
+
+.c31 svg {
+  margin-right: 7px;
+  fill: #555;
+}
+
 .c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -6388,162 +6552,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c32 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c32 .public-DraftStyleDefault-block {
-  line-height: 24px;
-}
-
-.c32::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c34 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c34::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c36 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-  min-height: 72px;
-  padding: 2px 6px;
-  line-height: 24px;
-}
-
-.c36 .public-DraftEditorPlaceholder-root {
-  color: #646464;
-}
-
-.c36 .public-DraftEditorPlaceholder-hasFocus {
-  color: #646464;
-}
-
-.c36::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin: 24px 0 0 0;
-}
-
-.c28 {
-  padding: 0 20px;
-}
-
-.c30 {
-  -webkit-flex: 1 1 200px;
-  -ms-flex: 1 1 200px;
-  flex: 1 1 200px;
-  min-width: 200px;
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 4px 0;
-}
-
-.c31 {
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  padding-left: 8px;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  font-size: 13px;
-}
-
-.c31 svg {
-  margin-right: 7px;
-  fill: #555;
 }
 
 .c33 {
@@ -6675,6 +6683,8 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
+  margin-left: 20px;
+  margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
@@ -8277,6 +8287,8 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
+  margin-right: 0px;
+  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -9267,6 +9279,162 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   fill: #0066cd;
 }
 
+.c32 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+}
+
+.c32::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c34 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+  min-height: 72px;
+  padding: 2px 6px;
+  line-height: 24px;
+}
+
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
+.c36::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 24px 0 0 0;
+}
+
+.c28 {
+  padding: 0 20px;
+}
+
+.c30 {
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
+  min-width: 200px;
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 4px 0;
+}
+
+.c31 {
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  padding-left: 8px;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  font-size: 13px;
+}
+
+.c31 svg {
+  margin-right: 7px;
+  fill: #555;
+}
+
 .c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -9357,162 +9525,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c32 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c32 .public-DraftStyleDefault-block {
-  line-height: 24px;
-}
-
-.c32::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c34 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c34::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c36 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-  min-height: 72px;
-  padding: 2px 6px;
-  line-height: 24px;
-}
-
-.c36 .public-DraftEditorPlaceholder-root {
-  color: #646464;
-}
-
-.c36 .public-DraftEditorPlaceholder-hasFocus {
-  color: #646464;
-}
-
-.c36::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin: 24px 0 0 0;
-}
-
-.c28 {
-  padding: 0 20px;
-}
-
-.c30 {
-  -webkit-flex: 1 1 200px;
-  -ms-flex: 1 1 200px;
-  flex: 1 1 200px;
-  min-width: 200px;
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 4px 0;
-}
-
-.c31 {
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  padding-left: 8px;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  font-size: 13px;
-}
-
-.c31 svg {
-  margin-right: 7px;
-  fill: #555;
 }
 
 .c33 {
@@ -9644,6 +9656,8 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
+  margin-left: 20px;
+  margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
@@ -11112,6 +11126,162 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   fill: #0066cd;
 }
 
+.c32 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+}
+
+.c32::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c34 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+  min-height: 72px;
+  padding: 2px 6px;
+  line-height: 24px;
+}
+
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
+.c36::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 24px 0 0 0;
+}
+
+.c28 {
+  padding: 0 20px;
+}
+
+.c30 {
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
+  min-width: 200px;
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 4px 0;
+}
+
+.c31 {
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  padding-left: 8px;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  font-size: 13px;
+}
+
+.c31 svg {
+  margin-right: 7px;
+  fill: #555;
+}
+
 .c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -11202,162 +11372,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c32 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c32 .public-DraftStyleDefault-block {
-  line-height: 24px;
-}
-
-.c32::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c34 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c34::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c36 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-  min-height: 72px;
-  padding: 2px 6px;
-  line-height: 24px;
-}
-
-.c36 .public-DraftEditorPlaceholder-root {
-  color: #646464;
-}
-
-.c36 .public-DraftEditorPlaceholder-hasFocus {
-  color: #646464;
-}
-
-.c36::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin: 24px 0 0 0;
-}
-
-.c28 {
-  padding: 0 20px;
-}
-
-.c30 {
-  -webkit-flex: 1 1 200px;
-  -ms-flex: 1 1 200px;
-  flex: 1 1 200px;
-  min-width: 200px;
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 4px 0;
-}
-
-.c31 {
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  padding-left: 8px;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  font-size: 13px;
-}
-
-.c31 svg {
-  margin-right: 7px;
-  fill: #555;
 }
 
 .c33 {
@@ -11489,6 +11503,8 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 .c22 {
   display: inline-block;
   margin-top: 10px;
+  margin-left: 20px;
+  margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
@@ -13091,6 +13107,8 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
+  margin-right: 0px;
+  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -13636,6 +13654,8 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
+  margin-right: 0px;
+  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -14047,6 +14067,162 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   fill: #0066cd;
 }
 
+.c33 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c33 .public-DraftStyleDefault-block {
+  line-height: 24px;
+}
+
+.c33::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c35 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c35::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c37 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #5b9dd9;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: 0 0 2px rgba(30,140,190,.8);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+  min-height: 72px;
+  padding: 2px 6px;
+  line-height: 24px;
+}
+
+.c37 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c37 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
+.c37::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%231e8cbe%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c30 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 24px 0 0 0;
+}
+
+.c29 {
+  padding: 0 20px;
+}
+
+.c31 {
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
+  min-width: 200px;
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 4px 0;
+}
+
+.c32 {
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  padding-left: 8px;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  font-size: 13px;
+}
+
+.c32 svg {
+  margin-right: 7px;
+  fill: #555;
+}
+
 .c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -14137,162 +14313,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c33 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c33 .public-DraftStyleDefault-block {
-  line-height: 24px;
-}
-
-.c33::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c35 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c35::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c37 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #5b9dd9;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: 0 0 2px rgba(30,140,190,.8);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-  min-height: 72px;
-  padding: 2px 6px;
-  line-height: 24px;
-}
-
-.c37 .public-DraftEditorPlaceholder-root {
-  color: #646464;
-}
-
-.c37 .public-DraftEditorPlaceholder-hasFocus {
-  color: #646464;
-}
-
-.c37::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%231e8cbe%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c30 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin: 24px 0 0 0;
-}
-
-.c29 {
-  padding: 0 20px;
-}
-
-.c31 {
-  -webkit-flex: 1 1 200px;
-  -ms-flex: 1 1 200px;
-  flex: 1 1 200px;
-  min-width: 200px;
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 4px 0;
-}
-
-.c32 {
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  padding-left: 8px;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  font-size: 13px;
-}
-
-.c32 svg {
-  margin-right: 7px;
-  fill: #555;
 }
 
 .c34 {
@@ -14424,6 +14444,8 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 .c23 {
   display: inline-block;
   margin-top: 10px;
+  margin-left: 20px;
+  margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
@@ -15912,6 +15934,162 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   fill: #0066cd;
 }
 
+.c33 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c33 .public-DraftStyleDefault-block {
+  line-height: 24px;
+}
+
+.c33::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c35 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c35::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c37 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+  min-height: 72px;
+  padding: 2px 6px;
+  line-height: 24px;
+}
+
+.c37 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c37 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
+.c37::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c30 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 24px 0 0 0;
+}
+
+.c29 {
+  padding: 0 20px;
+}
+
+.c31 {
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
+  min-width: 200px;
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 4px 0;
+}
+
+.c32 {
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  padding-left: 8px;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  font-size: 13px;
+}
+
+.c32 svg {
+  margin-right: 7px;
+  fill: #555;
+}
+
 .c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -16002,162 +16180,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c33 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c33 .public-DraftStyleDefault-block {
-  line-height: 24px;
-}
-
-.c33::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c35 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c35::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c37 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-  min-height: 72px;
-  padding: 2px 6px;
-  line-height: 24px;
-}
-
-.c37 .public-DraftEditorPlaceholder-root {
-  color: #646464;
-}
-
-.c37 .public-DraftEditorPlaceholder-hasFocus {
-  color: #646464;
-}
-
-.c37::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c30 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin: 24px 0 0 0;
-}
-
-.c29 {
-  padding: 0 20px;
-}
-
-.c31 {
-  -webkit-flex: 1 1 200px;
-  -ms-flex: 1 1 200px;
-  flex: 1 1 200px;
-  min-width: 200px;
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 4px 0;
-}
-
-.c32 {
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  padding-left: 8px;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  font-size: 13px;
-}
-
-.c32 svg {
-  margin-right: 7px;
-  fill: #555;
 }
 
 .c34 {
@@ -16289,6 +16311,8 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 .c23 {
   display: inline-block;
   margin-top: 10px;
+  margin-left: 20px;
+  margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
@@ -17777,6 +17801,162 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   fill: #0066cd;
 }
 
+.c32 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+}
+
+.c32::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c34 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+  min-height: 72px;
+  padding: 2px 6px;
+  line-height: 24px;
+}
+
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
+.c36::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 24px 0 0 0;
+}
+
+.c28 {
+  padding: 0 20px;
+}
+
+.c30 {
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
+  min-width: 200px;
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 4px 0;
+}
+
+.c31 {
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  padding-left: 8px;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  font-size: 13px;
+}
+
+.c31 svg {
+  margin-right: 7px;
+  fill: #555;
+}
+
 .c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -17867,162 +18047,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c32 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c32 .public-DraftStyleDefault-block {
-  line-height: 24px;
-}
-
-.c32::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c34 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c34::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c36 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-  min-height: 72px;
-  padding: 2px 6px;
-  line-height: 24px;
-}
-
-.c36 .public-DraftEditorPlaceholder-root {
-  color: #646464;
-}
-
-.c36 .public-DraftEditorPlaceholder-hasFocus {
-  color: #646464;
-}
-
-.c36::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin: 24px 0 0 0;
-}
-
-.c28 {
-  padding: 0 20px;
-}
-
-.c30 {
-  -webkit-flex: 1 1 200px;
-  -ms-flex: 1 1 200px;
-  flex: 1 1 200px;
-  min-width: 200px;
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 4px 0;
-}
-
-.c31 {
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  padding-left: 8px;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  font-size: 13px;
-}
-
-.c31 svg {
-  margin-right: 7px;
-  fill: #555;
 }
 
 .c33 {
@@ -18154,6 +18178,8 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
+  margin-left: 20px;
+  margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
@@ -19622,6 +19648,162 @@ exports[`SnippetEditor passes replacement variables to the title and description
   fill: #0066cd;
 }
 
+.c32 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+}
+
+.c32::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c34 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+  min-height: 72px;
+  padding: 2px 6px;
+  line-height: 24px;
+}
+
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
+.c36::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 24px 0 0 0;
+}
+
+.c28 {
+  padding: 0 20px;
+}
+
+.c30 {
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
+  min-width: 200px;
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 4px 0;
+}
+
+.c31 {
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  padding-left: 8px;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  font-size: 13px;
+}
+
+.c31 svg {
+  margin-right: 7px;
+  fill: #555;
+}
+
 .c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -19712,162 +19894,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c32 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c32 .public-DraftStyleDefault-block {
-  line-height: 24px;
-}
-
-.c32::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c34 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c34::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c36 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-  min-height: 72px;
-  padding: 2px 6px;
-  line-height: 24px;
-}
-
-.c36 .public-DraftEditorPlaceholder-root {
-  color: #646464;
-}
-
-.c36 .public-DraftEditorPlaceholder-hasFocus {
-  color: #646464;
-}
-
-.c36::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin: 24px 0 0 0;
-}
-
-.c28 {
-  padding: 0 20px;
-}
-
-.c30 {
-  -webkit-flex: 1 1 200px;
-  -ms-flex: 1 1 200px;
-  flex: 1 1 200px;
-  min-width: 200px;
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 4px 0;
-}
-
-.c31 {
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  padding-left: 8px;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  font-size: 13px;
-}
-
-.c31 svg {
-  margin-right: 7px;
-  fill: #555;
 }
 
 .c33 {
@@ -19999,6 +20025,8 @@ exports[`SnippetEditor passes replacement variables to the title and description
 .c22 {
   display: inline-block;
   margin-top: 10px;
+  margin-left: 20px;
+  margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
@@ -21671,6 +21699,8 @@ exports[`SnippetEditor passes the date prop 1`] = `
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
+  margin-right: 0px;
+  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -22166,6 +22196,162 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   fill: #0066cd;
 }
 
+.c32 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c32 .public-DraftStyleDefault-block {
+  line-height: 24px;
+}
+
+.c32::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c34 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+}
+
+.c34::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c36 {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  border: 1px solid #ddd;
+  padding: 3px 5px;
+  box-sizing: border-box;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+  background-color: #fff;
+  color: #32373c;
+  outline: 0;
+  -webkit-transition: 50ms border-color ease-in-out;
+  transition: 50ms border-color ease-in-out;
+  position: relative;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  font-size: 14px;
+  cursor: text;
+  min-height: 72px;
+  padding: 2px 6px;
+  line-height: 24px;
+}
+
+.c36 .public-DraftEditorPlaceholder-root {
+  color: #646464;
+}
+
+.c36 .public-DraftEditorPlaceholder-hasFocus {
+  color: #646464;
+}
+
+.c36::before {
+  display: block;
+  position: absolute;
+  top: -1px;
+  left: -25px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  background-size: 25px;
+  content: "";
+}
+
+.c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin: 24px 0 0 0;
+}
+
+.c28 {
+  padding: 0 20px;
+}
+
+.c30 {
+  -webkit-flex: 1 1 200px;
+  -ms-flex: 1 1 200px;
+  flex: 1 1 200px;
+  min-width: 200px;
+  cursor: pointer;
+  font-size: 16px;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  margin: 4px 0;
+}
+
+.c31 {
+  box-shadow: none;
+  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
+  padding-left: 8px;
+  height: 33px;
+  border: 1px solid #dbdbdb;
+  font-size: 13px;
+}
+
+.c31 svg {
+  margin-right: 7px;
+  fill: #555;
+}
+
 .c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
@@ -22256,162 +22442,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
-}
-
-.c32 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c32 .public-DraftStyleDefault-block {
-  line-height: 24px;
-}
-
-.c32::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c34 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-}
-
-.c34::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c36 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
-  border: 1px solid #ddd;
-  padding: 3px 5px;
-  box-sizing: border-box;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
-  background-color: #fff;
-  color: #32373c;
-  outline: 0;
-  -webkit-transition: 50ms border-color ease-in-out;
-  transition: 50ms border-color ease-in-out;
-  position: relative;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  font-size: 14px;
-  cursor: text;
-  min-height: 72px;
-  padding: 2px 6px;
-  line-height: 24px;
-}
-
-.c36 .public-DraftEditorPlaceholder-root {
-  color: #646464;
-}
-
-.c36 .public-DraftEditorPlaceholder-hasFocus {
-  color: #646464;
-}
-
-.c36::before {
-  display: block;
-  position: absolute;
-  top: -1px;
-  left: -25px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22transparent%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E);
-  background-size: 25px;
-  content: "";
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin: 24px 0 0 0;
-}
-
-.c28 {
-  padding: 0 20px;
-}
-
-.c30 {
-  -webkit-flex: 1 1 200px;
-  -ms-flex: 1 1 200px;
-  flex: 1 1 200px;
-  min-width: 200px;
-  cursor: pointer;
-  font-size: 16px;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  margin: 4px 0;
-}
-
-.c31 {
-  box-shadow: none;
-  font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
-  padding-left: 8px;
-  height: 33px;
-  border: 1px solid #dbdbdb;
-  font-size: 13px;
-}
-
-.c31 svg {
-  margin-right: 7px;
-  fill: #555;
 }
 
 .c33 {
@@ -22543,6 +22573,8 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 .c22 {
   display: inline-block;
   margin-top: 10px;
+  margin-left: 20px;
+  margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
@@ -24142,6 +24174,8 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   display: inline-block;
   margin-top: 10px;
   margin-left: 20px;
+  margin-right: 0px;
+  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -24686,6 +24720,8 @@ exports[`SnippetEditor shows the editor 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
+  margin-left: 20px;
+  margin-right: 0px;
   margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;

--- a/composites/Plugin/SnippetPreview/components/HelpTextWrapper.js
+++ b/composites/Plugin/SnippetPreview/components/HelpTextWrapper.js
@@ -11,19 +11,20 @@ import { Button } from "../../Shared/components/Button";
 import SvgIcon from "../../Shared/components/SvgIcon";
 import { rgba } from "../../../../style-guide/helpers";
 import { YoastSlideToggle } from "../../../../utils/animations";
+import { getRtlStyle } from "../../../../utils/helpers/styled-components";
 
-const HelpTextContainer = styled.div`
+export const HelpTextContainer = styled.div`
 	max-width: 600px;
 	font-weight: normal;
 	// Don't apply a bottom margin to avoid "jumpiness".
-	margin: 0 20px 0 25px;
+	margin: ${ getRtlStyle( "0 20px 0 25px", "0 20px 0 15px" ) };
 `;
 
-const HelpTextPanel = styled.div`
+export const HelpTextPanel = styled.div`
 	max-width: ${ props => props.panelMaxWidth };
 `;
 
-const HelpTextButton = styled( Button )`
+export const HelpTextButton = styled( Button )`
 	min-width: 14px;
 	min-height: 14px;
 	width: 30px;
@@ -34,8 +35,9 @@ const HelpTextButton = styled( Button )`
 	display: block;
 	margin: -44px -10px 10px 0;
 	background-color: transparent;
-	float: right;
-	padding: 3px 0 0 6px;
+	float: ${ getRtlStyle( "right", "left" ) };
+	padding: ${ getRtlStyle( "3px 0 0 6px", "3px 0 0 5px" ) };
+
 	&:hover {
 		color: ${ colors.$color_blue };
 	}
@@ -54,7 +56,7 @@ const HelpTextButton = styled( Button )`
 	}
 `;
 
-const StyledSvg = styled( SvgIcon )`
+export const StyledSvg = styled( SvgIcon )`
 	&:hover {
 		fill: ${ colors.$color_blue };
 	}

--- a/composites/Plugin/SnippetPreview/components/HelpTextWrapper.js
+++ b/composites/Plugin/SnippetPreview/components/HelpTextWrapper.js
@@ -13,18 +13,18 @@ import { rgba } from "../../../../style-guide/helpers";
 import { YoastSlideToggle } from "../../../../utils/animations";
 import { getRtlStyle } from "../../../../utils/helpers/styled-components";
 
-export const HelpTextContainer = styled.div`
+const HelpTextContainer = styled.div`
 	max-width: 600px;
 	font-weight: normal;
 	// Don't apply a bottom margin to avoid "jumpiness".
 	margin: ${ getRtlStyle( "0 20px 0 25px", "0 20px 0 15px" ) };
 `;
 
-export const HelpTextPanel = styled.div`
+const HelpTextPanel = styled.div`
 	max-width: ${ props => props.panelMaxWidth };
 `;
 
-export const HelpTextButton = styled( Button )`
+const HelpTextButton = styled( Button )`
 	min-width: 14px;
 	min-height: 14px;
 	width: 30px;
@@ -56,7 +56,7 @@ export const HelpTextButton = styled( Button )`
 	}
 `;
 
-export const StyledSvg = styled( SvgIcon )`
+const StyledSvg = styled( SvgIcon )`
 	&:hover {
 		fill: ${ colors.$color_blue };
 	}

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -17,6 +17,8 @@ import ScreenReaderText from "../../../../a11y/ScreenReaderText";
 import { DEFAULT_MODE, MODE_DESKTOP, MODE_MOBILE, MODES } from "../constants";
 import HelpTextWrapper from "../components/HelpTextWrapper";
 import { makeOutboundLink } from "../../../../utils/makeOutboundLink";
+import { angleLeft, angleRight } from "../../SnippetEditor/components/Shared";
+import { getRtlStyle } from "../../../../utils/helpers/styled-components";
 
 /*
  * These colors should not be abstracted. They are chosen because Google renders
@@ -49,12 +51,6 @@ const MobileContainer = styled.div`
 	font-size: 14px;
 `;
 
-const angleRight = ( color ) => "data:image/svg+xml;charset=utf8," + encodeURIComponent(
-	'<svg width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg">' +
-		'<path fill="' + color + '" d="M1152 896q0 26-19 45l-448 448q-19 19-45 19t-45-19-19-45v-896q0-26 19-45t45-19 45 19l448 448q19 19 19 45z" />' +
-	"</svg>"
-);
-
 export const BaseTitle = styled.div`
 	cursor: pointer;
 	position: relative;
@@ -77,10 +73,35 @@ function addCaretStyle( WithoutCaret, color, mode ) {
 			display: block;
 			position: absolute;
 			top: -3px;
-			left: ${ () => mode === MODE_DESKTOP ? "-22px" : "-40px" };
+			${ getRtlStyle( "left", "right" ) }: ${ () => mode === MODE_DESKTOP ? "-22px" : "-40px" };
 			width: 24px;
 			height: 24px;
-			background-image: url( ${ () => angleRight( color ) } );
+			background-image: url( ${ getRtlStyle( angleRight( color ), angleLeft( color ) ) } );
+			background-size: 25px;
+			content: "";
+		}
+	`;
+}
+
+/**
+ * Adds caret styles to a component.
+ *
+ * @param {ReactComponent} WithoutCaret The component without caret styles.
+ * @param {string} color The color to render the caret in.
+ * @param {string} mode The mode the snippet preview is in.
+ *
+ * @returns {ReactComponent} The component with caret styles.
+ */
+function addCaretStyleRTL( WithoutCaret, color, mode ) {
+	return styled( WithoutCaret )`
+		&::before {
+			display: block;
+			position: absolute;
+			top: -3px;
+			right: ${ () => mode === MODE_DESKTOP ? "-22px" : "-40px" };
+			width: 24px;
+			height: 24px;
+			background-image: url( ${ () => angleLeft( color ) } );
 			background-size: 25px;
 			content: "";
 		}

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -83,31 +83,6 @@ function addCaretStyle( WithoutCaret, color, mode ) {
 	`;
 }
 
-/**
- * Adds caret styles to a component.
- *
- * @param {ReactComponent} WithoutCaret The component without caret styles.
- * @param {string} color The color to render the caret in.
- * @param {string} mode The mode the snippet preview is in.
- *
- * @returns {ReactComponent} The component with caret styles.
- */
-function addCaretStyleRTL( WithoutCaret, color, mode ) {
-	return styled( WithoutCaret )`
-		&::before {
-			display: block;
-			position: absolute;
-			top: -3px;
-			right: ${ () => mode === MODE_DESKTOP ? "-22px" : "-40px" };
-			width: 24px;
-			height: 24px;
-			background-image: url( ${ () => angleLeft( color ) } );
-			background-size: 25px;
-			content: "";
-		}
-	`;
-}
-
 export const Title = styled.div`
 	color: ${ colorTitle };
 	text-decoration: none;

--- a/forms/StyledSection/StyledSection.js
+++ b/forms/StyledSection/StyledSection.js
@@ -47,7 +47,6 @@ export const StyledSectionBase = styled( Section )`
 	& ${ StyledIcon } {
 		flex: 0 0 auto;
 		${ getRtlStyle( "margin-right", "margin-left" ) }: 8px;
-		
 	}
 `;
 

--- a/forms/StyledSection/StyledSection.js
+++ b/forms/StyledSection/StyledSection.js
@@ -7,8 +7,12 @@ import Heading from "../../composites/basic/Heading";
 import colors from "../../style-guide/colors.json";
 import { rgba } from "../../style-guide/helpers";
 import SvgIcon from "../../composites/Plugin/Shared/components/SvgIcon";
+import { getRtlStyle } from "../../utils/helpers/styled-components";
 
-export const StyledHeading = styled( Heading )``;
+export const StyledHeading = styled( Heading )`
+	margin-left: ${ getRtlStyle( "0", "20px" ) };
+	padding: ${ getRtlStyle( "0", "20px" ) };
+`;
 
 export const StyledIcon = styled( SvgIcon )``;
 
@@ -42,7 +46,8 @@ export const StyledSectionBase = styled( Section )`
 
 	& ${ StyledIcon } {
 		flex: 0 0 auto;
-		margin-right: 8px;
+		${ getRtlStyle( "margin-right", "margin-left" ) }: 8px;
+		
 	}
 `;
 

--- a/forms/StyledSection/tests/__snapshots__/styledSectionTest.js.snap
+++ b/forms/StyledSection/tests/__snapshots__/styledSectionTest.js.snap
@@ -1,6 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StyledSection can change the heading level 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -40,14 +45,14 @@ exports[`StyledSection can change the heading level 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -59,11 +64,11 @@ exports[`StyledSection can change the heading level 1`] = `
   className="yoast-section c0"
 >
   <h4
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-file-text c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-file-text c3 c4"
       fill="blue"
       focusable="false"
       role="img"
@@ -87,6 +92,11 @@ exports[`StyledSection can change the heading level 1`] = `
 `;
 
 exports[`StyledSection can change the icon to angle-down 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -126,14 +136,14 @@ exports[`StyledSection can change the icon to angle-down 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -145,11 +155,11 @@ exports[`StyledSection can change the icon to angle-down 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-angle-down c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-angle-down c3 c4"
       fill="blue"
       focusable="false"
       role="img"
@@ -171,6 +181,11 @@ exports[`StyledSection can change the icon to angle-down 1`] = `
 `;
 
 exports[`StyledSection can change the icon to angle-left 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -210,14 +225,14 @@ exports[`StyledSection can change the icon to angle-left 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -229,11 +244,11 @@ exports[`StyledSection can change the icon to angle-left 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-angle-left c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-angle-left c3 c4"
       fill="blue"
       focusable="false"
       role="img"
@@ -255,6 +270,11 @@ exports[`StyledSection can change the icon to angle-left 1`] = `
 `;
 
 exports[`StyledSection can change the icon to angle-right 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -294,14 +314,14 @@ exports[`StyledSection can change the icon to angle-right 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -313,11 +333,11 @@ exports[`StyledSection can change the icon to angle-right 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-angle-right c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-angle-right c3 c4"
       fill="blue"
       focusable="false"
       role="img"
@@ -339,6 +359,11 @@ exports[`StyledSection can change the icon to angle-right 1`] = `
 `;
 
 exports[`StyledSection can change the icon to angle-up 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -378,14 +403,14 @@ exports[`StyledSection can change the icon to angle-up 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -397,11 +422,11 @@ exports[`StyledSection can change the icon to angle-up 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-angle-up c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-angle-up c3 c4"
       fill="blue"
       focusable="false"
       role="img"
@@ -423,6 +448,11 @@ exports[`StyledSection can change the icon to angle-up 1`] = `
 `;
 
 exports[`StyledSection can change the icon to circle 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -462,14 +492,14 @@ exports[`StyledSection can change the icon to circle 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -481,11 +511,11 @@ exports[`StyledSection can change the icon to circle 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-circle c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-circle c3 c4"
       fill="blue"
       focusable="false"
       role="img"
@@ -507,6 +537,11 @@ exports[`StyledSection can change the icon to circle 1`] = `
 `;
 
 exports[`StyledSection can change the icon to edit 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -546,14 +581,14 @@ exports[`StyledSection can change the icon to edit 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -565,11 +600,11 @@ exports[`StyledSection can change the icon to edit 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-edit c3 c4"
       fill="blue"
       focusable="false"
       role="img"
@@ -591,6 +626,11 @@ exports[`StyledSection can change the icon to edit 1`] = `
 `;
 
 exports[`StyledSection can change the icon to eye 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -630,14 +670,14 @@ exports[`StyledSection can change the icon to eye 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -649,11 +689,11 @@ exports[`StyledSection can change the icon to eye 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-eye c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-eye c3 c4"
       fill="blue"
       focusable="false"
       role="img"
@@ -675,6 +715,11 @@ exports[`StyledSection can change the icon to eye 1`] = `
 `;
 
 exports[`StyledSection can change the icon to file-text 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -714,14 +759,14 @@ exports[`StyledSection can change the icon to file-text 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -733,11 +778,11 @@ exports[`StyledSection can change the icon to file-text 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-file-text c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-file-text c3 c4"
       fill="blue"
       focusable="false"
       role="img"
@@ -759,6 +804,11 @@ exports[`StyledSection can change the icon to file-text 1`] = `
 `;
 
 exports[`StyledSection can change the icon to key 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -798,14 +848,14 @@ exports[`StyledSection can change the icon to key 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -817,11 +867,11 @@ exports[`StyledSection can change the icon to key 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-key c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-key c3 c4"
       fill="blue"
       focusable="false"
       role="img"
@@ -843,6 +893,11 @@ exports[`StyledSection can change the icon to key 1`] = `
 `;
 
 exports[`StyledSection can change the icon to list 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -882,14 +937,14 @@ exports[`StyledSection can change the icon to list 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -901,11 +956,11 @@ exports[`StyledSection can change the icon to list 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-list c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-list c3 c4"
       fill="blue"
       focusable="false"
       role="img"
@@ -927,6 +982,11 @@ exports[`StyledSection can change the icon to list 1`] = `
 `;
 
 exports[`StyledSection can change the icon to question-circle 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -966,14 +1026,14 @@ exports[`StyledSection can change the icon to question-circle 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -985,11 +1045,11 @@ exports[`StyledSection can change the icon to question-circle 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-question-circle c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-question-circle c3 c4"
       fill="blue"
       focusable="false"
       role="img"
@@ -1011,6 +1071,11 @@ exports[`StyledSection can change the icon to question-circle 1`] = `
 `;
 
 exports[`StyledSection can change the icon to search 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -1050,14 +1115,14 @@ exports[`StyledSection can change the icon to search 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -1069,11 +1134,11 @@ exports[`StyledSection can change the icon to search 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-search c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-search c3 c4"
       fill="blue"
       focusable="false"
       role="img"
@@ -1095,6 +1160,11 @@ exports[`StyledSection can change the icon to search 1`] = `
 `;
 
 exports[`StyledSection can change the icon to times 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -1134,14 +1204,14 @@ exports[`StyledSection can change the icon to times 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -1153,11 +1223,11 @@ exports[`StyledSection can change the icon to times 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-times c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-times c3 c4"
       fill="blue"
       focusable="false"
       role="img"
@@ -1179,6 +1249,11 @@ exports[`StyledSection can change the icon to times 1`] = `
 `;
 
 exports[`StyledSection have a red icon 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -1218,14 +1293,14 @@ exports[`StyledSection have a red icon 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -1237,11 +1312,11 @@ exports[`StyledSection have a red icon 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-search c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-search c3 c4"
       fill="red"
       focusable="false"
       role="img"
@@ -1262,6 +1337,11 @@ exports[`StyledSection have a red icon 1`] = `
 `;
 
 exports[`StyledSection match the snapshot 1`] = `
+.c2 {
+  margin-left: 0;
+  padding: 0;
+}
+
 .c0 {
   box-shadow: 0 1px 2px rgba( 0,0,0,0.2 );
   background-color: #fff;
@@ -1301,14 +1381,14 @@ exports[`StyledSection match the snapshot 1`] = `
   color: red;
 }
 
-.c0 .c2 {
+.c0 .c3 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   width: 16;
   height: 16;
   -webkit-flex: none;
@@ -1320,11 +1400,11 @@ exports[`StyledSection match the snapshot 1`] = `
   className="yoast-section c0"
 >
   <h2
-    className="c1 "
+    className="c1 c2"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-file-text c2 c3"
+      className="yoast-svg-icon yoast-svg-icon-file-text c3 c4"
       fill="blue"
       focusable="false"
       role="img"

--- a/index.js
+++ b/index.js
@@ -8,8 +8,9 @@ export {
 	AlgoliaSearcher,
 	HelpCenter,
 	MessageBox,
-}
+};
 
 export * from "./composites/Plugin/SnippetPreview";
 export * from "./composites/Plugin/SnippetEditor";
 export * from "./forms";
+export { getRtlStyle } from "./utils/helpers/styled-components";

--- a/utils/helpers/styled-components.js
+++ b/utils/helpers/styled-components.js
@@ -1,0 +1,17 @@
+/**
+ * Returns a function that returns the correct style based on if the current
+ * theme is right to left.
+ *
+ * This is determined by the `isRtl` property in the styled components theme.
+ *
+ * @param {string} left  Style to return if the theme is left to right.
+ * @param {string} right Style to return if the theme is right to left.
+ *
+ * @returns {Function} A function that returns the right styled based on the
+ * 					   theme in the props.
+ */
+export function getRtlStyle( left, right ) {
+	return ( props ) => {
+		return ( props.theme.isRtl ? right : left );
+	};
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix the styling of the ModeSwitcher, SnippetEditor, HelpTextWrapper, SnippetPreview and StyledSection for right-to-left languages. 

## Relevant technical choices:

* Introduce `getRtlStyle` function to determine which style to use. 

## Test instructions

This PR can be tested by following these steps:
* See https://github.com/Yoast/wordpress-seo/pull/10189

Fixes https://github.com/Yoast/wordpress-seo/issues/10174
