### PR TITLE
Fix propType of innerRef in mock

### DIFF
--- a/composites/Plugin/SnippetEditor/components/__mocks__/ReplacementVariableEditorStandalone.js
+++ b/composites/Plugin/SnippetEditor/components/__mocks__/ReplacementVariableEditorStandalone.js
@@ -45,7 +45,7 @@ const Wrapper = ( props ) => {
 };
 
 Wrapper.propTypes = {
-	innerRef: PropTypes.string,
+	innerRef: PropTypes.func,
 };
 
 export default Wrapper;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* innerRef is a function, not a string.

## Test instructions

This PR can be tested by following these steps:

* Run the tests and see that the following error has disappeared:

<img width="733" alt="schermafbeelding 2018-07-03 om 12 24 18" src="https://user-images.githubusercontent.com/17744553/42214560-214f9476-7ebc-11e8-85e0-f8c89cfce80f.png">

