### PR TITLE
Add rtl theme to snippet editor

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -102,7 +102,7 @@ class ReplacementVariableEditor extends React.Component {
 						onBlur={ onBlur }
 						replacementVariables={ replacementVariables }
 						recommendedReplacementVariables={ recommendedReplacementVariables }
-						ref={ ref => {
+						innerRef={ ref => {
 							this.ref = ref;
 							editorRef( ref );
 						} }

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditor.js
@@ -106,6 +106,10 @@ class ReplacementVariableEditor extends React.Component {
 							this.ref = ref;
 							editorRef( ref );
 						} }
+						ref={ ref => {
+							this.ref = ref;
+							editorRef( ref );
+						} }
 						ariaLabelledBy={ this.uniqueId }
 					/>
 				</InputContainer>

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
@@ -11,6 +11,7 @@ import PropTypes from "prop-types";
 import { speak as a11ySpeak } from "@wordpress/a11y";
 import { __, _n, sprintf } from "@wordpress/i18n";
 import styled from "styled-components";
+import { withTheme } from "styled-components";
 
 // Internal dependencies.
 import {
@@ -494,12 +495,12 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	 */
 	render() {
 		const { MentionSuggestions } = this.mentionsPlugin;
-		const { onFocus, onBlur, ariaLabelledBy, placeholder } = this.props;
+		const { onFocus, onBlur, ariaLabelledBy, placeholder, theme } = this.props;
 		const { editorState, suggestions } = this.state;
-
 		return (
 			<React.Fragment>
 				<Editor
+					textDirectionality={ theme.isRtl ? "RTL" : "LTR" }
 					editorState={ editorState }
 					onChange={ this.onChange }
 					onFocus={ onFocus }
@@ -530,6 +531,7 @@ ReplacementVariableEditorStandalone.propTypes = {
 	onChange: PropTypes.func.isRequired,
 	onFocus: PropTypes.func,
 	onBlur: PropTypes.func,
+	theme: PropTypes.object,
 	placeholder: PropTypes.string,
 };
 
@@ -541,4 +543,5 @@ ReplacementVariableEditorStandalone.defaultProps = {
 	placeholder: "",
 };
 
-export default ReplacementVariableEditorStandalone;
+export { ReplacementVariableEditorStandalone as InnerComponent };
+export default withTheme( ReplacementVariableEditorStandalone );

--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
@@ -497,6 +497,7 @@ class ReplacementVariableEditorStandalone extends React.Component {
 		const { MentionSuggestions } = this.mentionsPlugin;
 		const { onFocus, onBlur, ariaLabelledBy, placeholder, theme } = this.props;
 		const { editorState, suggestions } = this.state;
+
 		return (
 			<React.Fragment>
 				<Editor
@@ -543,5 +544,5 @@ ReplacementVariableEditorStandalone.defaultProps = {
 	placeholder: "",
 };
 
-export { ReplacementVariableEditorStandalone as InnerComponent };
+export { ReplacementVariableEditorStandalone as ReplacementVariableEditorStandaloneInnerComponent };
 export default withTheme( ReplacementVariableEditorStandalone );

--- a/composites/Plugin/SnippetEditor/components/__mocks__/ReplacementVariableEditorStandalone.js
+++ b/composites/Plugin/SnippetEditor/components/__mocks__/ReplacementVariableEditorStandalone.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { withTheme } from "styled-components";
 
 let focus = jest.fn();
 

--- a/composites/Plugin/SnippetEditor/components/__mocks__/ReplacementVariableEditorStandalone.js
+++ b/composites/Plugin/SnippetEditor/components/__mocks__/ReplacementVariableEditorStandalone.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { withTheme } from "styled-components";
 
 let focus = jest.fn();
 

--- a/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
@@ -1,5 +1,5 @@
 import { shallow } from "enzyme";
-import ReplacementVariableEditorStandalone from "../components/ReplacementVariableEditorStandalone";
+import ReplacementVariableEditorStandalone, { InnerComponent } from "../components/ReplacementVariableEditorStandalone";
 import React from "react";
 
 jest.mock( "draft-js/lib/generateRandomKey", () => () => {
@@ -23,6 +23,7 @@ describe( "ReplacementVariableEditor", () => {
 				content="Dummy content"
 				onChange={ () => {} }
 				ariaLabelledBy="id"
+				theme={ { isRtl: "false" } }
 			/>
 		);
 
@@ -65,7 +66,7 @@ describe( "suggestionsFilter", () => {
 			ariaLabelledBy: "id",
 		};
 
-		replacementVariablesEditor = new ReplacementVariableEditorStandalone( props );
+		replacementVariablesEditor = new InnerComponent( props );
 
 		suggestions = replacementVariablesEditor.mapReplacementVariablesToSuggestions( props.replacementVariables );
 

--- a/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/ReplacementVariableEditorTest.js
@@ -1,5 +1,6 @@
 import { shallow } from "enzyme";
-import ReplacementVariableEditorStandalone, { InnerComponent } from "../components/ReplacementVariableEditorStandalone";
+import ReplacementVariableEditorStandalone, { ReplacementVariableEditorStandaloneInnerComponent }
+	from "../components/ReplacementVariableEditorStandalone";
 import React from "react";
 
 jest.mock( "draft-js/lib/generateRandomKey", () => () => {
@@ -66,7 +67,7 @@ describe( "suggestionsFilter", () => {
 			ariaLabelledBy: "id",
 		};
 
-		replacementVariablesEditor = new InnerComponent( props );
+		replacementVariablesEditor = new ReplacementVariableEditorStandaloneInnerComponent( props );
 
 		suggestions = replacementVariablesEditor.mapReplacementVariablesToSuggestions( props.replacementVariables );
 

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/ReplacementVariableEditorTest.js.snap
@@ -1,194 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ReplacementVariableEditor wraps a Draft.js editor instance 1`] = `
-<React.Fragment>
-  <PluginEditor
-    ariaLabelledBy="id"
-    customStyleMap={Object {}}
-    decorators={Array []}
-    defaultBlockRenderMap={true}
-    defaultKeyBindings={true}
-    editorState={
-      EditorState {
-        "_immutable": Immutable.Record {
-          "allowUndo": true,
-          "currentContent": Immutable.Record {
-            "entityMap": Object {
-              "__add": [Function],
-              "__create": [Function],
-              "__get": [Function],
-              "__getLastCreatedEntityKey": [Function],
-              "__mergeData": [Function],
-              "__replaceData": [Function],
-              "add": [Function],
-              "create": [Function],
-              "get": [Function],
-              "getLastCreatedEntityKey": [Function],
-              "mergeData": [Function],
-              "replaceData": [Function],
-            },
-            "blockMap": Immutable.OrderedMap {
-              "1": Immutable.Record {
-                "key": "1",
-                "type": "unstyled",
-                "text": "Dummy content",
-                "characterList": Immutable.List [
-                  Immutable.Record {
-                    "style": Immutable.OrderedSet [],
-                    "entity": null,
-                  },
-                  Immutable.Record {
-                    "style": Immutable.OrderedSet [],
-                    "entity": null,
-                  },
-                  Immutable.Record {
-                    "style": Immutable.OrderedSet [],
-                    "entity": null,
-                  },
-                  Immutable.Record {
-                    "style": Immutable.OrderedSet [],
-                    "entity": null,
-                  },
-                  Immutable.Record {
-                    "style": Immutable.OrderedSet [],
-                    "entity": null,
-                  },
-                  Immutable.Record {
-                    "style": Immutable.OrderedSet [],
-                    "entity": null,
-                  },
-                  Immutable.Record {
-                    "style": Immutable.OrderedSet [],
-                    "entity": null,
-                  },
-                  Immutable.Record {
-                    "style": Immutable.OrderedSet [],
-                    "entity": null,
-                  },
-                  Immutable.Record {
-                    "style": Immutable.OrderedSet [],
-                    "entity": null,
-                  },
-                  Immutable.Record {
-                    "style": Immutable.OrderedSet [],
-                    "entity": null,
-                  },
-                  Immutable.Record {
-                    "style": Immutable.OrderedSet [],
-                    "entity": null,
-                  },
-                  Immutable.Record {
-                    "style": Immutable.OrderedSet [],
-                    "entity": null,
-                  },
-                  Immutable.Record {
-                    "style": Immutable.OrderedSet [],
-                    "entity": null,
-                  },
-                ],
-                "depth": 0,
-                "data": Immutable.Map {},
-              },
-            },
-            "selectionBefore": Immutable.Record {
-              "anchorKey": "1",
-              "anchorOffset": 0,
-              "focusKey": "1",
-              "focusOffset": 0,
-              "isBackward": false,
-              "hasFocus": false,
-            },
-            "selectionAfter": Immutable.Record {
-              "anchorKey": "1",
-              "anchorOffset": 0,
-              "focusKey": "1",
-              "focusOffset": 0,
-              "isBackward": false,
-              "hasFocus": false,
-            },
-          },
-          "decorator": null,
-          "directionMap": Immutable.OrderedMap {
-            "1": "LTR",
-          },
-          "forceSelection": false,
-          "inCompositionMode": false,
-          "inlineStyleOverride": null,
-          "lastChangeType": null,
-          "nativelyRenderedContent": null,
-          "redoStack": Immutable.Stack [],
-          "selection": Immutable.Record {
-            "anchorKey": "1",
-            "anchorOffset": 0,
-            "focusKey": "1",
-            "focusOffset": 0,
-            "isBackward": false,
-            "hasFocus": false,
-          },
-          "treeMap": Immutable.OrderedMap {
-            "1": Immutable.List [
-              Immutable.Record {
-                "start": 0,
-                "end": 13,
-                "decoratorKey": null,
-                "leaves": Immutable.List [
-                  Immutable.Record {
-                    "start": 0,
-                    "end": 13,
-                  },
-                ],
-              },
-            ],
-          },
-          "undoStack": Immutable.Stack [],
-        },
-      }
+<ReplacementVariableEditorStandalone
+  ariaLabelledBy="id"
+  className=""
+  content="Dummy content"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  placeholder=""
+  replacementVariables={Array []}
+  theme={
+    Object {
+      "isRtl": "false",
     }
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    placeholder=""
-    plugins={
-      Array [
-        Object {
-          "MentionSuggestions": [Function],
-          "decorators": Array [
-            Object {
-              "component": [Function],
-              "strategy": [Function],
-            },
-            Object {
-              "component": [Function],
-              "strategy": [Function],
-            },
-          ],
-          "getAccessibilityProps": [Function],
-          "handleReturn": [Function],
-          "initialize": [Function],
-          "onChange": [Function],
-          "onDownArrow": [Function],
-          "onEscape": [Function],
-          "onTab": [Function],
-          "onUpArrow": [Function],
-        },
-        Object {
-          "blockRenderMap": Immutable.Map {
-            "unstyled": Object {
-              "element": "div",
-            },
-          },
-          "handleReturn": [Function],
-          "onChange": [Function],
-        },
-      ]
-    }
-    stripPastedStyles={true}
-  />
-  <ReplacementVariableEditorStandalone__ZIndexOverride>
-    <Decorated(MentionSuggestions)
-      onSearchChange={[Function]}
-      suggestions={Array []}
-    />
-  </ReplacementVariableEditorStandalone__ZIndexOverride>
-</React.Fragment>
+  }
+/>
 `;

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -2161,6 +2161,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="30"
                         content="Test title"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -2372,6 +2373,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="31"
                         content="Test description, %%replacement_variable%%"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -4007,6 +4009,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="30"
                         content="Test title"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -4218,6 +4221,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="31"
                         content="Test description, %%replacement_variable%%"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -5853,6 +5857,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="30"
                         content="Test title"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -6064,6 +6069,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="31"
                         content="Test description, %%replacement_variable%%"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -10670,6 +10676,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="42"
                         content="Test title"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -10881,6 +10888,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="43"
                         content="Test description, %%replacement_variable%%"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -12516,6 +12524,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="38"
                         content="Test title"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -12727,6 +12736,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="39"
                         content="Test description, %%replacement_variable%%"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -17340,6 +17350,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="17"
                         content="Test title"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -17551,6 +17562,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="18"
                         content="Test description, %%replacement_variable%%"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -19186,6 +19198,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="9"
                         content="Test title"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -19397,6 +19410,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="10"
                         content="Test description, %%replacement_variable%%"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -21065,6 +21079,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="34"
                         content="Test title"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -21298,6 +21313,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="35"
                         content="Test description, %%replacement_variable%%"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -23578,6 +23594,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="25"
                         content="Test title"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -23789,6 +23806,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="26"
                         content="Test description, %%replacement_variable%%"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -7705,6 +7705,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="13"
                         content="Test title"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -7916,6 +7917,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="14"
                         content="Test description, %%replacement_variable%%"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -15484,6 +15486,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="21"
                         content="Test title"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -15695,6 +15698,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       <ReplacementVariableEditorStandalone
                         ariaLabelledBy="22"
                         content="Test description, %%replacement_variable%%"
+                        innerRef={[Function]}
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds Styled Component's `withTheme` to the `ReplacementVariableEditorStandalone` component in order to set the `textDirectionality ` of the `Editor` based on the language direction that is passed to the theme.

## Relevant technical choices:

* Add RTL theme to snippet editor

## Test instructions

This PR can be tested by following these steps:

* See https://github.com/Yoast/wordpress-seo/pull/10224

Fixes https://github.com/Yoast/wordpress-seo/issues/10208
