### PR TITLE
Styling improvements

### DIFF
--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -153,7 +153,7 @@ class ContentAnalysis extends React.Component {
 				prefixIconCollapsed={ { icon: "angle-down", color: colors.$color_grey_dark, size: "18px" } }
 				suffixIcon={ null }
 				suffixIconCollapsed={ null }
-				headingLevel={ headingLevel }
+				headingProps={ { level: headingLevel, fontSize: "13px", fontWeight: "bold" } }
 			>
 				<AnalysisList role="list">{ this.getResults( results ) }</AnalysisList>
 			</StyledCollapsible>

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -13,7 +13,6 @@ export const ContentAnalysisContainer = styled.div`
 	width: 100%;
 	background-color: white;
 	max-width: 800px;
-	margin: 0 auto;
 	border-bottom: 1px solid transparent; // Avoid parent and child margin collapsing.
 `;
 

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -25,14 +25,14 @@ const StyledCollapsible = styled( Collapsible )`
 	}
 
 	${ StyledIconsButton } {
-		padding: 8px 16px;
+		padding: 8px 0;
 		color: ${ colors.$color_blue }
 	}
 `;
 
 const AnalysisList = styled.ul`
-	margin: 0;
-	padding: 8px 16px;
+	margin: 8px 0;
+	padding: 0;
 	list-style: none;
 `;
 

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -182,7 +182,6 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
   width: 100%;
   background-color: white;
   max-width: 800px;
-  margin: 0 auto;
   border-bottom: 1px solid transparent;
 }
 
@@ -812,7 +811,6 @@ exports[`ContentAnalysis the ContentAnalysis component with hidden buttons match
   width: 100%;
   background-color: white;
   max-width: 800px;
-  margin: 0 auto;
   border-bottom: 1px solid transparent;
 }
 
@@ -1418,7 +1416,6 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
   width: 100%;
   background-color: white;
   max-width: 800px;
-  margin: 0 auto;
   border-bottom: 1px solid transparent;
 }
 
@@ -2072,7 +2069,6 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
   width: 100%;
   background-color: white;
   max-width: 800px;
-  margin: 0 auto;
   border-bottom: 1px solid transparent;
 }
 
@@ -2726,7 +2722,6 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and cons
   width: 100%;
   background-color: white;
   max-width: 800px;
-  margin: 0 auto;
   border-bottom: 1px solid transparent;
 }
 
@@ -3218,7 +3213,6 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and impr
   width: 100%;
   background-color: white;
   max-width: 800px;
-  margin: 0 auto;
   border-bottom: 1px solid transparent;
 }
 
@@ -3710,7 +3704,6 @@ exports[`ContentAnalysis the ContentAnalysis component without problems matches 
   width: 100%;
   background-color: white;
   max-width: 800px;
-  margin: 0 auto;
   border-bottom: 1px solid transparent;
 }
 
