### PR TITLE
Introduce wrapper in mock to pass innerRef as a ref and re-enable tests

### DIFF
--- a/composites/Plugin/SnippetEditor/components/__mocks__/ReplacementVariableEditorStandalone.js
+++ b/composites/Plugin/SnippetEditor/components/__mocks__/ReplacementVariableEditorStandalone.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 let focus = jest.fn();
 
@@ -28,6 +29,25 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	}
 }
 
-export default ReplacementVariableEditorStandalone;
+/**
+ * Wraps the ReplacementVariableEditorStandalone component to pass the innerRef as a ref.
+ *
+ * @param {Object} props The components props.
+ *
+ * @returns {ReactElement} The wrapped ReplacementVariableEditorStandalone component.
+ * @constructor
+ */
+const Wrapper = ( props ) => {
+	return <ReplacementVariableEditorStandalone
+		{ ...props }
+		ref={ props.innerRef }
+	/>;
+};
+
+Wrapper.propTypes = {
+	innerRef: PropTypes.string,
+};
+
+export default Wrapper;
 
 export { focus };

--- a/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
+++ b/composites/Plugin/SnippetEditor/tests/SnippetEditorTest.js
@@ -105,8 +105,7 @@ describe( "SnippetEditor", () => {
 		expect( editor ).toMatchSnapshot();
 	} );
 
