### PR TITLE
Extract yoast input field

### DIFF
--- a/app/KeywordExample.js
+++ b/app/KeywordExample.js
@@ -7,6 +7,7 @@ import KeywordInput from "../composites/Plugin/Shared/components/KeywordInput";
 import SynonymsSection from "../composites/Plugin/Synonyms/components/SynonymsSection";
 import HelpText from "../composites/Plugin/Shared/components/HelpText.js";
 import { makeOutboundLink } from "../utils/makeOutboundLink";
+import SynonymsInput from "../composites/Plugin/Shared/components/SynonymsInput";
 
 const HelpTextLink = makeOutboundLink();
 
@@ -85,6 +86,15 @@ export default class KeywordExample extends Component {
 					label={ "Focus keyword"}
 					onChange={ this.updateKeyword }
 					keyword={ this.state.keyword }
+				/>
+				<SynonymsInput
+					showLabel={ true }
+					label={ "Synonyms:" }
+					onChange={ ( event ) => {
+						console.log( "You typed: " + event.target.value );
+					} }
+					value={ "" }
+					explanationText={ "This is a fine explanation" }
 				/>
 
 				<SynonymsSection

--- a/app/KeywordExample.js
+++ b/app/KeywordExample.js
@@ -39,6 +39,7 @@ export default class KeywordExample extends Component {
 
 		this.updateKeyword = this.updateKeyword.bind( this );
 		this.updateSynonyms = this.updateSynonyms.bind( this );
+		this.updateSynonymsInput = this.updateSynonymsInput.bind( this );
 	}
 
 	/**
@@ -68,6 +69,19 @@ export default class KeywordExample extends Component {
 	}
 
 	/**
+	 * Updates the synonyms.
+	 *
+	 * @param {object} event The new synonyms.
+	 *
+	 * @returns {void}
+	 */
+	updateSynonymsInput( event ) {
+		this.setState( {
+			synonyms: event.target.value,
+		} );
+	}
+
+	/**
 	 * Renders an example of how to use the keyword input.
 	 *
 	 * @returns {ReactElement} The rendered keyword input.
@@ -90,10 +104,8 @@ export default class KeywordExample extends Component {
 				<SynonymsInput
 					showLabel={ true }
 					label={ "Synonyms:" }
-					onChange={ ( event ) => {
-						console.log( "You typed: " + event.target.value );
-					} }
-					value={ "" }
+					onChange={ this.updateSynonymsInput }
+					value={ this.state.synonyms }
 					explanationText={ "This is a fine explanation" }
 				/>
 

--- a/composites/Plugin/Shared/components/SynonymsInput.js
+++ b/composites/Plugin/Shared/components/SynonymsInput.js
@@ -37,7 +37,7 @@ SynonymsInput.propTypes = {
 };
 
 SynonymsInput.defaultProps = {
-	id: uniqueId( "yoast-input-" ),
+	id: uniqueId( "synonyms-input-" ),
 	label: "",
 	value: "",
 	explanationText: "",

--- a/composites/Plugin/Shared/components/SynonymsInput.js
+++ b/composites/Plugin/Shared/components/SynonymsInput.js
@@ -14,9 +14,9 @@ const SynonymsInput = ( { id, label, value, onChange, explanationText } ) => {
 			<YoastInputLabel htmlFor={ id }>
 				{ label }
 			</YoastInputLabel>
-			<ExplanationText>
+			{ explanationText !== "" && <ExplanationText>
 				{ explanationText }
-			</ExplanationText>
+			</ExplanationText> }
 			<YoastInputField
 				aria-label={ label }
 				type="text"

--- a/composites/Plugin/Shared/components/SynonymsInput.js
+++ b/composites/Plugin/Shared/components/SynonymsInput.js
@@ -1,0 +1,46 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import uniqueId from "lodash/uniqueId";
+import { YoastInputContainer, YoastInputField, YoastInputLabel } from "./YoastInput";
+
+const ExplanationText = styled.p`
+	font-size: .8em;
+`;
+
+const SynonymsInput = ( { id, label, value, onChange, explanationText } ) => {
+	return(
+		<YoastInputContainer>
+			<YoastInputLabel htmlFor={ id }>
+				{ label }
+			</YoastInputLabel>
+			<ExplanationText>
+				{ explanationText }
+			</ExplanationText>
+			<YoastInputField
+				aria-label={ label }
+				type="text"
+				id={ id }
+				onChange={ onChange }
+				value={ value }
+			/>
+		</YoastInputContainer>
+	);
+};
+
+SynonymsInput.propTypes = {
+	id: PropTypes.string,
+	label: PropTypes.string,
+	value: PropTypes.string,
+	onChange: PropTypes.func.isRequired,
+	explanationText: PropTypes.string,
+};
+
+SynonymsInput.defaultProps = {
+	id: uniqueId( "yoast-input-" ),
+	label: "",
+	value: "",
+	explanationText: "",
+};
+
+export default SynonymsInput;

--- a/composites/Plugin/Shared/components/YoastInput.js
+++ b/composites/Plugin/Shared/components/YoastInput.js
@@ -1,0 +1,56 @@
+// External dependencies.
+import React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import uniqueId from "lodash/uniqueId";
+
+// Internal dependencies.
+import colors from "../../../../style-guide/colors.json";
+
+const YoastInputLabel = styled.label`
+	font-size: 1em;
+	font-weight: bold;
+	margin-bottom: 0.5em;
+	display: block;
+`;
+
+const YoastInputField = styled.input`
+	border: 3px solid ${ colors.$color_input_border };
+	padding: 0.75em;
+	font-size: 1em;
+`;
+
+const YoastInput = ( { id, label, showLabel, value, onChange } ) => {
+	return(
+		<React.Fragment>
+			{ showLabel && label !== "" &&
+				<YoastInputLabel htmlFor={ id }>
+					{ label }
+				</YoastInputLabel> }
+			<YoastInputField
+				aria-label={ showLabel ? null : label }
+				type="text"
+				id={ id }
+				onChange={ onChange }
+				value={ value }
+			/>
+		</React.Fragment>
+	);
+};
+
+YoastInput.propTypes = {
+	id: PropTypes.string,
+	label: PropTypes.string,
+	showLabel: PropTypes.bool,
+	value: PropTypes.string,
+	onChange: PropTypes.func.isRequired,
+};
+
+YoastInput.defaultProps = {
+	id: uniqueId( "yoast-input-" ),
+	showLabel: true,
+	label: "",
+	value: "",
+};
+
+export default YoastInput;

--- a/composites/Plugin/Shared/components/YoastInput.js
+++ b/composites/Plugin/Shared/components/YoastInput.js
@@ -1,5 +1,4 @@
 // External dependencies.
-import React from "react";
 import styled from "styled-components";
 
 // Internal dependencies.

--- a/composites/Plugin/Shared/components/YoastInput.js
+++ b/composites/Plugin/Shared/components/YoastInput.js
@@ -1,56 +1,25 @@
 // External dependencies.
 import React from "react";
 import styled from "styled-components";
-import PropTypes from "prop-types";
-import uniqueId from "lodash/uniqueId";
 
 // Internal dependencies.
 import colors from "../../../../style-guide/colors.json";
 
-const YoastInputLabel = styled.label`
+export const YoastInputContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	margin: 1em 0;
+`;
+
+export const YoastInputLabel = styled.label`
 	font-size: 1em;
 	font-weight: bold;
 	margin-bottom: 0.5em;
 	display: block;
 `;
 
-const YoastInputField = styled.input`
+export const YoastInputField = styled.input`
 	border: 3px solid ${ colors.$color_input_border };
 	padding: 0.75em;
 	font-size: 1em;
 `;
-
-const YoastInput = ( { id, label, showLabel, value, onChange } ) => {
-	return(
-		<React.Fragment>
-			{ showLabel && label !== "" &&
-				<YoastInputLabel htmlFor={ id }>
-					{ label }
-				</YoastInputLabel> }
-			<YoastInputField
-				aria-label={ showLabel ? null : label }
-				type="text"
-				id={ id }
-				onChange={ onChange }
-				value={ value }
-			/>
-		</React.Fragment>
-	);
-};
-
-YoastInput.propTypes = {
-	id: PropTypes.string,
-	label: PropTypes.string,
-	showLabel: PropTypes.bool,
-	value: PropTypes.string,
-	onChange: PropTypes.func.isRequired,
-};
-
-YoastInput.defaultProps = {
-	id: uniqueId( "yoast-input-" ),
-	showLabel: true,
-	label: "",
-	value: "",
-};
-
-export default YoastInput;

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import { default as KeywordSuggestions } from "./composites/KeywordSuggestions/K
 import { default as LanguageNotice } from "./composites/Plugin/Shared/components/LanguageNotice";
 import { default as ContentAnalysis } from "./composites/Plugin/ContentAnalysis/components/ContentAnalysis";
 import { default as Collapsible } from "./composites/Plugin/Shared/components/Collapsible";
+import { default as YoastInput } from "./composites/Plugin/Shared/components/YoastInput";
 
 export {
 	OnboardingWizard,
@@ -18,6 +19,7 @@ export {
 	LanguageNotice,
 	ContentAnalysis,
 	Collapsible,
+	YoastInput,
 };
 
 export * from "./composites/Plugin/SnippetPreview";

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import { default as KeywordSuggestions } from "./composites/KeywordSuggestions/K
 import { default as LanguageNotice } from "./composites/Plugin/Shared/components/LanguageNotice";
 import { default as ContentAnalysis } from "./composites/Plugin/ContentAnalysis/components/ContentAnalysis";
 import { default as Collapsible } from "./composites/Plugin/Shared/components/Collapsible";
-import { default as YoastInput } from "./composites/Plugin/Shared/components/YoastInput";
+import { default as SynonymsInput } from "./composites/Plugin/Shared/components/SynonymsInput";
 
 export {
 	OnboardingWizard,
@@ -19,7 +19,7 @@ export {
 	LanguageNotice,
 	ContentAnalysis,
 	Collapsible,
-	YoastInput,
+	SynonymsInput,
 };
 
 export * from "./composites/Plugin/SnippetPreview";


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* SynonymsInput field now looks similar to the `KeywordInput`, and can have an explaniontext below the label.

## Relevant technical choices:

* Needed to reuse the KeywordInput for the SynonymsInput, but found it was too specific. So we extracted some stuff and created a new SynonymsInput from the extracted components. This does not affect the existing inputs.

## Test instructions

This PR can be tested by following these steps:

* Checkout branch, and run `yarn start`.
* Verify in the examples (under "Keyword") that the new SynonymsInput functions and looks as expected: it should have a label, a text below the label, and a functioning input field.

Connects https://github.com/Yoast/yoast-components/issues/660
