### PR TITLE
Remove unused replaceKeyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ combineReducers( {
 } );
 ```
 
-The Content Analysis requires the [`redux-thunk`](https://www.npmjs.com/package/redux-thunk) middleware.
-
 ## Setup
 - Run a `yarn install` in the root folder.
 - Run `yarn start` in the root folder.

--- a/app/configureStore.js
+++ b/app/configureStore.js
@@ -1,13 +1,10 @@
 /* global module */
-import { createStore, applyMiddleware, compose } from "redux";
-import thunk from "redux-thunk";
+import { createStore, compose } from "redux";
 
 import rootReducer from "./reducers";
 import DevTools from "./utils/DevTools";
 
-const middleware = applyMiddleware( thunk );
 const enhancer = compose(
-	middleware,
 	DevTools.instrument()
 );
 

--- a/composites/Plugin/ContentAnalysis/actions/contentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/actions/contentAnalysis.js
@@ -76,23 +76,6 @@ export function removeKeyword( keyword ) {
 }
 
 /**
- * An action creator for replacing a keyword.
- *
- * @param {string} oldKeyword The old focus keyword.
- * @param {string} newKeyword The new focus keyword.
- * @param {Array} newKeywordResults The results for the new focus keyword.
- *
- * @returns {Object} A replace keyword action.
- */
-export function replaceKeyword( oldKeyword, newKeyword, newKeywordResults ) {
-	let resultsPerKeyword = [ { keyword: newKeyword, results: newKeywordResults } ];
-	return function( dispatch ) {
-		dispatch( removeKeyword( oldKeyword ) );
-		dispatch( setSeoResults( resultsPerKeyword ) );
-	};
-}
-
-/**
  * An action creator for setting the readability results.
  *
  * @param {Object} results The readability results.

--- a/composites/Plugin/ContentAnalysis/actions/tests/ContentAnalysisTest.js
+++ b/composites/Plugin/ContentAnalysis/actions/tests/ContentAnalysisTest.js
@@ -7,7 +7,6 @@ import {
 	SET_SEO_RESULTS_FOR_KEYWORD,
 	updateSeoResult,
 	updateReadabilityResult,
-	replaceKeyword,
 	setSeoResults,
 	removeKeyword,
 	setReadabilityResults,
@@ -59,30 +58,6 @@ describe( "updateReadabilityResult action creator", function() {
 		};
 		const actual = updateReadabilityResult( result );
 		expect( actual ).toEqual( expected );
-	} );
-} );
-
-describe( "the replaceKeyword action creator", function() {
-	it( "creates the replaceKeyword action", function() {
-		const middlewares = [ thunk ];
-		const mockStore = configureMockStore( middlewares );
-
-		let results = [ { id: "result", score: 3, description: "This is a bad score!", markingIsActive: false } ];
-		let oldKeyword = "oldKeyword";
-		let newKeyword = "newKeyword";
-		let resultsPerKeyword = [ {
-			keyword: newKeyword,
-			results: [ { id: "result", score: 3, description: "This is a bad score!", markingIsActive: false } ],
-		} ];
-
-		const expectedActions = [
-			{ type: REMOVE_KEYWORD, keyword: oldKeyword },
-			{ type: SET_SEO_RESULTS, resultsPerKeyword: resultsPerKeyword },
-		];
-		const store = mockStore( { oldKeyword: [] }, { otherKeyword: [] } );
-
-		store.dispatch( replaceKeyword( oldKeyword, newKeyword, results ) );
-		expect( store.getActions() ).toEqual( expectedActions );
 	} );
 } );
 

--- a/composites/Plugin/ContentAnalysis/actions/tests/ContentAnalysisTest.js
+++ b/composites/Plugin/ContentAnalysis/actions/tests/ContentAnalysisTest.js
@@ -12,8 +12,6 @@ import {
 	setReadabilityResults,
 	setSeoResultsForKeyword,
 } from "../contentAnalysis";
-import configureMockStore from "redux-mock-store";
-import thunk from "redux-thunk";
 
 describe( "setSeoResultsForKeyword action creator", function() {
 	it( "creates the setSeoResultsForKeyword action", function() {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "react-tabs": "^2.2.1",
     "react-transition-group": "^2.3.1",
     "redux": "^3.7.2",
-    "redux-thunk": "^2.2.0",
     "striptags": "^3.1.0",
     "styled-components": "^2.1.2",
     "whatwg-fetch": "^1.0.0",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes the unused `replaceKeyword` action.

## Relevant technical choices:

* The `replaceKeyword` action was not used in either wordpress-seo or yoast-components. 
* This was the only action that needed redux-thunk, so I removed that dependency as well.

## Test instructions

This PR can be tested by following these steps:

* Link this branch to `wordpress-seo`. 
* Run `yarn test` and see that all tests pass.
* Go to the metabox in the plugin. Open Redux Devtools and look for our store. Change the keyword in the metabox, and see that the keyword is still updated correctly.