-	// This test is disabled due to a ref problem that is introduced by using styled-component's withTheme.
-	xit( "closes when calling close()", () => {
+	it( "closes when calling close()", () => {
 		focus.mockClear();
 		const editor = mountWithArgs( {} );
 
@@ -147,8 +146,7 @@ describe( "SnippetEditor", () => {
 		expect( editor ).toMatchSnapshot();
 	} );
 
-	// This test is disabled due to a ref problem that is introduced by using styled-component's withTheme.
-	xit( "highlights the active ReplacementVariableEditor when calling setFieldFocus", () => {
+	it( "highlights the active ReplacementVariableEditor when calling setFieldFocus", () => {
 		focus.mockClear();
 
 		const editor = mountWithArgs( {} );

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -2045,12 +2045,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="22"
+                    id="30"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="22"
+                      id="30"
                       onClick={[Function]}
                     >
                       SEO title
@@ -2161,8 +2161,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="22"
+                      <Wrapper
+                        ariaLabelledBy="30"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -2171,8 +2171,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="30"
+                          content="Test title"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -2198,12 +2209,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 className="c29"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-21-slug"
+                  id="snippet-editor-field-29-slug"
                   onClick={[Function]}
                 >
                   <div
                     className="c30"
-                    id="snippet-editor-field-21-slug"
+                    id="snippet-editor-field-29-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -2219,7 +2230,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-21-slug"
+                      aria-labelledby="snippet-editor-field-29-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -2228,7 +2239,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-21-slug"
+                        aria-labelledby="snippet-editor-field-29-slug"
                         className="c35"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
@@ -2262,12 +2273,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="23"
+                    id="31"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="23"
+                      id="31"
                       onClick={[Function]}
                     >
                       Meta description
@@ -2378,8 +2389,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="23"
+                      <Wrapper
+                        ariaLabelledBy="31"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -2389,8 +2400,20 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="31"
+                          content="Test description, %%replacement_variable%%"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder="Modify your meta description by editing it right here"
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -3901,12 +3924,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="22"
+                    id="30"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="22"
+                      id="30"
                       onClick={[Function]}
                     >
                       SEO title
@@ -4017,8 +4040,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="22"
+                      <Wrapper
+                        ariaLabelledBy="30"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -4027,8 +4050,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="30"
+                          content="Test title"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -4054,12 +4088,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 className="c29"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-21-slug"
+                  id="snippet-editor-field-29-slug"
                   onClick={[Function]}
                 >
                   <div
                     className="c30"
-                    id="snippet-editor-field-21-slug"
+                    id="snippet-editor-field-29-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -4075,7 +4109,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-21-slug"
+                      aria-labelledby="snippet-editor-field-29-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -4084,7 +4118,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-21-slug"
+                        aria-labelledby="snippet-editor-field-29-slug"
                         className="c35"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
@@ -4118,12 +4152,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="23"
+                    id="31"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="23"
+                      id="31"
                       onClick={[Function]}
                     >
                       Meta description
@@ -4234,8 +4268,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="23"
+                      <Wrapper
+                        ariaLabelledBy="31"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -4245,8 +4279,20 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="31"
+                          content="Test description, %%replacement_variable%%"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder="Modify your meta description by editing it right here"
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -5757,12 +5803,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="22"
+                    id="30"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="22"
+                      id="30"
                       onClick={[Function]}
                     >
                       SEO title
@@ -5873,8 +5919,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="22"
+                      <Wrapper
+                        ariaLabelledBy="30"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -5883,8 +5929,19 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="30"
+                          content="Test title"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -5910,12 +5967,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 className="c29"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-21-slug"
+                  id="snippet-editor-field-29-slug"
                   onClick={[Function]}
                 >
                   <div
                     className="c30"
-                    id="snippet-editor-field-21-slug"
+                    id="snippet-editor-field-29-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -5931,7 +5988,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-21-slug"
+                      aria-labelledby="snippet-editor-field-29-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -5940,7 +5997,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-21-slug"
+                        aria-labelledby="snippet-editor-field-29-slug"
                         className="c35"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
@@ -5974,12 +6031,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="23"
+                    id="31"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="23"
+                      id="31"
                       onClick={[Function]}
                     >
                       Meta description
@@ -6090,8 +6147,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="23"
+                      <Wrapper
+                        ariaLabelledBy="31"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -6101,8 +6158,20 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="31"
+                          content="Test description, %%replacement_variable%%"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder="Modify your meta description by editing it right here"
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -7729,7 +7798,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
+                      <Wrapper
                         ariaLabelledBy="13"
                         content="Test title"
                         innerRef={[Function]}
@@ -7739,8 +7808,19 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="13"
+                          content="Test title"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -7946,7 +8026,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
+                      <Wrapper
                         ariaLabelledBy="14"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
@@ -7957,8 +8037,20 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="14"
+                          content="Test description, %%replacement_variable%%"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder="Modify your meta description by editing it right here"
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -10594,12 +10686,12 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="34"
+                    id="42"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="34"
+                      id="42"
                       onClick={[Function]}
                     >
                       SEO title
@@ -10710,8 +10802,8 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="34"
+                      <Wrapper
+                        ariaLabelledBy="42"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -10720,8 +10812,19 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="42"
+                          content="Test title"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -10747,12 +10850,12 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 className="c29"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-33-slug"
+                  id="snippet-editor-field-41-slug"
                   onClick={[Function]}
                 >
                   <div
                     className="c30"
-                    id="snippet-editor-field-33-slug"
+                    id="snippet-editor-field-41-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -10768,7 +10871,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-33-slug"
+                      aria-labelledby="snippet-editor-field-41-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -10777,7 +10880,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-33-slug"
+                        aria-labelledby="snippet-editor-field-41-slug"
                         className="c35"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
@@ -10811,12 +10914,12 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="35"
+                    id="43"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="35"
+                      id="43"
                       onClick={[Function]}
                     >
                       Meta description
@@ -10927,8 +11030,8 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="35"
+                      <Wrapper
+                        ariaLabelledBy="43"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -10938,8 +11041,20 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="43"
+                          content="Test description, %%replacement_variable%%"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder="Modify your meta description by editing it right here"
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -12450,12 +12565,12 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="30"
+                    id="38"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="30"
+                      id="38"
                       onClick={[Function]}
                     >
                       SEO title
@@ -12566,8 +12681,8 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="30"
+                      <Wrapper
+                        ariaLabelledBy="38"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -12576,8 +12691,19 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="38"
+                          content="Test title"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -12603,12 +12729,12 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 className="c29"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-29-slug"
+                  id="snippet-editor-field-37-slug"
                   onClick={[Function]}
                 >
                   <div
                     className="c30"
-                    id="snippet-editor-field-29-slug"
+                    id="snippet-editor-field-37-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -12624,7 +12750,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-29-slug"
+                      aria-labelledby="snippet-editor-field-37-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -12633,7 +12759,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-29-slug"
+                        aria-labelledby="snippet-editor-field-37-slug"
                         className="c35"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
@@ -12667,12 +12793,12 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="31"
+                    id="39"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="31"
+                      id="39"
                       onClick={[Function]}
                     >
                       Meta description
@@ -12783,8 +12909,8 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="31"
+                      <Wrapper
+                        ariaLabelledBy="39"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -12794,8 +12920,20 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="39"
+                          content="Test description, %%replacement_variable%%"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder="Modify your meta description by editing it right here"
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -15534,7 +15672,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
+                      <Wrapper
                         ariaLabelledBy="21"
                         content="Test title"
                         innerRef={[Function]}
@@ -15544,8 +15682,19 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="21"
+                          content="Test title"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -15751,7 +15900,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
+                      <Wrapper
                         ariaLabelledBy="22"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
@@ -15762,8 +15911,20 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="22"
+                          content="Test description, %%replacement_variable%%"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder="Modify your meta description by editing it right here"
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -17294,12 +17455,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="13"
+                    id="17"
                     onClick={[Function]}
                   >
                     <div
                       className="c31"
-                      id="13"
+                      id="17"
                       onClick={[Function]}
                     >
                       SEO title
@@ -17410,8 +17571,8 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="13"
+                      <Wrapper
+                        ariaLabelledBy="17"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -17420,8 +17581,19 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="17"
+                          content="Test title"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -17447,12 +17619,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                 className="c30"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-12-slug"
+                  id="snippet-editor-field-16-slug"
                   onClick={[Function]}
                 >
                   <div
                     className="c31"
-                    id="snippet-editor-field-12-slug"
+                    id="snippet-editor-field-16-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -17468,7 +17640,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-12-slug"
+                      aria-labelledby="snippet-editor-field-16-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -17477,7 +17649,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-12-slug"
+                        aria-labelledby="snippet-editor-field-16-slug"
                         className="c36"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
@@ -17511,12 +17683,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="14"
+                    id="18"
                     onClick={[Function]}
                   >
                     <div
                       className="c31"
-                      id="14"
+                      id="18"
                       onClick={[Function]}
                     >
                       Meta description
@@ -17627,8 +17799,8 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="14"
+                      <Wrapper
+                        ariaLabelledBy="18"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -17638,8 +17810,20 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="18"
+                          content="Test description, %%replacement_variable%%"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder="Modify your meta description by editing it right here"
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -19266,7 +19450,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
+                      <Wrapper
                         ariaLabelledBy="9"
                         content="Test title"
                         innerRef={[Function]}
@@ -19276,8 +19460,19 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="9"
+                          content="Test title"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -19483,7 +19678,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
+                      <Wrapper
                         ariaLabelledBy="10"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
@@ -19494,8 +19689,20 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="10"
+                          content="Test description, %%replacement_variable%%"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder="Modify your meta description by editing it right here"
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -21039,12 +21246,12 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="26"
+                    id="34"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="26"
+                      id="34"
                       onClick={[Function]}
                     >
                       SEO title
@@ -21155,8 +21362,8 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="26"
+                      <Wrapper
+                        ariaLabelledBy="34"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -21176,8 +21383,30 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           ]
                         }
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="34"
+                          content="Test title"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={
+                            Array [
+                              Object {
+                                "name": "title",
+                                "value": "Title!!!",
+                              },
+                              Object {
+                                "name": "excerpt",
+                                "value": "Excerpt!!!",
+                              },
+                            ]
+                          }
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -21203,12 +21432,12 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 className="c29"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-25-slug"
+                  id="snippet-editor-field-33-slug"
                   onClick={[Function]}
                 >
                   <div
                     className="c30"
-                    id="snippet-editor-field-25-slug"
+                    id="snippet-editor-field-33-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -21224,7 +21453,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-25-slug"
+                      aria-labelledby="snippet-editor-field-33-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -21233,7 +21462,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-25-slug"
+                        aria-labelledby="snippet-editor-field-33-slug"
                         className="c35"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
@@ -21278,12 +21507,12 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="27"
+                    id="35"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="27"
+                      id="35"
                       onClick={[Function]}
                     >
                       Meta description
@@ -21394,8 +21623,8 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="27"
+                      <Wrapper
+                        ariaLabelledBy="35"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -21416,8 +21645,31 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           ]
                         }
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="35"
+                          content="Test description, %%replacement_variable%%"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder="Modify your meta description by editing it right here"
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={
+                            Array [
+                              Object {
+                                "name": "title",
+                                "value": "Title!!!",
+                              },
+                              Object {
+                                "name": "excerpt",
+                                "value": "Excerpt!!!",
+                              },
+                            ]
+                          }
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -23562,12 +23814,12 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="17"
+                    id="25"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="17"
+                      id="25"
                       onClick={[Function]}
                     >
                       SEO title
@@ -23678,8 +23930,8 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="17"
+                      <Wrapper
+                        ariaLabelledBy="25"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -23688,8 +23940,19 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="25"
+                          content="Test title"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>
@@ -23715,12 +23978,12 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                 className="c29"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-16-slug"
+                  id="snippet-editor-field-24-slug"
                   onClick={[Function]}
                 >
                   <div
                     className="c30"
-                    id="snippet-editor-field-16-slug"
+                    id="snippet-editor-field-24-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -23736,7 +23999,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-16-slug"
+                      aria-labelledby="snippet-editor-field-24-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -23745,7 +24008,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-16-slug"
+                        aria-labelledby="snippet-editor-field-24-slug"
                         className="c35"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
@@ -23779,12 +24042,12 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="18"
+                    id="26"
                     onClick={[Function]}
                   >
                     <div
                       className="c30"
-                      id="18"
+                      id="26"
                       onClick={[Function]}
                     >
                       Meta description
@@ -23895,8 +24158,8 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
-                      <ReplacementVariableEditorStandalone
-                        ariaLabelledBy="18"
+                      <Wrapper
+                        ariaLabelledBy="26"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -23906,8 +24169,20 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         recommendedReplacementVariables={Array []}
                         replacementVariables={Array []}
                       >
-                        <div />
-                      </ReplacementVariableEditorStandalone>
+                        <ReplacementVariableEditorStandalone
+                          ariaLabelledBy="26"
+                          content="Test description, %%replacement_variable%%"
+                          innerRef={[Function]}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder="Modify your meta description by editing it right here"
+                          recommendedReplacementVariables={Array []}
+                          replacementVariables={Array []}
+                        >
+                          <div />
+                        </ReplacementVariableEditorStandalone>
+                      </Wrapper>
                     </div>
                   </Shared__InputContainer>
                 </ReplacementVariableEditor>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Introduced a wrapper in the mock for ReplacementVariableEditorStandalone which passes `innerRef` as a `ref`. ReplacementVariableEditorStandalone needs the ref prop because the `focus` function needs it.
* Re-enable tests that are dependent on this mock.

## Test instructions

This PR can be tested by following these steps:

* Run `yarn test` and check that all tests pass.
