### PR TITLE
Change synonyms explanation text size and color

### DIFF
--- a/composites/Plugin/Shared/components/SynonymsInput.js
+++ b/composites/Plugin/Shared/components/SynonymsInput.js
@@ -3,9 +3,10 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import uniqueId from "lodash/uniqueId";
 import { YoastInputContainer, YoastInputField, YoastInputLabel } from "./YoastInput";
+import colors from "../../../../style-guide/colors.json";
 
 const ExplanationText = styled.p`
-	font-size: .8em;
+	color: ${ colors.$color_grey_text };
 `;
 
 const SynonymsInput = ( { id, label, value, onChange, explanationText } ) => {

--- a/composites/Plugin/Shared/components/SynonymsInput.js
+++ b/composites/Plugin/Shared/components/SynonymsInput.js
@@ -21,7 +21,6 @@ const SynonymsInput = ( { id, label, value, onChange, explanationText } ) => {
 				</ExplanationText>
 			) }
 			<YoastInputField
-				aria-label={ label }
 				type="text"
 				id={ id }
 				onChange={ onChange }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Increases the synonyms explanation text size and changes color

## Relevant technical choices:

- also removes a redundant aria-label

## Test instructions

- check the text is bigger (inherits 13 pixels in WordPress) and color is `#646464`

To test in the plugin, the process is a bit more articulated:
- switch the plugin to the branch release/8.0 to avoid the babel error
- `yarn link yoast-components` just in the root
- cd to the premium folder and build the JS
- no need to build the JS in the root

<img width="567" alt="screen shot 2018-08-06 at 13 49 28" src="https://user-images.githubusercontent.com/1682452/43715117-ad0a3db2-997f-11e8-9c9f-115a922fc125.png">


Fixes #688 
