### PR TITLE
Add an .editorconfig file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+tab_width = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.txt]
+trim_trailing_whitespace = false
+
+[*.{md,json,yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
## Summary

A bit surprisingly, there was no `.editorconfig` file in the project.

* Adds an `.editorconfig` file with the same settings used on MyYoast and the plugin

## Test instructions

- your favorite IDE/Editor should now pick up and use some useful rules for indentation, spacing, trailing spaces, new line at the end fo the file, etc.

Fixes #630 
