### PR TITLE
Add ThemeProvider to pass a language direction prop to the editor example

### DIFF
--- a/app/SnippetEditorExample.js
+++ b/app/SnippetEditorExample.js
@@ -1,6 +1,6 @@
 // External dependencies.
 import React, { Component } from "react";
-import styled from "styled-components";
+import styled, { ThemeProvider } from "styled-components";
 import debounce from "lodash/debounce";
 import MetaDescriptionLengthAssessment from "yoastseo/js/assessments/seo/metaDescriptionLengthAssessment";
 
@@ -11,6 +11,10 @@ const Container = styled.div`
 	background-color: white;
 	margin: 5em auto 0;
 	padding: 0 0 10px;
+`;
+
+const LanguageDirectionContainer = styled.div`
+	text-align: center;
 `;
 
 const replacementVariables = [
@@ -88,9 +92,11 @@ export default class SnippetEditorExample extends Component {
 			isOpen: false,
 			currentTitleLength: 0,
 			currentDescriptionLength: 0,
+			isRtl: false,
 		};
 
 		this.onChangedData = debounce( this.onChangedData.bind( this ), 150 );
+		this.changeLanguageDirection = this.changeLanguageDirection.bind( this );
 	}
 
 	/**
@@ -134,6 +140,32 @@ export default class SnippetEditorExample extends Component {
 	}
 
 	/**
+	 * Renders a switch language directionality button.
+	 *
+	 * @param {string} key The key for this data.
+	 *
+	 * @returns {ReactElement} The rendered button.
+	 */
+	renderLanguageDirectionButton() {
+		return (
+			<button type="button" onClick={ this.changeLanguageDirection }>
+				Change Editor language direction
+			</button>
+		);
+	}
+
+	/**
+	 * Changes the language direction state.
+	 *
+	 * @returns {void}
+	 */
+	changeLanguageDirection() {
+		this.setState( {
+			isRtl: ! this.state.isRtl,
+		} );
+	}
+
+	/**
 	 * Renders an example of how to use the snippet editor.
 	 *
 	 * @returns {ReactElement} The rendered snippet editor.
@@ -158,17 +190,24 @@ export default class SnippetEditorExample extends Component {
 			score: this.state.currentDescriptionLength > 120 ? 9 : 3,
 		};
 
-		return <Container>
-			<SnippetEditor
-				{ ...this.state }
-				data={ data }
-				baseUrl="https://local.wordpress.test/"
-				onChange={ this.onChangedData }
-				replacementVariables={ replacementVariables }
-				recommendedReplacementVariables={ recommendedReplacementVariables }
-				titleLengthProgress={ titleLengthProgress }
-				descriptionLengthProgress={ descriptionLengthProgress }
-			/>
-		</Container>;
+		return <ThemeProvider theme={ { isRtl: this.state.isRtl } }>
+			<React.Fragment>
+				<LanguageDirectionContainer>
+					{ this.renderLanguageDirectionButton() }
+				</LanguageDirectionContainer>
+				<Container>
+					<SnippetEditor
+						{ ...this.state }
+						data={ data }
+						baseUrl="https://local.wordpress.test/"
+						onChange={ this.onChangedData }
+						replacementVariables={ replacementVariables }
+						recommendedReplacementVariables={ recommendedReplacementVariables }
+						titleLengthProgress={ titleLengthProgress }
+						descriptionLengthProgress={ descriptionLengthProgress }
+					/>
+				</Container>
+			</React.Fragment>
+		</ThemeProvider>;
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an error in the snippet editor standalone example

## Relevant technical choices:

- uses ThemeProvider to pass a theme prop with a proper `isRtl` setting
- `isRtl` is handled in the state
- adds a button to switch language direction in the editor, thought this was a nice-to-have for testing

Notes:
- the language switch is not immediately applied to the replacement variable editors, not sure why; there's the need to click on them or click the preview elements to trigger the re-rendering
- consider this switches the language just on the draft.js editors and for components that use the state `isRtl` property; for a proper, full, language direction switch many other things are needed for example setting a `dir` attribute on the document
- for the future: maybe consider to extend the language switch to all the examples, I guess the components will support more and more RTL languages and this would help in testing

## Test instructions

- yarn start and go to localhost:3333
- in the snippet preview tab, click on the "Edit snippet" button and verify the editor opens without errors
- click the "Change Editor language direction" then click the editors and check the text directionality changes
- note: a few other elements in the page are affected by the language directionality switch, some of them (button icons) should be addressed separately

Fixes #663 
