### PR TITLE
Fix min-height CSS hack for buttons in IE11.

### DIFF
--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/AnalysisCollapsibleTest.js.snap
@@ -142,7 +142,7 @@ exports[`AnalysisCollapsible matches the snapshot by default 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";
@@ -339,7 +339,7 @@ exports[`AnalysisCollapsible matches the snapshot by default 2`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";
@@ -519,7 +519,7 @@ exports[`AnalysisCollapsible matches the snapshot when it is closed 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";
@@ -705,7 +705,7 @@ exports[`AnalysisCollapsible matches the snapshot when it is closed 2`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";
@@ -908,7 +908,7 @@ exports[`AnalysisCollapsible matches the snapshot when it is open 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";
@@ -1105,7 +1105,7 @@ exports[`AnalysisCollapsible matches the snapshot when it is open 2`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -221,7 +221,7 @@ exports[`the ContentAnalysis component with disabled buttons matches the snapsho
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c9::after {
     display: inline-block;
     content: "";
@@ -832,7 +832,7 @@ exports[`the ContentAnalysis component with hidden buttons matches the snapshot 
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c9::after {
     display: inline-block;
     content: "";
@@ -1450,7 +1450,7 @@ exports[`the ContentAnalysis component with language notice for someone who can 
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c11::after {
     display: inline-block;
     content: "";
@@ -2129,7 +2129,7 @@ exports[`the ContentAnalysis component with language notice for someone who cann
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c11::after {
     display: inline-block;
     content: "";
@@ -2785,7 +2785,7 @@ exports[`the ContentAnalysis component with language notice matches the snapshot
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c9::after {
     display: inline-block;
     content: "";
@@ -3422,7 +3422,7 @@ exports[`the ContentAnalysis component with specified header level matches the s
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c8::after {
     display: inline-block;
     content: "";
@@ -4050,7 +4050,7 @@ exports[`the ContentAnalysis component without language notice matches the snaps
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c8::after {
     display: inline-block;
     content: "";
@@ -4678,7 +4678,7 @@ exports[`the ContentAnalysis component without problems and considerations, but 
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c8::after {
     display: inline-block;
     content: "";
@@ -5152,7 +5152,7 @@ exports[`the ContentAnalysis component without problems and improvements matches
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c8::after {
     display: inline-block;
     content: "";
@@ -5626,7 +5626,7 @@ exports[`the ContentAnalysis component without problems matches the snapshot 1`]
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c8::after {
     display: inline-block;
     content: "";
@@ -6165,7 +6165,7 @@ exports[`the ContentAnalysis component without problems, improvements and consid
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c8::after {
     display: inline-block;
     content: "";

--- a/composites/Plugin/Shared/components/Button.js
+++ b/composites/Plugin/Shared/components/Button.js
@@ -48,8 +48,8 @@ export function addBaseStyle( component ) {
 			align-self: center;
 		}
 
-		// Only needed for IE 10+.
-		@media all and ( -ms-high-contrast: none ), ( -ms-high-contrast: active ) {
+		// Only needed for IE 10+. Don't add spaces within brackets for this to work.
+		@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
 			::after {
 				display: inline-block;
 				content: "";

--- a/composites/Plugin/Shared/tests/__snapshots__/ButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/ButtonTest.js.snap
@@ -61,7 +61,7 @@ exports[`BaseButton executes callback 1`] = `
   align-self: center;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c3::after {
     display: inline-block;
     content: "";
@@ -139,7 +139,7 @@ exports[`BaseButton executes callback 2`] = `
   align-self: center;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c3::after {
     display: inline-block;
     content: "";
@@ -221,7 +221,7 @@ exports[`SnippetPreviewButton executes callback 1`] = `
   font-size: 0.8rem;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c4::after {
     display: inline-block;
     content: "";
@@ -303,7 +303,7 @@ exports[`SnippetPreviewButton executes callback 2`] = `
   font-size: 0.8rem;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c4::after {
     display: inline-block;
     content: "";
@@ -381,7 +381,7 @@ exports[`the BaseButton matches the snapshot 1`] = `
   align-self: center;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c3::after {
     display: inline-block;
     content: "";
@@ -470,7 +470,7 @@ exports[`the IconButton matches the snapshot 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c4::after {
     display: inline-block;
     content: "";
@@ -579,7 +579,7 @@ exports[`the IconButton with text matches the snapshot 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c4::after {
     display: inline-block;
     content: "";
@@ -674,7 +674,7 @@ exports[`the SnippetPreviewButton matches the snapshot 1`] = `
   font-size: 0.8rem;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c4::after {
     display: inline-block;
     content: "";

--- a/composites/Plugin/Shared/tests/__snapshots__/CollapsibleTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/CollapsibleTest.js.snap
@@ -117,7 +117,7 @@ exports[`Collapsible matches the snapshot by default 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";
@@ -282,7 +282,7 @@ exports[`Collapsible matches the snapshot by default 2`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";
@@ -459,7 +459,7 @@ exports[`Collapsible matches the snapshot when it is closed 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";
@@ -624,7 +624,7 @@ exports[`Collapsible matches the snapshot when it is closed 2`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";
@@ -805,7 +805,7 @@ exports[`Collapsible matches the snapshot when it is open 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";
@@ -982,7 +982,7 @@ exports[`Collapsible matches the snapshot when it is open 2`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";
@@ -1135,7 +1135,7 @@ exports[`CollapsibleStateless matches the snapshot by default 1`] = `
   font-weight: normal;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";
@@ -1286,7 +1286,7 @@ exports[`CollapsibleStateless matches the snapshot when it is opened and closed 
   font-weight: normal;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";
@@ -1437,7 +1437,7 @@ exports[`CollapsibleStateless matches the snapshot when it is opened and closed 
   font-weight: normal;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";
@@ -1596,7 +1596,7 @@ exports[`CollapsibleStateless matches the snapshot with prefix seo icon and scre
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c7::after {
     display: inline-block;
     content: "";

--- a/composites/Plugin/Shared/tests/__snapshots__/LinkButtonTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/LinkButtonTest.js.snap
@@ -63,7 +63,7 @@ exports[`the BaseLinkButton matches the snapshot 1`] = `
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c3::after {
     display: inline-block;
     content: "";
@@ -145,7 +145,7 @@ exports[`the LinkButton matches the snapshot 1`] = `
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c4::after {
     display: inline-block;
     content: "";

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -305,7 +305,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -1173,7 +1173,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -3019,7 +3019,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -4865,7 +4865,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -6711,7 +6711,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -8313,7 +8313,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -9682,7 +9682,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -11528,7 +11528,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -13130,7 +13130,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -13676,7 +13676,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -14478,7 +14478,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   content: "";
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -16344,7 +16344,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   content: "";
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -18198,7 +18198,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -20044,7 +20044,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -21716,7 +21716,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -22590,7 +22590,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -24189,7 +24189,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -24735,7 +24735,7 @@ exports[`SnippetEditor shows the editor 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/HelpTextWrapperTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/HelpTextWrapperTest.js.snap
@@ -123,7 +123,7 @@ exports[`HelpTextWrapper matches the snapshot by default 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -212,7 +212,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -567,7 +567,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -925,7 +925,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -1297,7 +1297,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -1658,7 +1658,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -2016,7 +2016,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -2371,7 +2371,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -2738,7 +2738,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   content: "";
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -3105,7 +3105,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   content: "";
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -3472,7 +3472,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   content: "";
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -3839,7 +3839,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   content: "";
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -4206,7 +4206,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   content: "";
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -4573,7 +4573,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   content: "";
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";
@@ -4932,7 +4932,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   flex: none;
 }
 
-@media all and ( -ms-high-contrast:none ),( -ms-high-contrast:active ) {
+@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
   .c6::after {
     display: inline-block;
     content: "";


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix the CSS media query to target IE11 used for the buttons min-height

## Relevant technical choices:

- for the media query to work and target IE11, there shouldn't be spaces within brackets
- pairs with what was already done for the `YoastButton` component

## Test instructions

- best way to test this in IE11 is to increase the `settings.minHeight` value for both the `Button` and `YoastButton` components
- you should then add the buttons somewhere in the standalone examples but there's really no need for it, I've already tested it and the PR just removes a few spaces

Aside: I'd like to propose to add a page to the standalone App to test all the buttons.

Before:

![screenshot 17](https://user-images.githubusercontent.com/1682452/42097921-b64c3dc8-7bb9-11e8-8573-d751663907bf.png)

After:

![screenshot 18](https://user-images.githubusercontent.com/1682452/42097927-bdd7d0ca-7bb9-11e8-8fe7-b45ab299581b.png)


Fixes #633 