@@ -4271,7 +4264,6 @@ exports[`ContentAnalysis the ContentAnalysis component without problems, improve
   width: 100%;
   background-color: white;
   max-width: 800px;
-  margin: 0 auto;
   border-bottom: 1px solid transparent;
 }
 

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -169,12 +169,13 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c3 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 13px !important;
+  font-weight: bold !important;
 }
 
 .c0 {
@@ -194,13 +195,13 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
 }
 
 .c1 .c4 {
-  padding: 8px 16px;
+  padding: 8px 0;
   color: #0066cd;
 }
 
 .c15 {
-  margin: 0;
-  padding: 8px 16px;
+  margin: 8px 0;
+  padding: 0;
   list-style: none;
 }
 
@@ -798,12 +799,13 @@ exports[`ContentAnalysis the ContentAnalysis component with hidden buttons match
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c3 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 13px !important;
+  font-weight: bold !important;
 }
 
 .c0 {
@@ -823,13 +825,13 @@ exports[`ContentAnalysis the ContentAnalysis component with hidden buttons match
 }
 
 .c1 .c4 {
-  padding: 8px 16px;
+  padding: 8px 0;
   color: #0066cd;
 }
 
 .c15 {
-  margin: 0;
-  padding: 8px 16px;
+  margin: 8px 0;
+  padding: 0;
   list-style: none;
 }
 
@@ -1403,12 +1405,13 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c3 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 13px !important;
+  font-weight: bold !important;
 }
 
 .c0 {
@@ -1428,13 +1431,13 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
 }
 
 .c1 .c4 {
-  padding: 8px 16px;
+  padding: 8px 0;
   color: #0066cd;
 }
 
 .c15 {
-  margin: 0;
-  padding: 8px 16px;
+  margin: 8px 0;
+  padding: 0;
   list-style: none;
 }
 
@@ -2056,12 +2059,13 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c3 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 13px !important;
+  font-weight: bold !important;
 }
 
 .c0 {
@@ -2081,13 +2085,13 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
 }
 
 .c1 .c4 {
-  padding: 8px 16px;
+  padding: 8px 0;
   color: #0066cd;
 }
 
 .c15 {
-  margin: 0;
-  padding: 8px 16px;
+  margin: 8px 0;
+  padding: 0;
   list-style: none;
 }
 
@@ -2709,12 +2713,13 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and cons
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c3 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 13px !important;
+  font-weight: bold !important;
 }
 
 .c0 {
@@ -2734,13 +2739,13 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and cons
 }
 
 .c1 .c4 {
-  padding: 8px 16px;
+  padding: 8px 0;
   color: #0066cd;
 }
 
 .c15 {
-  margin: 0;
-  padding: 8px 16px;
+  margin: 8px 0;
+  padding: 0;
   list-style: none;
 }
 
@@ -3200,12 +3205,13 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and impr
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c3 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 13px !important;
+  font-weight: bold !important;
 }
 
 .c0 {
@@ -3225,13 +3231,13 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and impr
 }
 
 .c1 .c4 {
-  padding: 8px 16px;
+  padding: 8px 0;
   color: #0066cd;
 }
 
 .c15 {
-  margin: 0;
-  padding: 8px 16px;
+  margin: 8px 0;
+  padding: 0;
   list-style: none;
 }
 
@@ -3691,12 +3697,13 @@ exports[`ContentAnalysis the ContentAnalysis component without problems matches 
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c3 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 13px !important;
+  font-weight: bold !important;
 }
 
 .c0 {
@@ -3716,13 +3723,13 @@ exports[`ContentAnalysis the ContentAnalysis component without problems matches 
 }
 
 .c1 .c4 {
-  padding: 8px 16px;
+  padding: 8px 0;
   color: #0066cd;
 }
 
 .c15 {
-  margin: 0;
-  padding: 8px 16px;
+  margin: 8px 0;
+  padding: 0;
   list-style: none;
 }
 
@@ -4251,12 +4258,13 @@ exports[`ContentAnalysis the ContentAnalysis component without problems, improve
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c3 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 13px !important;
+  font-weight: bold !important;
 }
 
 .c0 {
@@ -4276,13 +4284,13 @@ exports[`ContentAnalysis the ContentAnalysis component without problems, improve
 }
 
 .c1 .c4 {
-  padding: 8px 16px;
+  padding: 8px 0;
   color: #0066cd;
 }
 
 .c15 {
-  margin: 0;
-  padding: 8px 16px;
+  margin: 8px 0;
+  padding: 0;
   list-style: none;
 }
 

--- a/composites/Plugin/CornerstoneContent/components/CornerstoneToggle.js
+++ b/composites/Plugin/CornerstoneContent/components/CornerstoneToggle.js
@@ -12,8 +12,7 @@ const Cornerstone = styled.div`
 
 	label { 
 		margin-right: 10px;
-		flex-shrink: 0;
-		max-width: 75%;
+		flex: 1;
 	}
 `;
 

--- a/composites/Plugin/CornerstoneContent/tests/__snapshots__/CornerstoneToggleTest.js.snap
+++ b/composites/Plugin/CornerstoneContent/tests/__snapshots__/CornerstoneToggleTest.js.snap
@@ -41,6 +41,7 @@ exports[`The CornerstoneToggle matches the snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  width: 100%;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -69,10 +70,9 @@ exports[`The CornerstoneToggle matches the snapshot 1`] = `
 
 .c0 label {
   margin-right: 10px;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: 75%;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 <div

--- a/composites/Plugin/Shared/components/Collapsible.js
+++ b/composites/Plugin/Shared/components/Collapsible.js
@@ -7,8 +7,19 @@ import colors from "../../../../style-guide/colors.json";
 import { IconsButton } from "../../Shared/components/Button";
 import ScreenReaderText from "../../../../a11y/ScreenReaderText";
 
+const Content = styled.div`
+	padding: 0 16px;
+	margin-bottom: 16px;
+`;
+
 const StyledContainer = styled.div`
 	background-color: ${ colors.$color_white };
+`;
+
+const StyledContainerTopLevel = styled( StyledContainer )`
+	border-top: 1px solid ${ colors.$palette_grey_light };
+	border-bottom: 1px solid ${ colors.$palette_grey_light };
+	margin-top: -1px;
 `;
 
 export const StyledIconsButton = styled( IconsButton )`
@@ -75,7 +86,8 @@ const StyledSubTitle = styled.span`
 export function wrapInHeading( Component, headingLevel ) {
 	const Heading = `h${ headingLevel }`;
 	const StyledHeading = styled( Heading )`
-		margin: 0;
+		margin: 0 !important;
+		padding: 0 !important;
 		font-weight: normal;
 	`;
 
@@ -98,6 +110,8 @@ const StyledHeading = wrapInHeading( StyledIconsButton, 2 );
  * @param {string}      props.className             The name of the collapsible CSS class.
  * @param {IconsButton} props.Heading               Heading button. May be wrapped or styled or both.
  * @param {boolean}     props.isOpen                True displays the children. False means collapsed.
+ * @param {boolean}     props.hasPadding            True adds padding to the content. False means no padding.
+ * @param {boolean}     props.hasSeparator          True displays borders around the section. False means no borders.
  * @param {function}    props.onToggle              Function to handle the Heading click event.
  * @param {object}      props.prefixIcon            Heading icon before the title.
  * @param {object}      props.prefixIconCollapsed   Prefix icon when in collapsed state.
@@ -110,8 +124,14 @@ const StyledHeading = wrapInHeading( StyledIconsButton, 2 );
  * @returns {ReactElement} A collapsible panel.
  */
 export const CollapsibleStateless = ( props ) => {
+	let children = null;
+	if ( props.isOpen ) {
+		children = ( props.hasPadding ) ? <Content>{props.children}</Content> : props.children;
+	}
+	const Container = ( props.hasSeparator ) ? StyledContainerTopLevel : StyledContainer;
+
 	return (
-		<StyledContainer
+		<Container
 			// Pass the classname to allow re-styling with styled-components.
 			className={ props.className }
 		>
@@ -130,8 +150,8 @@ export const CollapsibleStateless = ( props ) => {
 					{ props.subTitle && <StyledSubTitle>{ props.subTitle }</StyledSubTitle> }
 				</StyledTitleContainer>
 			</props.Heading>
-			{ props.isOpen && props.children }
-		</StyledContainer>
+			{ children }
+		</Container>
 	);
 };
 
@@ -307,6 +327,8 @@ Collapsible.propTypes = {
 
 Collapsible.defaultProps = {
 	headingLevel: 2,
+	hasSeparator: false,
+	hasPadding: false,
 	initialIsOpen: false,
 	prefixIcon: null,
 	prefixIconCollapsed: null,

--- a/composites/Plugin/Shared/components/Collapsible.js
+++ b/composites/Plugin/Shared/components/Collapsible.js
@@ -78,10 +78,10 @@ const StyledSubTitle = styled.span`
  * Wraps a component in a heading element with a defined heading level.
  *
  * @param {ReactElement} Component        The component to wrap.
- * @param {object}       props            The heading props.
- * @param {boolean}      props.level      The heading level.
- * @param {boolean}      props.fontSize   The heading font-size.
- * @param {boolean}      props.fontWeight The heading font-weigth.
+ * @param {Object}       props            The heading props.
+ * @param {number}       props.level      The heading level.
+ * @param {string}       props.fontSize   The heading font-size.
+ * @param {string}       props.fontWeight The heading font-weight.
  *
  * @returns {Function} A function that will return the wrapped component with given properties.
  */
@@ -108,7 +108,7 @@ const StyledHeading = wrapInHeading( StyledIconsButton, { level: 2, fontSize: "1
 /**
  * Base collapsible panel. Optionally has a heading around the button.
  *
- * @param {object}      props                       The properties for the component.
+ * @param {Object}      props                       The properties for the component.
  * @param {children}    props.children              The content of the Collapsible.
  * @param {string}      props.className             The name of the collapsible CSS class.
  * @param {IconsButton} props.Heading               Heading button. May be wrapped or styled or both.
@@ -116,11 +116,11 @@ const StyledHeading = wrapInHeading( StyledIconsButton, { level: 2, fontSize: "1
  * @param {boolean}     props.hasPadding            True adds padding to the content. False means no padding.
  * @param {boolean}     props.hasSeparator          True displays borders around the section. False means no borders.
  * @param {function}    props.onToggle              Function to handle the Heading click event.
- * @param {object}      props.prefixIcon            Heading icon before the title.
- * @param {object}      props.prefixIconCollapsed   Prefix icon when in collapsed state.
+ * @param {Object}      props.prefixIcon            Heading icon before the title.
+ * @param {Object}      props.prefixIconCollapsed   Prefix icon when in collapsed state.
  * @param {string}      props.subTitle              Sub-title for the Heading.
- * @param {object}      props.suffixIcon            Heading icon after the title.
- * @param {object}      props.suffixIconCollapsed   Suffix icon when in collapsed state.
+ * @param {Object}      props.suffixIcon            Heading icon after the title.
+ * @param {Object}      props.suffixIconCollapsed   Suffix icon when in collapsed state.
  * @param {string}      props.title                 Title for the Heading.
  * @param {string}      props.titleScreenReaderText Chance for an extra text to feed to a screenreader.
  *
@@ -129,7 +129,7 @@ const StyledHeading = wrapInHeading( StyledIconsButton, { level: 2, fontSize: "1
 export const CollapsibleStateless = ( props ) => {
 	let children = null;
 	if ( props.isOpen ) {
-		children = ( props.hasPadding ) ? <Content>{props.children}</Content> : props.children;
+		children = ( props.hasPadding ) ? <Content>{ props.children }</Content> : props.children;
 	}
 	const Container = ( props.hasSeparator ) ? StyledContainerTopLevel : StyledContainer;
 
@@ -205,14 +205,14 @@ export class Collapsible extends React.Component {
 	/**
 	 * The constructor.
 	 *
-	 * @param {object}  props                       The properties for the component.
+	 * @param {Object}  props                       The properties for the component.
 	 * @param {string}  props.className             The name of the collapsible CSS class.
-	 * @param {object}  props.headingProps          Props to use in the Heading.
+	 * @param {Object}  props.headingProps          Props to use in the Heading.
 	 * @param {boolean} props.initialIsOpen         Determines if the initial isOpen state is open or closed.
-	 * @param {object}  props.prefixIcon            Heading icon before the title.
-	 * @param {object}  props.prefixIconCollapsed   Prefix icon when in collapsed state.
-	 * @param {object}  props.suffixIcon            Heading icon after the title.
-	 * @param {object}  props.suffixIconCollapsed   Suffix icon when in collapsed state.
+	 * @param {Object}  props.prefixIcon            Heading icon before the title.
+	 * @param {Object}  props.prefixIconCollapsed   Prefix icon when in collapsed state.
+	 * @param {Object}  props.suffixIcon            Heading icon after the title.
+	 * @param {Object}  props.suffixIconCollapsed   Suffix icon when in collapsed state.
 	 * @param {string}  props.title                 Title for in the Heading.
 	 * @param {string}  props.titleScreenReaderText Chance for an extra text to feed to a screenreader.
 	 *
@@ -265,7 +265,7 @@ export class Collapsible extends React.Component {
 	/**
 	 * Creates the header by wrapping the IconsButton with a header.
 	 *
-	 * @param {object} props The properties for the component.
+	 * @param {Object} props The properties for the component.
 	 *
 	 * @returns {ReactElement} The header to render.
 	 */

--- a/composites/Plugin/Shared/components/Collapsible.js
+++ b/composites/Plugin/Shared/components/Collapsible.js
@@ -63,7 +63,6 @@ const StyledTitle = styled.span`
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow-x: hidden;
-	font-size: 1rem;
 `;
 
 const StyledSubTitle = styled.span`
@@ -78,17 +77,21 @@ const StyledSubTitle = styled.span`
 /**
  * Wraps a component in a heading element with a defined heading level.
  *
- * @param {ReactElement} Component    The component to wrap.
- * @param {int}          headingLevel The heading level.
+ * @param {ReactElement} Component        The component to wrap.
+ * @param {object}       props            The heading props.
+ * @param {boolean}      props.level      The heading level.
+ * @param {boolean}      props.fontSize   The heading font-size.
+ * @param {boolean}      props.fontWeight The heading font-weigth.
  *
  * @returns {Function} A function that will return the wrapped component with given properties.
  */
-export function wrapInHeading( Component, headingLevel ) {
-	const Heading = `h${ headingLevel }`;
+export function wrapInHeading( Component, props ) {
+	const Heading = `h${ props.level }`;
 	const StyledHeading = styled( Heading )`
 		margin: 0 !important;
 		padding: 0 !important;
-		font-weight: normal;
+		font-size: ${ props.fontSize } !important;
+		font-weight: ${ props.fontWeight } !important;
 	`;
 
 	return function Wrapped( props ) {
@@ -100,7 +103,7 @@ export function wrapInHeading( Component, headingLevel ) {
 	};
 }
 
-const StyledHeading = wrapInHeading( StyledIconsButton, 2 );
+const StyledHeading = wrapInHeading( StyledIconsButton, { level: 2, fontSize: "1rem", fontWeight: "normal" } );
 
 /**
  * Base collapsible panel. Optionally has a heading around the button.
@@ -202,7 +205,7 @@ export class Collapsible extends React.Component {
 	 *
 	 * @param {object}  props                       The properties for the component.
 	 * @param {string}  props.className             The name of the collapsible CSS class.
-	 * @param {number}  props.headingLevel          Heading level: 1 for h1, 2 for h2, etc.
+	 * @param {object}  props.headingProps          Props to use in the Heading.
 	 * @param {boolean} props.initialIsOpen         Determines if the initial isOpen state is open or closed.
 	 * @param {object}  props.prefixIcon            Heading icon before the title.
 	 * @param {object}  props.prefixIconCollapsed   Prefix icon when in collapsed state.
@@ -237,9 +240,9 @@ export class Collapsible extends React.Component {
 	 * @returns {void}
 	 */
 	componentWillReceiveProps( nextProps ) {
-		const { headingLevel } = this.props;
+		const { level } = this.props.headingProps;
 
-		if ( nextProps.headingLevel !== headingLevel ) {
+		if ( nextProps.headingProps.level !== level ) {
 			this.Heading = Collapsible.getHeading( nextProps );
 		}
 	}
@@ -265,7 +268,7 @@ export class Collapsible extends React.Component {
 	 * @returns {ReactElement} The header to render.
 	 */
 	static getHeading( props ) {
-		return wrapInHeading( StyledIconsButton, props.headingLevel );
+		return wrapInHeading( StyledIconsButton, props.headingProps );
 	}
 
 	/**
@@ -298,7 +301,6 @@ Collapsible.propTypes = {
 		PropTypes.node,
 	] ),
 	className: PropTypes.string,
-	headingLevel: PropTypes.number,
 	initialIsOpen: PropTypes.bool,
 	prefixIcon: PropTypes.shape( {
 		icon: PropTypes.string,
@@ -323,10 +325,14 @@ Collapsible.propTypes = {
 	title: PropTypes.string.isRequired,
 	titleScreenReaderText: PropTypes.string,
 	subTitle: PropTypes.string,
+	headingProps: PropTypes.shape( {
+		level: PropTypes.number,
+		fontSize: PropTypes.string,
+		fontWeight: PropTypes.string,
+	} ),
 };
 
 Collapsible.defaultProps = {
-	headingLevel: 2,
 	hasSeparator: false,
 	hasPadding: false,
 	initialIsOpen: false,
@@ -341,6 +347,11 @@ Collapsible.defaultProps = {
 		icon: "arrow-down",
 		color: colors.$black,
 		size: "9px",
+	},
+	headingProps: {
+		level: 2,
+		fontSize: "1rem",
+		fontWeight: "normal",
 	},
 };
 

--- a/composites/Plugin/Shared/components/Collapsible.js
+++ b/composites/Plugin/Shared/components/Collapsible.js
@@ -166,6 +166,8 @@ CollapsibleStateless.propTypes = {
 	className: PropTypes.string,
 	Heading: PropTypes.func,
 	isOpen: PropTypes.bool.isRequired,
+	hasSeparator: PropTypes.bool,
+	hasPadding: PropTypes.bool,
 	onToggle: PropTypes.func.isRequired,
 	prefixIcon: PropTypes.shape( {
 		icon: PropTypes.string,
@@ -302,6 +304,8 @@ Collapsible.propTypes = {
 	] ),
 	className: PropTypes.string,
 	initialIsOpen: PropTypes.bool,
+	hasSeparator: PropTypes.bool,
+	hasPadding: PropTypes.bool,
 	prefixIcon: PropTypes.shape( {
 		icon: PropTypes.string,
 		color: PropTypes.string,

--- a/composites/Plugin/Shared/components/Toggle.js
+++ b/composites/Plugin/Shared/components/Toggle.js
@@ -40,6 +40,7 @@ const ToggleVisualLabel = styled.span`
 
 const ToggleDiv = styled.div`
 	display: flex;
+	width: 100%;
 	justify-content: space-between;
 	align-items: center;
 `;

--- a/composites/Plugin/Shared/tests/__snapshots__/CollapsibleTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/CollapsibleTest.js.snap
@@ -121,12 +121,13 @@ exports[`Collapsible matches the snapshot by default 1`] = `
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c1 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 1rem !important;
+  font-weight: normal !important;
 }
 
 .c11 {
@@ -306,12 +307,13 @@ exports[`Collapsible matches the snapshot by default 2`] = `
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c1 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 1rem !important;
+  font-weight: normal !important;
 }
 
 .c11 {
@@ -503,12 +505,13 @@ exports[`Collapsible matches the snapshot when it is closed 1`] = `
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c1 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 1rem !important;
+  font-weight: normal !important;
 }
 
 .c11 {
@@ -688,12 +691,13 @@ exports[`Collapsible matches the snapshot when it is closed 2`] = `
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c1 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 1rem !important;
+  font-weight: normal !important;
 }
 
 .c11 {
@@ -885,12 +889,13 @@ exports[`Collapsible matches the snapshot when it is open 1`] = `
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c1 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 1rem !important;
+  font-weight: normal !important;
 }
 
 .c11 {
@@ -1082,12 +1087,13 @@ exports[`Collapsible matches the snapshot when it is open 2`] = `
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c1 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 1rem !important;
+  font-weight: normal !important;
 }
 
 .c11 {
@@ -1267,12 +1273,13 @@ exports[`CollapsibleStateless matches the snapshot by default 1`] = `
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c1 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 1rem !important;
+  font-weight: normal !important;
 }
 
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
@@ -1442,12 +1449,13 @@ exports[`CollapsibleStateless matches the snapshot when it is opened and closed 
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c1 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 1rem !important;
+  font-weight: normal !important;
 }
 
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
@@ -1617,12 +1625,13 @@ exports[`CollapsibleStateless matches the snapshot when it is opened and closed 
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c1 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 1rem !important;
+  font-weight: normal !important;
 }
 
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
@@ -1792,12 +1801,13 @@ exports[`CollapsibleStateless matches the snapshot with prefix seo icon and scre
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  font-size: 1rem;
 }
 
 .c1 {
-  margin: 0;
-  font-weight: normal;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 1rem !important;
+  font-weight: normal !important;
 }
 
 .c9 {

--- a/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
+++ b/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
@@ -54,8 +54,6 @@ const DesktopButton = SwitcherButton.extend`
 const Switcher = styled.div`
 	display: inline-block;
 	margin-top: 10px;
-	margin-right: ${ getRtlStyle( "0px", "20px" ) };
-	margin-left: ${ getRtlStyle( "20px", "4px" ) };
 	border: 1px solid #dbdbdb;
 	border-radius: 4px;
 	background-color: #f7f7f7;

--- a/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
+++ b/composites/Plugin/SnippetEditor/components/ModeSwitcher.js
@@ -10,7 +10,6 @@ import { MODE_DESKTOP, MODE_MOBILE, MODES } from "../../SnippetPreview/constants
 import ScreenReaderText from "../../../../a11y/ScreenReaderText";
 import SvgIcon from "../../Shared/components/SvgIcon";
 import PropTypes from "prop-types";
-import { getRtlStyle } from "../../../../utils/helpers/styled-components";
 
 /**
  * Renders a switcher button.

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -46,7 +46,6 @@ const EditSnippetButton = SnippetEditorButton.extend`
 
 const CloseEditorButton = SnippetEditorButton.extend`
 	margin-top: 24px;
-	${ getRtlStyle( "margin-left", "margin-right" ) }: 20px;
 `;
 
 /**

--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -141,7 +141,6 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -280,8 +279,6 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -725,7 +722,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-top: 24px;
-  margin-left: 20px;
 }
 
 .c10 >:first-child {
@@ -938,7 +934,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -1155,8 +1150,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -2926,7 +2919,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-top: 24px;
-  margin-left: 20px;
 }
 
 .c10 >:first-child {
@@ -3139,7 +3131,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -3356,8 +3347,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -5127,7 +5116,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-top: 24px;
-  margin-left: 20px;
 }
 
 .c10 >:first-child {
@@ -5340,7 +5328,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -5557,8 +5544,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -7328,7 +7313,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-top: 24px;
-  margin-left: 20px;
 }
 
 .c10 >:first-child {
@@ -7541,7 +7525,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -7758,8 +7741,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -9576,7 +9557,6 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -9715,8 +9695,6 @@ exports[`SnippetEditor closes when calling close() 2`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -10841,7 +10819,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-top: 24px;
-  margin-left: 20px;
 }
 
 .c10 >:first-child {
@@ -11054,7 +11031,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -11271,8 +11247,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -13042,7 +13016,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-top: 24px;
-  margin-left: 20px;
 }
 
 .c10 >:first-child {
@@ -13255,7 +13228,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -13472,8 +13444,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -15290,7 +15260,6 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -15429,8 +15398,6 @@ exports[`SnippetEditor highlights a focused field 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -15843,7 +15810,6 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -15982,8 +15948,6 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -16349,7 +16313,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-top: 24px;
-  margin-left: 20px;
 }
 
 .c10 >:first-child {
@@ -16562,7 +16525,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -16779,8 +16741,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 .c23 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -18570,7 +18530,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-top: 24px;
-  margin-left: 20px;
 }
 
 .c10 >:first-child {
@@ -18783,7 +18742,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -19000,8 +18958,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 .c23 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -20791,7 +20747,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-top: 24px;
-  margin-left: 20px;
 }
 
 .c10 >:first-child {
@@ -21004,7 +20959,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -21221,8 +21175,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -22992,7 +22944,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-top: 24px;
-  margin-left: 20px;
 }
 
 .c10 >:first-child {
@@ -23205,7 +23156,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -23422,8 +23372,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -25328,7 +25276,6 @@ exports[`SnippetEditor passes the date prop 1`] = `
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -25471,8 +25418,6 @@ exports[`SnippetEditor passes the date prop 1`] = `
 .c23 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -25922,7 +25867,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   margin-top: 24px;
-  margin-left: 20px;
 }
 
 .c10 >:first-child {
@@ -26135,7 +26079,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -26352,8 +26295,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -28306,8 +28247,6 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;
@@ -28720,7 +28659,6 @@ exports[`SnippetEditor shows the editor 1`] = `
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -28859,8 +28797,6 @@ exports[`SnippetEditor shows the editor 1`] = `
 .c22 {
   display: inline-block;
   margin-top: 10px;
-  margin-right: 0px;
-  margin-left: 20px;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
   background-color: #f7f7f7;

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -44,7 +44,6 @@ const MobileContainer = styled.div`
 	border-bottom: 1px hidden #fff;
 	border-radius: 2px;
 	box-shadow: 0 1px 2px rgba(0,0,0,.2);
-	margin: 0 20px 10px;
 	font-family: Arial, Roboto-Regular, HelveticaNeue, sans-serif;
 	max-width: ${ MAX_WIDTH }px;
 	box-sizing: border-box;
@@ -660,7 +659,7 @@ export default class SnippetPreview extends PureComponent {
 				</div>
 				<Container
 					onMouseLeave={ this.onMouseLeave }
-					width={ MAX_WIDTH + 2 * WIDTH_PADDING }
+					width={ MAX_WIDTH + ( 2 * WIDTH_PADDING ) }
 					padding={ WIDTH_PADDING }
 				>
 					<PartContainer>

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -1218,7 +1218,6 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -1597,7 +1596,6 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;
@@ -1962,7 +1960,6 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
-  margin: 0 20px 10px;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   max-width: 600px;
   box-sizing: border-box;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* Added `!important` to `h2` overrides in the Collapsible, otherwise the styling of the `#postbox h2` in WordPress will not be changed - these can be seen in the components in the metabox.
* Added `hasPadding` to the Collapsible, to make the content of the collapsible to have padding and the internal items have no padding.
* Added `hasSeparator` to the Collapsible to make borders around the entries to have them visually separated

## Test instructions

This PR can be tested by following these steps:

* Use the PR (https://github.com/Yoast/wordpress-seo/pull/10483) on Yoast SEO to see the changes.

Fixes #671
