### PR TITLE
Bump YoastSEO.js to 1.34.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "striptags": "^3.1.0",
     "styled-components": "^2.1.2",
     "whatwg-fetch": "^1.0.0",
-    "yoastseo": "^1.34.0"
+    "yoastseo": "^1.35.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Bumps YoastSEO.js to 1.35.0

## Test instructions

This PR can be tested by following these steps:

* Check whether nothing breaks.