### PR TITLE
Fix collapsible headers RTL style.

### DIFF
--- a/composites/Plugin/Shared/components/Button.js
+++ b/composites/Plugin/Shared/components/Button.js
@@ -7,6 +7,7 @@ import PropTypes from "prop-types";
 import colors from "../../../../style-guide/colors.json";
 import SvgIcon from "./SvgIcon";
 import { rgba } from "../../../../style-guide/helpers";
+import { getRtlStyle } from "../../../../utils/helpers/styled-components";
 
 const settings = {
 	minHeight: 32,
@@ -39,7 +40,7 @@ export function addBaseStyle( component ) {
 		font-size: inherit;
 		font-family: inherit;
 		font-weight: inherit;
-		text-align: left;
+		text-align: ${ getRtlStyle( "left", "right" ) };
 		overflow: visible;
 		min-height: ${ `${ settings.minHeight }px` };
 
@@ -216,7 +217,7 @@ export const Button = addFontSizeStyles( BaseButton );
  */
 function addIconTextStyle( icon ) {
 	return styled( icon )`
-		margin: 0 8px 0 0;
+		margin: ${ getRtlStyle( "0 8px 0 0", "0 0 0 8px" ) };
 		flex-shrink: 0;
 	`;
 }

--- a/composites/Plugin/Shared/components/Collapsible.js
+++ b/composites/Plugin/Shared/components/Collapsible.js
@@ -6,6 +6,7 @@ import omit from "lodash/omit";
 import colors from "../../../../style-guide/colors.json";
 import { IconsButton } from "../../Shared/components/Button";
 import ScreenReaderText from "../../../../a11y/ScreenReaderText";
+import { getRtlStyle } from "../../../../utils/helpers/styled-components";
 
 const Content = styled.div`
 	padding: 0 16px;
@@ -45,10 +46,10 @@ export const StyledIconsButton = styled( IconsButton )`
 	svg {
 		${ props => props.hasSubTitle ? "align-self: flex-start;" : "" }
 		&:first-child {
-			margin-right: 8px;
+			${ getRtlStyle( "margin-right: 8px", "margin-left: 8px" ) };
 		}
 		&:last-child {
-			margin-left: 8px;
+			${ getRtlStyle( "margin-left: 8px", "margin-right: 8px" ) };
 		}
 	}
 `;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the Collapsible headers RTL style

## Relevant technical choices:

* uses `getRtlStyle()` where needed, relies on `ThemeProvider` to be used properly

## Test instructions

- can't be tested in the standalone app until #681 is merged to add the global RTL switch to the demo pages
- can't be tested in the plugin until https://github.com/Yoast/wordpress-seo/pull/10506 gets merged

Fixes #683 
