### PR TITLE
Expose makeOutboundLink for UpsellBox in wpseo

### DIFF
--- a/composites/LinkSuggestions/LinkSuggestions.js
+++ b/composites/LinkSuggestions/LinkSuggestions.js
@@ -4,7 +4,7 @@ import LinkSuggestion from "./composites/LinkSuggestion";
 import Clipboard from "clipboard";
 import { localize } from "../../utils/i18n";
 import interpolateComponents from "interpolate-components";
-import a11ySpeak from "a11y-speak";
+import { speak } from "@wordpress/a11y";
 
 /**
  * Represents the Suggestions component.
@@ -43,7 +43,7 @@ class LinkSuggestions extends React.Component {
 		// Update the button `data-label` attribute.
 		evt.trigger.setAttribute( "data-label", message );
 		// Send audible message to the ARIA live region.
-		a11ySpeak( message, "assertive" );
+		speak( message, "assertive" );
 	}
 
 	/**
@@ -60,7 +60,7 @@ class LinkSuggestions extends React.Component {
 		// Update the button `data-label` attribute.
 		evt.trigger.setAttribute( "data-label", message );
 		// Send audible message to the ARIA live region.
-		a11ySpeak( message, "assertive" );
+		speak( message, "assertive" );
 	}
 
 	/**

--- a/index.js
+++ b/index.js
@@ -17,4 +17,5 @@ export {
 export * from "./composites/Plugin/SnippetPreview";
 export * from "./composites/Plugin/SnippetEditor";
 export * from "./forms";
+export { default as utils } from "./utils";
 export { getRtlStyle } from "./utils/helpers/styled-components";

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "author": "Yoast",
   "license": "GPL-3.0",
   "dependencies": {
-    "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#master",
     "@wordpress/a11y": "^1.0.7",
     "@wordpress/i18n": "^1.1.0",
     "algoliasearch": "^3.22.3",

--- a/package.json
+++ b/package.json
@@ -43,9 +43,11 @@
   "author": "Yoast",
   "license": "GPL-3.0",
   "dependencies": {
+    "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#master",
     "@wordpress/a11y": "^1.0.7",
     "@wordpress/i18n": "^1.1.0",
     "algoliasearch": "^3.22.3",
+    "clipboard": "^1.5.15",
     "debug": "^3.0.0",
     "draft-js": "^0.10.5",
     "draft-js-mention-plugin": "^3.0.4",

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,5 @@
+import { makeOutboundLink } from "./makeOutboundLink";
+
+export default {
+	makeOutboundLink,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,6 +140,10 @@
     lodash "^4.17.5"
     memize "^1.0.5"
 
+"a11y-speak@git+https://github.com/Yoast/a11y-speak.git#master":
+  version "0.0.1"
+  resolved "git+https://github.com/Yoast/a11y-speak.git#4e772809a2fed1a54ba29176ada175b15436e977"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -1752,6 +1756,14 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
+clipboard@^1.5.15:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.7.1.tgz#360d6d6946e99a7a1fef395e42ba92b5e9b5a16b"
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -2311,6 +2323,10 @@ del@^3.0.0:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -3573,6 +3589,12 @@ globule@^1.0.0:
     glob "~7.1.1"
     lodash "~4.17.4"
     minimatch "~3.0.2"
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  dependencies:
+    delegate "^3.1.2"
 
 got@^7.0.0:
   version "7.1.0"
@@ -7626,6 +7648,10 @@ select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
 
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+
 selfsigned@^1.9.1:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.3.tgz#d628ecf9e3735f84e8bafba936b3cf85bea43823"
@@ -8292,6 +8318,10 @@ timers-browserify@^2.0.4:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-emitter@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
 
 tmp@^0.0.33:
   version "0.0.33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,10 +140,6 @@
     lodash "^4.17.5"
     memize "^1.0.5"
 
-"a11y-speak@git+https://github.com/Yoast/a11y-speak.git#master":
-  version "0.0.1"
-  resolved "git+https://github.com/Yoast/a11y-speak.git#4e772809a2fed1a54ba29176ada175b15436e977"
-
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* We now expose makeOutboundLink, inside a utils object.
* Added `Clipboard` and `a11y-speak` to the `package.json` because tests were failing.

## Relevant technical choices:

* We needed makeOutboundLink() in wordpress-seo, but were asked by @atimmer to not use paths when importing. Thus, we needed to expose makeOutboundLink in a `utils/index.js` file.

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch and verify that all tests succeed, also when linking to wordpress-seo.

Fixes #661 
