### PR TITLE
Add all imports needed by wordpress seo to the export file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ import { default as LanguageNotice } from "./composites/Plugin/Shared/components
 import { default as YoastButton } from "./composites/Plugin/Shared/components/YoastButton";
 import { default as YoastModal } from "./composites/Plugin/Shared/components/YoastModal";
 import { default as SvgIcon } from "./composites/Plugin/Shared/components/SvgIcon";
+import { default as SynonymsInput } from "./composites/Plugin/Shared/components/SynonymsInput";
 import { default as Collabsible } from ".//composites/Plugin/shared/components/Collapsible";
 import { default as ContentAnalysis } from "./composites/Plugin/ContentAnalysis/components/ContentAnalysis";
 import { default as HelpCenter } from "./composites/Plugin/HelpCenter/HelpCenter.js";
@@ -35,6 +36,7 @@ export {
 	LanguageNotice,
 	ContentAnalysis,
 	Collapsible,
+	SynonymsInput,
 	LoadingIndicator,
 	ScoreAssessment,
 	YoastButton,

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ export {
 	Loader,
 	Synonyms,
 	Collabsible,
-}
+};
 
 export * from "./composites/Plugin/SnippetPreview";
 export * from "./composites/Plugin/SnippetEditor";

--- a/index.js
+++ b/index.js
@@ -1,12 +1,29 @@
+/*
+ * Composites imports.
+ */
+// Composites/OnboardingWizard imports.
 import { default as OnboardingWizard } from "./composites/OnboardingWizard/OnboardingWizard";
-import { default as AlgoliaSearcher } from "./composites/AlgoliaSearch/AlgoliaSearcher";
-import { default as HelpCenter } from "./composites/Plugin/HelpCenter/HelpCenter.js";
 import { default as MessageBox } from "./composites/OnboardingWizard/MessageBox";
-import { default as LinkSuggestions } from "./composites/LinkSuggestions/LinkSuggestions";
-import { default as KeywordSuggestions } from "./composites/KeywordSuggestions/KeywordSuggestions";
-import { default as LanguageNotice } from "./composites/Plugin/Shared/components/LanguageNotice";
-import { default as ContentAnalysis } from "./composites/Plugin/ContentAnalysis/components/ContentAnalysis";
+import { default as LoadingIndicator } from "./composites/OnboardingWizard/LoadingIndicator";
+// Composites/AngoliaSearch imports.
+import { default as AlgoliaSearcher } from "./composites/AlgoliaSearch/AlgoliaSearcher";
+// Composites/Plugin imports.
+import { default as ScoreAssessment } from "./composites/Plugin/Shared/components/ScoreAssessments";
 import { default as Collapsible } from "./composites/Plugin/Shared/components/Collapsible";
+import { default as LanguageNotice } from "./composites/Plugin/Shared/components/LanguageNotice";
+import { default as YoastButton } from "./composites/Plugin/Shared/components/YoastButton";
+import { default as YoastModal } from "./composites/Plugin/Shared/components/YoastModal";
+import { default as SvgIcon } from "./composites/Plugin/Shared/components/SvgIcon";
+import { default as Collabsible } from ".//composites/Plugin/shared/components/Collapsible";
+import { default as ContentAnalysis } from "./composites/Plugin/ContentAnalysis/components/ContentAnalysis";
+import { default as HelpCenter } from "./composites/Plugin/HelpCenter/HelpCenter.js";
+import { default as Synonyms } from "./composites/Plugin/Synonyms/actions/synonyms";
+// Composites/LinkSuggestions imports.
+import { default as LinkSuggestions } from "./composites/LinkSuggestions/LinkSuggestions";
+// Composites/KeywordSuggestions imports.
+import { default as KeywordSuggestions } from "./composites/KeywordSuggestions/KeywordSuggestions";
+// Composites/basic imports.
+import { default as Loader } from "./yoast-components/composites/basic/Loader";
 
 export {
 	OnboardingWizard,
@@ -18,10 +35,29 @@ export {
 	LanguageNotice,
 	ContentAnalysis,
 	Collapsible,
+	LoadingIndicator,
+	ScoreAssessment,
+	YoastButton,
+	YoastModal,
+	SvgIcon,
+	Loader,
+	Synonyms,
+	Collabsible,
 };
 
 export * from "./composites/Plugin/SnippetPreview";
 export * from "./composites/Plugin/SnippetEditor";
+export * from "./composites/Plugin/Synonyms/";
+export * from "./composites/Plugin/ContentAnalysis";
 export * from "./forms";
+export * from "./redux";
+export StyledSection from "./forms/StyledSection";
+export { default as colors } from "./style-guide/colors.json";
 export { default as utils } from "./utils";
 export { getRtlStyle } from "./utils/helpers/styled-components";
+export { localize } from "./utils/i18n";
+export { setTranslations } from "./utils/i18n";
+export { translate } from "./utils/i18n";
+export { default as OnboardingWizardHelper } from "./composites/OnboardingWizard/helpers/";
+export * from "./composites/Plugin/DashboardWidget";
+


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Exposes all exports needed by wordpress seo to the export file.

## Relevant technical choices:

* Adding all exports in the main `index.js` since the directory format is somewhat weird

## Test instructions

This PR can be tested by following these steps:

* Use the library in the plugin and make sure the added exports work as expected.

Needed for: https://github.com/Yoast/wordpress-seo/issues/10478
