### PR TITLE
Changed video alignment in help center when no ads present

### DIFF
--- a/composites/HelpCenter/views/VideoTutorial.js
+++ b/composites/HelpCenter/views/VideoTutorial.js
@@ -15,7 +15,7 @@ const VideoTutorialContainer = styled.div`
 `;
 
 const VideoContainer = styled.div`
-	float: left;
+	${ props => props.hasAdvertisements ? "float: left;" : "margin: auto;" }
 	width: ${ VIDEO_WIDTH };
 
 	@media screen and ( max-width: ${ breakpoints.tablet } ) {
@@ -24,6 +24,10 @@ const VideoContainer = styled.div`
 		margin: 0 auto;
 	}
 `;
+
+VideoContainer.propTypes = {
+	hasAdvertisements: PropTypes.bool.isRequired,
+};
 
 const VideoDescriptions = styled.div`
 	margin-left: ${ VIDEO_WIDTH };
@@ -102,10 +106,14 @@ VideoDescriptionItem.defaultProps = {
 export default function VideoTutorial( props ) {
 	return (
 		<VideoTutorialContainer className={ `${ props.className }__container` }>
-			<VideoContainer className={ `${ props.className }__video-container` }>
+			<VideoContainer
+				className={ `${ props.className }__video-container` }
+				hasAdvertisements={ props.paragraphs.length > 0 }
+			>
 				<YouTubeVideo
 					src={ props.src }
-					title={ props.title } />
+					title={ props.title }
+				/>
 			</VideoContainer>
 			<VideoDescriptions className={ `${ props.className }__descriptions` }>
 				{ props.paragraphs.map( paragraph => {

--- a/composites/HelpCenter/views/VideoTutorial.js
+++ b/composites/HelpCenter/views/VideoTutorial.js
@@ -104,18 +104,20 @@ VideoDescriptionItem.defaultProps = {
  * @returns {ReactElement} The VideoTutorial component.
  */
 export default function VideoTutorial( props ) {
+	const hasParagraphs = props.paragraphs.length > 0;
+
 	return (
 		<VideoTutorialContainer className={ `${ props.className }__container` }>
 			<VideoContainer
 				className={ `${ props.className }__video-container` }
-				hasParagraphs={ props.paragraphs.length > 0 }
+				hasParagraphs={ hasParagraphs }
 			>
 				<YouTubeVideo
 					src={ props.src }
 					title={ props.title }
 				/>
 			</VideoContainer>
-			<VideoDescriptions className={ `${ props.className }__descriptions` }>
+			{ hasParagraphs && <VideoDescriptions className={ `${ props.className }__descriptions` }>
 				{ props.paragraphs.map( paragraph => {
 					return (
 						<VideoDescriptionItem className={ `${ props.className }__description` }
@@ -123,7 +125,7 @@ export default function VideoTutorial( props ) {
 							{ ...paragraph } />
 					);
 				} ) }
-			</VideoDescriptions>
+			</VideoDescriptions> }
 		</VideoTutorialContainer>
 	);
 }

--- a/composites/HelpCenter/views/VideoTutorial.js
+++ b/composites/HelpCenter/views/VideoTutorial.js
@@ -137,10 +137,11 @@ VideoTutorial.propTypes = {
 		PropTypes.shape(
 			VideoDescriptionItem.propTypes
 		)
-	).isRequired,
+	),
 	className: PropTypes.string,
 };
 
 VideoTutorial.defaultProps = {
 	className: "yoast-video-tutorial",
+	paragraphs: [],
 };

--- a/composites/HelpCenter/views/VideoTutorial.js
+++ b/composites/HelpCenter/views/VideoTutorial.js
@@ -15,7 +15,7 @@ const VideoTutorialContainer = styled.div`
 `;
 
 const VideoContainer = styled.div`
-	${ props => props.hasParagraphs ? "float: left;" : "margin: auto;" }
+	${ props => props.hasParagraphs ? "float: left;" : "margin: 0 auto;" }
 	width: ${ VIDEO_WIDTH };
 
 	@media screen and ( max-width: ${ breakpoints.tablet } ) {

--- a/composites/HelpCenter/views/VideoTutorial.js
+++ b/composites/HelpCenter/views/VideoTutorial.js
@@ -15,7 +15,7 @@ const VideoTutorialContainer = styled.div`
 `;
 
 const VideoContainer = styled.div`
-	${ props => props.hasAdvertisements ? "float: left;" : "margin: auto;" }
+	${ props => props.hasParagraphs ? "float: left;" : "margin: auto;" }
 	width: ${ VIDEO_WIDTH };
 
 	@media screen and ( max-width: ${ breakpoints.tablet } ) {
@@ -26,7 +26,7 @@ const VideoContainer = styled.div`
 `;
 
 VideoContainer.propTypes = {
-	hasAdvertisements: PropTypes.bool.isRequired,
+	hasParagraphs: PropTypes.bool.isRequired,
 };
 
 const VideoDescriptions = styled.div`
@@ -108,7 +108,7 @@ export default function VideoTutorial( props ) {
 		<VideoTutorialContainer className={ `${ props.className }__container` }>
 			<VideoContainer
 				className={ `${ props.className }__video-container` }
-				hasAdvertisements={ props.paragraphs.length > 0 }
+				hasParagraphs={ props.paragraphs.length > 0 }
 			>
 				<YouTubeVideo
 					src={ props.src }

--- a/composites/HelpCenter/views/tests/VideoTutorialTest.js
+++ b/composites/HelpCenter/views/tests/VideoTutorialTest.js
@@ -27,3 +27,15 @@ test( "the VideoTutorial component matches the snapshot", () => {
 	let tree = component.toJSON();
 	expect( tree ).toMatchSnapshot();
 } );
+
+test( "the VideoTutorial component without paragraphs matches the snapshot", () => {
+	const component = createComponentWithIntl(
+		<VideoTutorial
+			src="https://www.youtube.com/embed/bIgcj_pPIbw"
+			title="Video title"
+		/>
+	);
+
+	let tree = component.toJSON();
+	expect( tree ).toMatchSnapshot();
+} );

--- a/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
+++ b/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
@@ -179,7 +179,7 @@ exports[`the VideoTutorial component without paragraphs matches the snapshot 1`]
 }
 
 .c1 {
-  margin: auto;
+  margin: 0 auto;
   width: 560px;
 }
 

--- a/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
+++ b/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
@@ -157,3 +157,58 @@ exports[`the VideoTutorial component matches the snapshot 1`] = `
   </div>
 </div>
 `;
+
+exports[`the VideoTutorial component without paragraphs matches the snapshot 1`] = `
+.c2 {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+}
+
+.c2 iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.c0 {
+  overflow: hidden;
+}
+
+.c1 {
+  margin: auto;
+  width: 560px;
+}
+
+@media screen and ( max-width:1224px ) {
+  .c1 {
+    float: none;
+    max-width: 100%;
+    margin: 0 auto;
+  }
+}
+
+<div
+  className="yoast-video-tutorial__container c0"
+>
+  <div
+    className="yoast-video-tutorial__video-container c1"
+  >
+    <div
+      className="c2"
+    >
+      <iframe
+        allowFullScreen={true}
+        frameBorder={0}
+        height={315}
+        src="https://www.youtube.com/embed/bIgcj_pPIbw"
+        title="Video title"
+        width={560}
+      />
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes alignment of video in help center when no ads are present.

## Relevant technical choices:

* Added a prop based on VideoContainer determining whether or not there are ads present. 

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch.
* Run `yarn install` on this branch.
* Link this branch to WordPress SEO Premium. ( run`yarn link` in this branch, and run `yarn link yoast-components` in wordpress-seo-premium.
* Go to the help center, first tab: "Video Tutorial" and see that the video is now correctly aligned in the center. 
* Follow the same steps for WordPress SEO to make sure the alignment is still to the left and allows space for advertisements on the right side. 

Fixes #[10106](https://github.com/Yoast/wordpress-seo/issues/10106)
