### PR TITLE
Removed HelpTextWrapper from SnippetPreview

### DIFF
--- a/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/composites/Plugin/SnippetEditor/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SnippetEditor accepts a custom data mapping function 1`] = `
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -41,23 +41,23 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -65,14 +65,14 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -83,61 +83,11 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -147,12 +97,12 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -167,13 +117,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -182,7 +132,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -192,7 +142,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -205,7 +155,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -213,22 +163,22 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -242,8 +192,8 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -252,7 +202,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -266,8 +216,8 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -276,7 +226,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -285,15 +235,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -301,7 +243,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -309,8 +251,16 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -319,45 +269,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
 
 <div>
   <section>
-    <div>
-      <div
-        className="yoast-help c0"
-      >
-        <button
-          aria-controls={null}
-          aria-expanded={false}
-          aria-label="Help on the Snippet Preview"
-          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-          onClick={[Function]}
-          type="button"
-        >
-          <svg
-            aria-hidden={true}
-            className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-            fill="#646464"
-            focusable="false"
-            role="img"
-            size="16px"
-            viewBox="0 0 1792 1792"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-            />
-          </svg>
-        </button>
-        <div
-          className="c10"
-        />
-      </div>
-    </div>
     <div
-      className="c11"
+      className="c0"
       onMouseLeave={undefined}
       width={640}
     >
       <div
-        className="c12"
+        className="c1"
       >
         <span
           className="screen-reader-text"
@@ -374,16 +292,16 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
           SEO title preview:
         </span>
         <div
-          className="c13"
+          className="c2"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c14 c15"
+            className="c3 c4"
           >
             <span
-              className="c16"
+              className="c5"
             >
               Totally different title
             </span>
@@ -404,10 +322,10 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
           Url preview:
         </span>
         <div
-          className="c17"
+          className="c6"
         >
           <div
-            className="c18"
+            className="c7"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -417,10 +335,10 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
         </div>
       </div>
       <hr
-        className="c19"
+        className="c8"
       />
       <div
-        className="c12"
+        className="c1"
       >
         <span
           className="screen-reader-text"
@@ -437,13 +355,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c20 c21"
+          className="c9 c10"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c20 c21"
+            className="c9 c10"
           >
             Totally different description
           </div>
@@ -452,17 +370,17 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
     </div>
   </section>
   <div
-    className="c22"
+    className="c11"
   >
     <button
       aria-pressed={true}
-      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c24"
+        className="yoast-svg-icon yoast-svg-icon-mobile c19"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -491,13 +409,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c26"
+        className="yoast-svg-icon yoast-svg-icon-desktop c21"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -527,13 +445,13 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
     onClick={[Function]}
     type="button"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c9"
+      className="yoast-svg-icon yoast-svg-icon-edit c23"
       fill={undefined}
       focusable="false"
       role="img"
@@ -629,18 +547,18 @@ exports[`SnippetEditor activates a field on onMouseUp() and opens the editor 1`]
 `;
 
 exports[`SnippetEditor calls callbacks when the editors are focused or changed 1`] = `
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -669,23 +587,23 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -693,14 +611,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -711,11 +629,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c34 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -724,57 +642,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   margin-top: 24px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
-.c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c32 {
+.c28 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -793,11 +661,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   cursor: text;
 }
 
-.c32 .public-DraftStyleDefault-block {
+.c28 .public-DraftStyleDefault-block {
   line-height: 24px;
 }
 
-.c32::before {
+.c28::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -809,7 +677,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   content: "";
 }
 
-.c34 {
+.c30 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -828,7 +696,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   cursor: text;
 }
 
-.c34::before {
+.c30::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -840,7 +708,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   content: "";
 }
 
-.c36 {
+.c32 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -862,15 +730,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   line-height: 24px;
 }
 
-.c36 .public-DraftEditorPlaceholder-root {
+.c32 .public-DraftEditorPlaceholder-root {
   color: #646464;
 }
 
-.c36 .public-DraftEditorPlaceholder-hasFocus {
+.c32 .public-DraftEditorPlaceholder-hasFocus {
   color: #646464;
 }
 
-.c36::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -882,7 +750,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   content: "";
 }
 
-.c29 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -901,11 +769,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   margin: 24px 0 0 0;
 }
 
-.c28 {
+.c24 {
   padding: 0 20px;
 }
 
-.c30 {
+.c26 {
   -webkit-flex: 1 1 200px;
   -ms-flex: 1 1 200px;
   flex: 1 1 200px;
@@ -916,7 +784,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   margin: 4px 0;
 }
 
-.c31 {
+.c27 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   padding-left: 8px;
@@ -925,12 +793,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   font-size: 13px;
 }
 
-.c31 svg {
+.c27 svg {
   margin-right: 7px;
   fill: #555;
 }
 
-.c11 {
+.c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -940,12 +808,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -960,13 +828,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -975,7 +843,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -985,7 +853,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -998,7 +866,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -1006,19 +874,51 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c29::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
 }
 
 .c33 {
@@ -1039,53 +939,21 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 }
 
 .c33::-webkit-progress-value {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c33::-moz-progress-bar {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
 }
 
 .c33::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
   background-color: #ee7c1b;
   border: 0;
 }
 
-.c35 {
+.c31 {
   border: none;
   width: 100%;
   height: inherit;
@@ -1095,11 +963,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   color: inherit;
 }
 
-.c35:focus {
+.c31:focus {
   outline: 0;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -1113,8 +981,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -1123,7 +991,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -1137,8 +1005,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -1147,7 +1015,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -1156,15 +1024,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -1172,7 +1032,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -1180,8 +1040,16 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -1267,256 +1135,17 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
         url="example.org/test-slug"
       >
         <section>
-          <div>
-            <HelpTextWrapper
-              className="yoast-help"
-              helpText={
-                Array [
-                  "This is a rendering of what this post might look like in Google's search results. ",
-                  <OutboundLink
-                    href="https://yoa.st/snippet-preview"
-                  >
-                    Learn more about the Snippet Preview.
-                  </OutboundLink>,
-                ]
-              }
-              helpTextButtonLabel="Help on the Snippet Preview"
-              panelMaxWidth="400px"
-            >
-              <HelpTextWrapper__HelpTextContainer
-                className="yoast-help"
-              >
-                <div
-                  className="yoast-help c0"
-                >
-                  <HelpTextWrapper__HelpTextButton
-                    aria-controls={null}
-                    aria-expanded={false}
-                    aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button"
-                    onClick={[Function]}
-                  >
-                    <Button
-                      aria-controls={null}
-                      aria-expanded={false}
-                      aria-label="Help on the Snippet Preview"
-                      className="yoast-help__button c1"
-                      onClick={[Function]}
-                    >
-                      <Button
-                        activeBackgroundColor="#f7f7f7"
-                        activeBorderColor="#888"
-                        activeColor="#000"
-                        aria-controls={null}
-                        aria-expanded={false}
-                        aria-label="Help on the Snippet Preview"
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2"
-                        focusBackgroundColor="#fff"
-                        focusBorderColor="#0066cd"
-                        focusColor="#000"
-                        hoverBackgroundColor="#fff"
-                        hoverBorderColor="#888"
-                        hoverColor="#000"
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <Button
-                          activeBackgroundColor="#f7f7f7"
-                          activeBorderColor="#888"
-                          activeColor="#000"
-                          aria-controls={null}
-                          aria-expanded={false}
-                          aria-label="Help on the Snippet Preview"
-                          backgroundColor="#f7f7f7"
-                          borderColor="#ccc"
-                          boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
-                          focusBackgroundColor="#fff"
-                          focusBorderColor="#0066cd"
-                          focusColor="#000"
-                          hoverBackgroundColor="#fff"
-                          hoverBorderColor="#888"
-                          hoverColor="#000"
-                          onClick={[Function]}
-                          textColor="#555"
-                          type="button"
-                        >
-                          <Button
-                            activeBackgroundColor="#f7f7f7"
-                            activeBorderColor="#888"
-                            activeColor="#000"
-                            aria-controls={null}
-                            aria-expanded={false}
-                            aria-label="Help on the Snippet Preview"
-                            backgroundColor="#f7f7f7"
-                            borderColor="#ccc"
-                            boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            focusBackgroundColor="#fff"
-                            focusBorderColor="#0066cd"
-                            focusColor="#000"
-                            hoverBackgroundColor="#fff"
-                            hoverBorderColor="#888"
-                            hoverColor="#000"
-                            onClick={[Function]}
-                            textColor="#555"
-                            type="button"
-                          >
-                            <Button
-                              activeBackgroundColor="#f7f7f7"
-                              activeBorderColor="#888"
-                              activeColor="#000"
-                              aria-controls={null}
-                              aria-expanded={false}
-                              aria-label="Help on the Snippet Preview"
-                              backgroundColor="#f7f7f7"
-                              borderColor="#ccc"
-                              boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              focusBackgroundColor="#fff"
-                              focusBorderColor="#0066cd"
-                              focusColor="#000"
-                              hoverBackgroundColor="#fff"
-                              hoverBorderColor="#888"
-                              hoverColor="#000"
-                              onClick={[Function]}
-                              textColor="#555"
-                              type="button"
-                            >
-                              <Button__BaseButton
-                                activeBackgroundColor="#f7f7f7"
-                                activeBorderColor="#888"
-                                activeColor="#000"
-                                aria-controls={null}
-                                aria-expanded={false}
-                                aria-label="Help on the Snippet Preview"
-                                backgroundColor="#f7f7f7"
-                                borderColor="#ccc"
-                                boxShadowColor="#ccc"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                focusBackgroundColor="#fff"
-                                focusBorderColor="#0066cd"
-                                focusColor="#000"
-                                hoverBackgroundColor="#fff"
-                                hoverBorderColor="#888"
-                                hoverColor="#000"
-                                onClick={[Function]}
-                                textColor="#555"
-                                type="button"
-                              >
-                                <button
-                                  aria-controls={null}
-                                  aria-expanded={false}
-                                  aria-label="Help on the Snippet Preview"
-                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <HelpTextWrapper__StyledSvg
-                                    color="#646464"
-                                    icon="question-circle"
-                                    size="16px"
-                                  >
-                                    <SvgIcon
-                                      className="c8"
-                                      color="#646464"
-                                      icon="question-circle"
-                                      size="16px"
-                                    >
-                                      <SvgIcon__StyledSvg
-                                        aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                        fill="#646464"
-                                        focusable="false"
-                                        role="img"
-                                        size="16px"
-                                        viewBox="0 0 1792 1792"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-                                          fill="#646464"
-                                          focusable="false"
-                                          role="img"
-                                          size="16px"
-                                          viewBox="0 0 1792 1792"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                          />
-                                        </svg>
-                                      </SvgIcon__StyledSvg>
-                                    </SvgIcon>
-                                  </HelpTextWrapper__StyledSvg>
-                                </button>
-                              </Button__BaseButton>
-                            </Button>
-                          </Button>
-                        </Button>
-                      </Button>
-                    </Button>
-                  </HelpTextWrapper__HelpTextButton>
-                  <YoastSlideToggle
-                    duration={300}
-                    isOpen={false}
-                  >
-                    <animations__YoastSlideToggleContainer
-                      duration={300}
-                    >
-                      <div
-                        className="c10"
-                      >
-                        <CSSTransition
-                          classNames="slide"
-                          in={false}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExiting={[Function]}
-                          timeout={300}
-                          unmountOnExit={true}
-                        >
-                          <Transition
-                            appear={false}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            timeout={300}
-                            unmountOnExit={true}
-                          />
-                        </CSSTransition>
-                      </div>
-                    </animations__YoastSlideToggleContainer>
-                  </YoastSlideToggle>
-                </div>
-              </HelpTextWrapper__HelpTextContainer>
-            </HelpTextWrapper>
-          </div>
           <SnippetPreview__MobileContainer
             padding={20}
             width={640}
           >
             <div
-              className="c11"
+              className="c0"
               width={640}
             >
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -1540,23 +1169,23 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     onMouseUp={[Function]}
                   >
                     <div
-                      className="c13"
+                      className="c2"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <SnippetPreview__TitleBounded>
                         <SnippetPreview__Title
-                          className="c14"
+                          className="c3"
                         >
                           <div
-                            className="c14 c15"
+                            className="c3 c4"
                           >
                             <SnippetPreview__TitleUnboundedMobile
                               innerRef={[Function]}
                             >
                               <span
-                                className="c16"
+                                className="c5"
                               >
                                 Test title
                               </span>
@@ -1584,7 +1213,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   </ScreenReaderText>
                   <SnippetPreview__BaseUrl>
                     <div
-                      className="c17"
+                      className="c6"
                     >
                       <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
@@ -1592,7 +1221,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         onMouseUp={[Function]}
                       >
                         <div
-                          className="c18"
+                          className="c7"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           onMouseUp={[Function]}
@@ -1606,12 +1235,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               </SnippetPreview__MobilePartContainer>
               <SnippetPreview__Separator>
                 <hr
-                  className="c19"
+                  className="c8"
                 />
               </SnippetPreview__Separator>
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -1636,14 +1265,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     onMouseUp={[Function]}
                   >
                     <SnippetPreview__DesktopDescription
-                      className="c20"
+                      className="c9"
                       isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <div
-                        className="c20 c21"
+                        className="c9 c10"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
@@ -1653,12 +1282,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                           isDescriptionPlaceholder={false}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c20"
+                            className="c9"
                             innerRef={[Function]}
                             isDescriptionPlaceholder={false}
                           >
                             <div
-                              className="c20 c21"
+                              className="c9 c10"
                             >
                               Test description, %%replacement_variable%%
                             </div>
@@ -1679,7 +1308,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
       >
         <ModeSwitcher__Switcher>
           <div
-            className="c22"
+            className="c11"
           >
             <ModeSwitcher__SwitcherButton
               aria-pressed={true}
@@ -1688,7 +1317,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             >
               <Button
                 aria-pressed={true}
-                className="c23"
+                className="c12"
                 isActive={true}
                 onClick={[Function]}
               >
@@ -1700,7 +1329,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2"
+                  className="c12 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -1720,7 +1349,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3"
+                    className="c12 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -1740,7 +1369,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -1760,7 +1389,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -1780,7 +1409,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -1794,7 +1423,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         >
                           <button
                             aria-pressed={true}
-                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -1815,7 +1444,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c19"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -1860,7 +1489,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             >
               <Button
                 aria-pressed={false}
-                className="c25"
+                className="c20"
                 isActive={false}
                 onClick={[Function]}
               >
@@ -1872,7 +1501,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2"
+                  className="c20 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -1892,7 +1521,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3"
+                    className="c20 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -1912,7 +1541,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -1932,7 +1561,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -1952,7 +1581,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -1966,7 +1595,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         >
                           <button
                             aria-pressed={false}
-                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -1987,7 +1616,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c21"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -2041,7 +1670,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27"
+          className="c22"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -2061,7 +1690,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3"
+            className="c22 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -2081,7 +1710,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -2101,7 +1730,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -2121,7 +1750,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -2135,7 +1764,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 >
                   <button
                     aria-expanded={true}
-                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -2154,7 +1783,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       >
                         <svg
                           aria-hidden={true}
-                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          className="yoast-svg-icon yoast-svg-icon-edit c23"
                           focusable="false"
                           role="img"
                           size="16px"
@@ -2211,11 +1840,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           padding="0 20px"
         >
           <section
-            className="c28"
+            className="c24"
           >
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test title"
@@ -2232,12 +1861,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="30"
+                    id="17"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="30"
+                      className="c26"
+                      id="17"
                       onClick={[Function]}
                     >
                       SEO title
@@ -2247,7 +1876,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -2257,7 +1886,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -2275,7 +1904,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -2293,7 +1922,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -2311,7 +1940,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -2329,7 +1958,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -2341,7 +1970,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -2360,7 +1989,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -2389,12 +2018,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     onClick={[Function]}
                   >
                     <div
-                      className="c32"
+                      className="c28"
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="30"
+                        ariaLabelledBy="17"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -2404,7 +2033,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="30"
+                          ariaLabelledBy="17"
                           content="Test title"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -2429,7 +2058,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 >
                   <progress
                     aria-hidden="true"
-                    className="c33"
+                    className="c29"
                     max={600}
                     value={0}
                   />
@@ -2438,15 +2067,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-29-slug"
+                  id="snippet-editor-field-16-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c30"
-                    id="snippet-editor-field-29-slug"
+                    className="c26"
+                    id="snippet-editor-field-16-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -2458,11 +2087,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   onClick={[Function]}
                 >
                   <div
-                    className="c34"
+                    className="c30"
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-29-slug"
+                      aria-labelledby="snippet-editor-field-16-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -2471,8 +2100,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-29-slug"
-                        className="c35"
+                        aria-labelledby="snippet-editor-field-16-slug"
+                        className="c31"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -2486,7 +2115,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
@@ -2505,12 +2134,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="31"
+                    id="18"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="31"
+                      className="c26"
+                      id="18"
                       onClick={[Function]}
                     >
                       Meta description
@@ -2520,7 +2149,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -2530,7 +2159,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -2548,7 +2177,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -2566,7 +2195,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -2584,7 +2213,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -2602,7 +2231,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -2614,7 +2243,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -2633,7 +2262,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -2662,12 +2291,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                     onClick={[Function]}
                   >
                     <div
-                      className="c36"
+                      className="c32"
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="31"
+                        ariaLabelledBy="18"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -2678,7 +2307,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="31"
+                          ariaLabelledBy="18"
                           content="Test description, %%replacement_variable%%"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -2704,7 +2333,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 >
                   <progress
                     aria-hidden="true"
-                    className="c37"
+                    className="c33"
                     max={156}
                     value={42}
                   />
@@ -2724,7 +2353,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38"
+          className="c34"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -2742,7 +2371,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3"
+            className="c34 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -2760,7 +2389,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c34 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -2778,7 +2407,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -2796,7 +2425,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -2808,7 +2437,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                   type="button"
                 >
                   <button
-                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -2826,18 +2455,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 `;
 
 exports[`SnippetEditor calls callbacks when the editors are focused or changed 2`] = `
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2866,23 +2495,23 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -2890,14 +2519,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -2908,11 +2537,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c34 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -2921,57 +2550,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   margin-top: 24px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
-.c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c32 {
+.c28 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -2990,11 +2569,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   cursor: text;
 }
 
-.c32 .public-DraftStyleDefault-block {
+.c28 .public-DraftStyleDefault-block {
   line-height: 24px;
 }
 
-.c32::before {
+.c28::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -3006,7 +2585,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   content: "";
 }
 
-.c34 {
+.c30 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -3025,7 +2604,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   cursor: text;
 }
 
-.c34::before {
+.c30::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -3037,7 +2616,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   content: "";
 }
 
-.c36 {
+.c32 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -3059,15 +2638,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   line-height: 24px;
 }
 
-.c36 .public-DraftEditorPlaceholder-root {
+.c32 .public-DraftEditorPlaceholder-root {
   color: #646464;
 }
 
-.c36 .public-DraftEditorPlaceholder-hasFocus {
+.c32 .public-DraftEditorPlaceholder-hasFocus {
   color: #646464;
 }
 
-.c36::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -3079,7 +2658,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   content: "";
 }
 
-.c29 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3098,11 +2677,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   margin: 24px 0 0 0;
 }
 
-.c28 {
+.c24 {
   padding: 0 20px;
 }
 
-.c30 {
+.c26 {
   -webkit-flex: 1 1 200px;
   -ms-flex: 1 1 200px;
   flex: 1 1 200px;
@@ -3113,7 +2692,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   margin: 4px 0;
 }
 
-.c31 {
+.c27 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   padding-left: 8px;
@@ -3122,12 +2701,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   font-size: 13px;
 }
 
-.c31 svg {
+.c27 svg {
   margin-right: 7px;
   fill: #555;
 }
 
-.c11 {
+.c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -3137,12 +2716,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3157,13 +2736,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -3172,7 +2751,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -3182,7 +2761,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -3195,7 +2774,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -3203,19 +2782,51 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c29::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
 }
 
 .c33 {
@@ -3236,53 +2847,21 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 }
 
 .c33::-webkit-progress-value {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c33::-moz-progress-bar {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
 }
 
 .c33::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
   background-color: #ee7c1b;
   border: 0;
 }
 
-.c35 {
+.c31 {
   border: none;
   width: 100%;
   height: inherit;
@@ -3292,11 +2871,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   color: inherit;
 }
 
-.c35:focus {
+.c31:focus {
   outline: 0;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -3310,8 +2889,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -3320,7 +2899,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -3334,8 +2913,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -3344,7 +2923,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -3353,15 +2932,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -3369,7 +2940,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -3377,8 +2948,16 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -3464,256 +3043,17 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
         url="example.org/test-slug"
       >
         <section>
-          <div>
-            <HelpTextWrapper
-              className="yoast-help"
-              helpText={
-                Array [
-                  "This is a rendering of what this post might look like in Google's search results. ",
-                  <OutboundLink
-                    href="https://yoa.st/snippet-preview"
-                  >
-                    Learn more about the Snippet Preview.
-                  </OutboundLink>,
-                ]
-              }
-              helpTextButtonLabel="Help on the Snippet Preview"
-              panelMaxWidth="400px"
-            >
-              <HelpTextWrapper__HelpTextContainer
-                className="yoast-help"
-              >
-                <div
-                  className="yoast-help c0"
-                >
-                  <HelpTextWrapper__HelpTextButton
-                    aria-controls={null}
-                    aria-expanded={false}
-                    aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button"
-                    onClick={[Function]}
-                  >
-                    <Button
-                      aria-controls={null}
-                      aria-expanded={false}
-                      aria-label="Help on the Snippet Preview"
-                      className="yoast-help__button c1"
-                      onClick={[Function]}
-                    >
-                      <Button
-                        activeBackgroundColor="#f7f7f7"
-                        activeBorderColor="#888"
-                        activeColor="#000"
-                        aria-controls={null}
-                        aria-expanded={false}
-                        aria-label="Help on the Snippet Preview"
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2"
-                        focusBackgroundColor="#fff"
-                        focusBorderColor="#0066cd"
-                        focusColor="#000"
-                        hoverBackgroundColor="#fff"
-                        hoverBorderColor="#888"
-                        hoverColor="#000"
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <Button
-                          activeBackgroundColor="#f7f7f7"
-                          activeBorderColor="#888"
-                          activeColor="#000"
-                          aria-controls={null}
-                          aria-expanded={false}
-                          aria-label="Help on the Snippet Preview"
-                          backgroundColor="#f7f7f7"
-                          borderColor="#ccc"
-                          boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
-                          focusBackgroundColor="#fff"
-                          focusBorderColor="#0066cd"
-                          focusColor="#000"
-                          hoverBackgroundColor="#fff"
-                          hoverBorderColor="#888"
-                          hoverColor="#000"
-                          onClick={[Function]}
-                          textColor="#555"
-                          type="button"
-                        >
-                          <Button
-                            activeBackgroundColor="#f7f7f7"
-                            activeBorderColor="#888"
-                            activeColor="#000"
-                            aria-controls={null}
-                            aria-expanded={false}
-                            aria-label="Help on the Snippet Preview"
-                            backgroundColor="#f7f7f7"
-                            borderColor="#ccc"
-                            boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            focusBackgroundColor="#fff"
-                            focusBorderColor="#0066cd"
-                            focusColor="#000"
-                            hoverBackgroundColor="#fff"
-                            hoverBorderColor="#888"
-                            hoverColor="#000"
-                            onClick={[Function]}
-                            textColor="#555"
-                            type="button"
-                          >
-                            <Button
-                              activeBackgroundColor="#f7f7f7"
-                              activeBorderColor="#888"
-                              activeColor="#000"
-                              aria-controls={null}
-                              aria-expanded={false}
-                              aria-label="Help on the Snippet Preview"
-                              backgroundColor="#f7f7f7"
-                              borderColor="#ccc"
-                              boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              focusBackgroundColor="#fff"
-                              focusBorderColor="#0066cd"
-                              focusColor="#000"
-                              hoverBackgroundColor="#fff"
-                              hoverBorderColor="#888"
-                              hoverColor="#000"
-                              onClick={[Function]}
-                              textColor="#555"
-                              type="button"
-                            >
-                              <Button__BaseButton
-                                activeBackgroundColor="#f7f7f7"
-                                activeBorderColor="#888"
-                                activeColor="#000"
-                                aria-controls={null}
-                                aria-expanded={false}
-                                aria-label="Help on the Snippet Preview"
-                                backgroundColor="#f7f7f7"
-                                borderColor="#ccc"
-                                boxShadowColor="#ccc"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                focusBackgroundColor="#fff"
-                                focusBorderColor="#0066cd"
-                                focusColor="#000"
-                                hoverBackgroundColor="#fff"
-                                hoverBorderColor="#888"
-                                hoverColor="#000"
-                                onClick={[Function]}
-                                textColor="#555"
-                                type="button"
-                              >
-                                <button
-                                  aria-controls={null}
-                                  aria-expanded={false}
-                                  aria-label="Help on the Snippet Preview"
-                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <HelpTextWrapper__StyledSvg
-                                    color="#646464"
-                                    icon="question-circle"
-                                    size="16px"
-                                  >
-                                    <SvgIcon
-                                      className="c8"
-                                      color="#646464"
-                                      icon="question-circle"
-                                      size="16px"
-                                    >
-                                      <SvgIcon__StyledSvg
-                                        aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                        fill="#646464"
-                                        focusable="false"
-                                        role="img"
-                                        size="16px"
-                                        viewBox="0 0 1792 1792"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-                                          fill="#646464"
-                                          focusable="false"
-                                          role="img"
-                                          size="16px"
-                                          viewBox="0 0 1792 1792"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                          />
-                                        </svg>
-                                      </SvgIcon__StyledSvg>
-                                    </SvgIcon>
-                                  </HelpTextWrapper__StyledSvg>
-                                </button>
-                              </Button__BaseButton>
-                            </Button>
-                          </Button>
-                        </Button>
-                      </Button>
-                    </Button>
-                  </HelpTextWrapper__HelpTextButton>
-                  <YoastSlideToggle
-                    duration={300}
-                    isOpen={false}
-                  >
-                    <animations__YoastSlideToggleContainer
-                      duration={300}
-                    >
-                      <div
-                        className="c10"
-                      >
-                        <CSSTransition
-                          classNames="slide"
-                          in={false}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExiting={[Function]}
-                          timeout={300}
-                          unmountOnExit={true}
-                        >
-                          <Transition
-                            appear={false}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            timeout={300}
-                            unmountOnExit={true}
-                          />
-                        </CSSTransition>
-                      </div>
-                    </animations__YoastSlideToggleContainer>
-                  </YoastSlideToggle>
-                </div>
-              </HelpTextWrapper__HelpTextContainer>
-            </HelpTextWrapper>
-          </div>
           <SnippetPreview__MobileContainer
             padding={20}
             width={640}
           >
             <div
-              className="c11"
+              className="c0"
               width={640}
             >
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -3737,23 +3077,23 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     onMouseUp={[Function]}
                   >
                     <div
-                      className="c13"
+                      className="c2"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <SnippetPreview__TitleBounded>
                         <SnippetPreview__Title
-                          className="c14"
+                          className="c3"
                         >
                           <div
-                            className="c14 c15"
+                            className="c3 c4"
                           >
                             <SnippetPreview__TitleUnboundedMobile
                               innerRef={[Function]}
                             >
                               <span
-                                className="c16"
+                                className="c5"
                               >
                                 Test title
                               </span>
@@ -3781,7 +3121,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   </ScreenReaderText>
                   <SnippetPreview__BaseUrl>
                     <div
-                      className="c17"
+                      className="c6"
                     >
                       <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
@@ -3789,7 +3129,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         onMouseUp={[Function]}
                       >
                         <div
-                          className="c18"
+                          className="c7"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           onMouseUp={[Function]}
@@ -3803,12 +3143,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               </SnippetPreview__MobilePartContainer>
               <SnippetPreview__Separator>
                 <hr
-                  className="c19"
+                  className="c8"
                 />
               </SnippetPreview__Separator>
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -3833,14 +3173,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     onMouseUp={[Function]}
                   >
                     <SnippetPreview__DesktopDescription
-                      className="c20"
+                      className="c9"
                       isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <div
-                        className="c20 c21"
+                        className="c9 c10"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
@@ -3850,12 +3190,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                           isDescriptionPlaceholder={false}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c20"
+                            className="c9"
                             innerRef={[Function]}
                             isDescriptionPlaceholder={false}
                           >
                             <div
-                              className="c20 c21"
+                              className="c9 c10"
                             >
                               Test description, %%replacement_variable%%
                             </div>
@@ -3876,7 +3216,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
       >
         <ModeSwitcher__Switcher>
           <div
-            className="c22"
+            className="c11"
           >
             <ModeSwitcher__SwitcherButton
               aria-pressed={true}
@@ -3885,7 +3225,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             >
               <Button
                 aria-pressed={true}
-                className="c23"
+                className="c12"
                 isActive={true}
                 onClick={[Function]}
               >
@@ -3897,7 +3237,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2"
+                  className="c12 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -3917,7 +3257,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3"
+                    className="c12 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -3937,7 +3277,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -3957,7 +3297,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -3977,7 +3317,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -3991,7 +3331,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         >
                           <button
                             aria-pressed={true}
-                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -4012,7 +3352,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c19"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -4057,7 +3397,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             >
               <Button
                 aria-pressed={false}
-                className="c25"
+                className="c20"
                 isActive={false}
                 onClick={[Function]}
               >
@@ -4069,7 +3409,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2"
+                  className="c20 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -4089,7 +3429,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3"
+                    className="c20 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -4109,7 +3449,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -4129,7 +3469,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -4149,7 +3489,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -4163,7 +3503,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         >
                           <button
                             aria-pressed={false}
-                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -4184,7 +3524,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c21"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -4238,7 +3578,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27"
+          className="c22"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -4258,7 +3598,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3"
+            className="c22 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -4278,7 +3618,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -4298,7 +3638,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -4318,7 +3658,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -4332,7 +3672,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 >
                   <button
                     aria-expanded={true}
-                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -4351,7 +3691,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       >
                         <svg
                           aria-hidden={true}
-                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          className="yoast-svg-icon yoast-svg-icon-edit c23"
                           focusable="false"
                           role="img"
                           size="16px"
@@ -4408,11 +3748,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           padding="0 20px"
         >
           <section
-            className="c28"
+            className="c24"
           >
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test title"
@@ -4429,12 +3769,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="30"
+                    id="17"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="30"
+                      className="c26"
+                      id="17"
                       onClick={[Function]}
                     >
                       SEO title
@@ -4444,7 +3784,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -4454,7 +3794,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -4472,7 +3812,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -4490,7 +3830,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -4508,7 +3848,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -4526,7 +3866,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -4538,7 +3878,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -4557,7 +3897,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -4586,12 +3926,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     onClick={[Function]}
                   >
                     <div
-                      className="c32"
+                      className="c28"
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="30"
+                        ariaLabelledBy="17"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -4601,7 +3941,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="30"
+                          ariaLabelledBy="17"
                           content="Test title"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -4626,7 +3966,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 >
                   <progress
                     aria-hidden="true"
-                    className="c33"
+                    className="c29"
                     max={600}
                     value={0}
                   />
@@ -4635,15 +3975,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-29-slug"
+                  id="snippet-editor-field-16-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c30"
-                    id="snippet-editor-field-29-slug"
+                    className="c26"
+                    id="snippet-editor-field-16-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -4655,11 +3995,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   onClick={[Function]}
                 >
                   <div
-                    className="c34"
+                    className="c30"
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-29-slug"
+                      aria-labelledby="snippet-editor-field-16-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -4668,8 +4008,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-29-slug"
-                        className="c35"
+                        aria-labelledby="snippet-editor-field-16-slug"
+                        className="c31"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -4683,7 +4023,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
@@ -4702,12 +4042,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="31"
+                    id="18"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="31"
+                      className="c26"
+                      id="18"
                       onClick={[Function]}
                     >
                       Meta description
@@ -4717,7 +4057,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -4727,7 +4067,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -4745,7 +4085,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -4763,7 +4103,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -4781,7 +4121,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -4799,7 +4139,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -4811,7 +4151,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -4830,7 +4170,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -4859,12 +4199,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                     onClick={[Function]}
                   >
                     <div
-                      className="c36"
+                      className="c32"
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="31"
+                        ariaLabelledBy="18"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -4875,7 +4215,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="31"
+                          ariaLabelledBy="18"
                           content="Test description, %%replacement_variable%%"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -4901,7 +4241,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 >
                   <progress
                     aria-hidden="true"
-                    className="c37"
+                    className="c33"
                     max={156}
                     value={42}
                   />
@@ -4921,7 +4261,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38"
+          className="c34"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -4939,7 +4279,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3"
+            className="c34 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -4957,7 +4297,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c34 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -4975,7 +4315,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -4993,7 +4333,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -5005,7 +4345,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                   type="button"
                 >
                   <button
-                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -5023,18 +4363,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 `;
 
 exports[`SnippetEditor calls callbacks when the editors are focused or changed 3`] = `
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -5063,23 +4403,23 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -5087,14 +4427,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -5105,11 +4445,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c34 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -5118,57 +4458,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   margin-top: 24px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
-.c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c32 {
+.c28 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -5187,11 +4477,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   cursor: text;
 }
 
-.c32 .public-DraftStyleDefault-block {
+.c28 .public-DraftStyleDefault-block {
   line-height: 24px;
 }
 
-.c32::before {
+.c28::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -5203,7 +4493,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   content: "";
 }
 
-.c34 {
+.c30 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -5222,7 +4512,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   cursor: text;
 }
 
-.c34::before {
+.c30::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -5234,7 +4524,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   content: "";
 }
 
-.c36 {
+.c32 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -5256,15 +4546,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   line-height: 24px;
 }
 
-.c36 .public-DraftEditorPlaceholder-root {
+.c32 .public-DraftEditorPlaceholder-root {
   color: #646464;
 }
 
-.c36 .public-DraftEditorPlaceholder-hasFocus {
+.c32 .public-DraftEditorPlaceholder-hasFocus {
   color: #646464;
 }
 
-.c36::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -5276,7 +4566,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   content: "";
 }
 
-.c29 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5295,11 +4585,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   margin: 24px 0 0 0;
 }
 
-.c28 {
+.c24 {
   padding: 0 20px;
 }
 
-.c30 {
+.c26 {
   -webkit-flex: 1 1 200px;
   -ms-flex: 1 1 200px;
   flex: 1 1 200px;
@@ -5310,7 +4600,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   margin: 4px 0;
 }
 
-.c31 {
+.c27 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   padding-left: 8px;
@@ -5319,12 +4609,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   font-size: 13px;
 }
 
-.c31 svg {
+.c27 svg {
   margin-right: 7px;
   fill: #555;
 }
 
-.c11 {
+.c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -5334,12 +4624,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -5354,13 +4644,13 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -5369,7 +4659,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -5379,7 +4669,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -5392,7 +4682,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -5400,19 +4690,51 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c29::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
 }
 
 .c33 {
@@ -5433,53 +4755,21 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 }
 
 .c33::-webkit-progress-value {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c33::-moz-progress-bar {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
 }
 
 .c33::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
   background-color: #ee7c1b;
   border: 0;
 }
 
-.c35 {
+.c31 {
   border: none;
   width: 100%;
   height: inherit;
@@ -5489,11 +4779,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   color: inherit;
 }
 
-.c35:focus {
+.c31:focus {
   outline: 0;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -5507,8 +4797,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -5517,7 +4807,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -5531,8 +4821,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -5541,7 +4831,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -5550,15 +4840,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -5566,7 +4848,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -5574,8 +4856,16 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -5661,256 +4951,17 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
         url="example.org/test-slug"
       >
         <section>
-          <div>
-            <HelpTextWrapper
-              className="yoast-help"
-              helpText={
-                Array [
-                  "This is a rendering of what this post might look like in Google's search results. ",
-                  <OutboundLink
-                    href="https://yoa.st/snippet-preview"
-                  >
-                    Learn more about the Snippet Preview.
-                  </OutboundLink>,
-                ]
-              }
-              helpTextButtonLabel="Help on the Snippet Preview"
-              panelMaxWidth="400px"
-            >
-              <HelpTextWrapper__HelpTextContainer
-                className="yoast-help"
-              >
-                <div
-                  className="yoast-help c0"
-                >
-                  <HelpTextWrapper__HelpTextButton
-                    aria-controls={null}
-                    aria-expanded={false}
-                    aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button"
-                    onClick={[Function]}
-                  >
-                    <Button
-                      aria-controls={null}
-                      aria-expanded={false}
-                      aria-label="Help on the Snippet Preview"
-                      className="yoast-help__button c1"
-                      onClick={[Function]}
-                    >
-                      <Button
-                        activeBackgroundColor="#f7f7f7"
-                        activeBorderColor="#888"
-                        activeColor="#000"
-                        aria-controls={null}
-                        aria-expanded={false}
-                        aria-label="Help on the Snippet Preview"
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2"
-                        focusBackgroundColor="#fff"
-                        focusBorderColor="#0066cd"
-                        focusColor="#000"
-                        hoverBackgroundColor="#fff"
-                        hoverBorderColor="#888"
-                        hoverColor="#000"
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <Button
-                          activeBackgroundColor="#f7f7f7"
-                          activeBorderColor="#888"
-                          activeColor="#000"
-                          aria-controls={null}
-                          aria-expanded={false}
-                          aria-label="Help on the Snippet Preview"
-                          backgroundColor="#f7f7f7"
-                          borderColor="#ccc"
-                          boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
-                          focusBackgroundColor="#fff"
-                          focusBorderColor="#0066cd"
-                          focusColor="#000"
-                          hoverBackgroundColor="#fff"
-                          hoverBorderColor="#888"
-                          hoverColor="#000"
-                          onClick={[Function]}
-                          textColor="#555"
-                          type="button"
-                        >
-                          <Button
-                            activeBackgroundColor="#f7f7f7"
-                            activeBorderColor="#888"
-                            activeColor="#000"
-                            aria-controls={null}
-                            aria-expanded={false}
-                            aria-label="Help on the Snippet Preview"
-                            backgroundColor="#f7f7f7"
-                            borderColor="#ccc"
-                            boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            focusBackgroundColor="#fff"
-                            focusBorderColor="#0066cd"
-                            focusColor="#000"
-                            hoverBackgroundColor="#fff"
-                            hoverBorderColor="#888"
-                            hoverColor="#000"
-                            onClick={[Function]}
-                            textColor="#555"
-                            type="button"
-                          >
-                            <Button
-                              activeBackgroundColor="#f7f7f7"
-                              activeBorderColor="#888"
-                              activeColor="#000"
-                              aria-controls={null}
-                              aria-expanded={false}
-                              aria-label="Help on the Snippet Preview"
-                              backgroundColor="#f7f7f7"
-                              borderColor="#ccc"
-                              boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              focusBackgroundColor="#fff"
-                              focusBorderColor="#0066cd"
-                              focusColor="#000"
-                              hoverBackgroundColor="#fff"
-                              hoverBorderColor="#888"
-                              hoverColor="#000"
-                              onClick={[Function]}
-                              textColor="#555"
-                              type="button"
-                            >
-                              <Button__BaseButton
-                                activeBackgroundColor="#f7f7f7"
-                                activeBorderColor="#888"
-                                activeColor="#000"
-                                aria-controls={null}
-                                aria-expanded={false}
-                                aria-label="Help on the Snippet Preview"
-                                backgroundColor="#f7f7f7"
-                                borderColor="#ccc"
-                                boxShadowColor="#ccc"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                focusBackgroundColor="#fff"
-                                focusBorderColor="#0066cd"
-                                focusColor="#000"
-                                hoverBackgroundColor="#fff"
-                                hoverBorderColor="#888"
-                                hoverColor="#000"
-                                onClick={[Function]}
-                                textColor="#555"
-                                type="button"
-                              >
-                                <button
-                                  aria-controls={null}
-                                  aria-expanded={false}
-                                  aria-label="Help on the Snippet Preview"
-                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <HelpTextWrapper__StyledSvg
-                                    color="#646464"
-                                    icon="question-circle"
-                                    size="16px"
-                                  >
-                                    <SvgIcon
-                                      className="c8"
-                                      color="#646464"
-                                      icon="question-circle"
-                                      size="16px"
-                                    >
-                                      <SvgIcon__StyledSvg
-                                        aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                        fill="#646464"
-                                        focusable="false"
-                                        role="img"
-                                        size="16px"
-                                        viewBox="0 0 1792 1792"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-                                          fill="#646464"
-                                          focusable="false"
-                                          role="img"
-                                          size="16px"
-                                          viewBox="0 0 1792 1792"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                          />
-                                        </svg>
-                                      </SvgIcon__StyledSvg>
-                                    </SvgIcon>
-                                  </HelpTextWrapper__StyledSvg>
-                                </button>
-                              </Button__BaseButton>
-                            </Button>
-                          </Button>
-                        </Button>
-                      </Button>
-                    </Button>
-                  </HelpTextWrapper__HelpTextButton>
-                  <YoastSlideToggle
-                    duration={300}
-                    isOpen={false}
-                  >
-                    <animations__YoastSlideToggleContainer
-                      duration={300}
-                    >
-                      <div
-                        className="c10"
-                      >
-                        <CSSTransition
-                          classNames="slide"
-                          in={false}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExiting={[Function]}
-                          timeout={300}
-                          unmountOnExit={true}
-                        >
-                          <Transition
-                            appear={false}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            timeout={300}
-                            unmountOnExit={true}
-                          />
-                        </CSSTransition>
-                      </div>
-                    </animations__YoastSlideToggleContainer>
-                  </YoastSlideToggle>
-                </div>
-              </HelpTextWrapper__HelpTextContainer>
-            </HelpTextWrapper>
-          </div>
           <SnippetPreview__MobileContainer
             padding={20}
             width={640}
           >
             <div
-              className="c11"
+              className="c0"
               width={640}
             >
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -5934,23 +4985,23 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     onMouseUp={[Function]}
                   >
                     <div
-                      className="c13"
+                      className="c2"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <SnippetPreview__TitleBounded>
                         <SnippetPreview__Title
-                          className="c14"
+                          className="c3"
                         >
                           <div
-                            className="c14 c15"
+                            className="c3 c4"
                           >
                             <SnippetPreview__TitleUnboundedMobile
                               innerRef={[Function]}
                             >
                               <span
-                                className="c16"
+                                className="c5"
                               >
                                 Test title
                               </span>
@@ -5978,7 +5029,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   </ScreenReaderText>
                   <SnippetPreview__BaseUrl>
                     <div
-                      className="c17"
+                      className="c6"
                     >
                       <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
@@ -5986,7 +5037,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         onMouseUp={[Function]}
                       >
                         <div
-                          className="c18"
+                          className="c7"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           onMouseUp={[Function]}
@@ -6000,12 +5051,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               </SnippetPreview__MobilePartContainer>
               <SnippetPreview__Separator>
                 <hr
-                  className="c19"
+                  className="c8"
                 />
               </SnippetPreview__Separator>
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -6030,14 +5081,14 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     onMouseUp={[Function]}
                   >
                     <SnippetPreview__DesktopDescription
-                      className="c20"
+                      className="c9"
                       isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <div
-                        className="c20 c21"
+                        className="c9 c10"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
@@ -6047,12 +5098,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                           isDescriptionPlaceholder={false}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c20"
+                            className="c9"
                             innerRef={[Function]}
                             isDescriptionPlaceholder={false}
                           >
                             <div
-                              className="c20 c21"
+                              className="c9 c10"
                             >
                               Test description, %%replacement_variable%%
                             </div>
@@ -6073,7 +5124,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
       >
         <ModeSwitcher__Switcher>
           <div
-            className="c22"
+            className="c11"
           >
             <ModeSwitcher__SwitcherButton
               aria-pressed={true}
@@ -6082,7 +5133,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             >
               <Button
                 aria-pressed={true}
-                className="c23"
+                className="c12"
                 isActive={true}
                 onClick={[Function]}
               >
@@ -6094,7 +5145,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2"
+                  className="c12 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -6114,7 +5165,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3"
+                    className="c12 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -6134,7 +5185,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -6154,7 +5205,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -6174,7 +5225,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -6188,7 +5239,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         >
                           <button
                             aria-pressed={true}
-                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -6209,7 +5260,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c19"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -6254,7 +5305,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             >
               <Button
                 aria-pressed={false}
-                className="c25"
+                className="c20"
                 isActive={false}
                 onClick={[Function]}
               >
@@ -6266,7 +5317,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2"
+                  className="c20 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -6286,7 +5337,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3"
+                    className="c20 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -6306,7 +5357,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -6326,7 +5377,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -6346,7 +5397,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -6360,7 +5411,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         >
                           <button
                             aria-pressed={false}
-                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -6381,7 +5432,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c21"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -6435,7 +5486,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27"
+          className="c22"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -6455,7 +5506,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3"
+            className="c22 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -6475,7 +5526,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -6495,7 +5546,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -6515,7 +5566,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -6529,7 +5580,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 >
                   <button
                     aria-expanded={true}
-                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -6548,7 +5599,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       >
                         <svg
                           aria-hidden={true}
-                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          className="yoast-svg-icon yoast-svg-icon-edit c23"
                           focusable="false"
                           role="img"
                           size="16px"
@@ -6605,11 +5656,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           padding="0 20px"
         >
           <section
-            className="c28"
+            className="c24"
           >
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test title"
@@ -6626,12 +5677,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="30"
+                    id="17"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="30"
+                      className="c26"
+                      id="17"
                       onClick={[Function]}
                     >
                       SEO title
@@ -6641,7 +5692,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -6651,7 +5702,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -6669,7 +5720,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -6687,7 +5738,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -6705,7 +5756,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -6723,7 +5774,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -6735,7 +5786,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -6754,7 +5805,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -6783,12 +5834,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     onClick={[Function]}
                   >
                     <div
-                      className="c32"
+                      className="c28"
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="30"
+                        ariaLabelledBy="17"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -6798,7 +5849,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="30"
+                          ariaLabelledBy="17"
                           content="Test title"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -6823,7 +5874,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 >
                   <progress
                     aria-hidden="true"
-                    className="c33"
+                    className="c29"
                     max={600}
                     value={0}
                   />
@@ -6832,15 +5883,15 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-29-slug"
+                  id="snippet-editor-field-16-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c30"
-                    id="snippet-editor-field-29-slug"
+                    className="c26"
+                    id="snippet-editor-field-16-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -6852,11 +5903,11 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   onClick={[Function]}
                 >
                   <div
-                    className="c34"
+                    className="c30"
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-29-slug"
+                      aria-labelledby="snippet-editor-field-16-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -6865,8 +5916,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-29-slug"
-                        className="c35"
+                        aria-labelledby="snippet-editor-field-16-slug"
+                        className="c31"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -6880,7 +5931,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
@@ -6899,12 +5950,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="31"
+                    id="18"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="31"
+                      className="c26"
+                      id="18"
                       onClick={[Function]}
                     >
                       Meta description
@@ -6914,7 +5965,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -6924,7 +5975,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -6942,7 +5993,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -6960,7 +6011,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -6978,7 +6029,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -6996,7 +6047,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -7008,7 +6059,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -7027,7 +6078,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -7056,12 +6107,12 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                     onClick={[Function]}
                   >
                     <div
-                      className="c36"
+                      className="c32"
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="31"
+                        ariaLabelledBy="18"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -7072,7 +6123,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="31"
+                          ariaLabelledBy="18"
                           content="Test description, %%replacement_variable%%"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -7098,7 +6149,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 >
                   <progress
                     aria-hidden="true"
-                    className="c37"
+                    className="c33"
                     max={156}
                     value={42}
                   />
@@ -7118,7 +6169,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38"
+          className="c34"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -7136,7 +6187,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3"
+            className="c34 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -7154,7 +6205,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c34 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -7172,7 +6223,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -7190,7 +6241,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -7202,7 +6253,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                   type="button"
                 >
                   <button
-                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -7220,18 +6271,18 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 `;
 
 exports[`SnippetEditor closes when calling close() 1`] = `
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -7260,23 +6311,23 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -7284,14 +6335,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -7302,11 +6353,11 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c34 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -7315,57 +6366,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   margin-top: 24px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
-.c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c32 {
+.c28 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -7384,11 +6385,11 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   cursor: text;
 }
 
-.c32 .public-DraftStyleDefault-block {
+.c28 .public-DraftStyleDefault-block {
   line-height: 24px;
 }
 
-.c32::before {
+.c28::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -7400,7 +6401,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   content: "";
 }
 
-.c34 {
+.c30 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -7419,7 +6420,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   cursor: text;
 }
 
-.c34::before {
+.c30::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -7431,7 +6432,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   content: "";
 }
 
-.c36 {
+.c32 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -7453,15 +6454,15 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   line-height: 24px;
 }
 
-.c36 .public-DraftEditorPlaceholder-root {
+.c32 .public-DraftEditorPlaceholder-root {
   color: #646464;
 }
 
-.c36 .public-DraftEditorPlaceholder-hasFocus {
+.c32 .public-DraftEditorPlaceholder-hasFocus {
   color: #646464;
 }
 
-.c36::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -7473,7 +6474,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   content: "";
 }
 
-.c29 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7492,11 +6493,11 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   margin: 24px 0 0 0;
 }
 
-.c28 {
+.c24 {
   padding: 0 20px;
 }
 
-.c30 {
+.c26 {
   -webkit-flex: 1 1 200px;
   -ms-flex: 1 1 200px;
   flex: 1 1 200px;
@@ -7507,7 +6508,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   margin: 4px 0;
 }
 
-.c31 {
+.c27 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   padding-left: 8px;
@@ -7516,12 +6517,12 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   font-size: 13px;
 }
 
-.c31 svg {
+.c27 svg {
   margin-right: 7px;
   fill: #555;
 }
 
-.c11 {
+.c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -7531,12 +6532,12 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -7551,13 +6552,13 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -7566,7 +6567,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -7576,7 +6577,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -7589,7 +6590,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -7597,19 +6598,51 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c29::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
 }
 
 .c33 {
@@ -7630,53 +6663,21 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 }
 
 .c33::-webkit-progress-value {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c33::-moz-progress-bar {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
 }
 
 .c33::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
   background-color: #ee7c1b;
   border: 0;
 }
 
-.c35 {
+.c31 {
   border: none;
   width: 100%;
   height: inherit;
@@ -7686,11 +6687,11 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   color: inherit;
 }
 
-.c35:focus {
+.c31:focus {
   outline: 0;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -7704,8 +6705,8 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -7714,7 +6715,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -7728,8 +6729,8 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -7738,7 +6739,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -7747,15 +6748,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -7763,7 +6756,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -7771,8 +6764,16 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -7858,256 +6859,17 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         url="example.org/test-slug"
       >
         <section>
-          <div>
-            <HelpTextWrapper
-              className="yoast-help"
-              helpText={
-                Array [
-                  "This is a rendering of what this post might look like in Google's search results. ",
-                  <OutboundLink
-                    href="https://yoa.st/snippet-preview"
-                  >
-                    Learn more about the Snippet Preview.
-                  </OutboundLink>,
-                ]
-              }
-              helpTextButtonLabel="Help on the Snippet Preview"
-              panelMaxWidth="400px"
-            >
-              <HelpTextWrapper__HelpTextContainer
-                className="yoast-help"
-              >
-                <div
-                  className="yoast-help c0"
-                >
-                  <HelpTextWrapper__HelpTextButton
-                    aria-controls={null}
-                    aria-expanded={false}
-                    aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button"
-                    onClick={[Function]}
-                  >
-                    <Button
-                      aria-controls={null}
-                      aria-expanded={false}
-                      aria-label="Help on the Snippet Preview"
-                      className="yoast-help__button c1"
-                      onClick={[Function]}
-                    >
-                      <Button
-                        activeBackgroundColor="#f7f7f7"
-                        activeBorderColor="#888"
-                        activeColor="#000"
-                        aria-controls={null}
-                        aria-expanded={false}
-                        aria-label="Help on the Snippet Preview"
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2"
-                        focusBackgroundColor="#fff"
-                        focusBorderColor="#0066cd"
-                        focusColor="#000"
-                        hoverBackgroundColor="#fff"
-                        hoverBorderColor="#888"
-                        hoverColor="#000"
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <Button
-                          activeBackgroundColor="#f7f7f7"
-                          activeBorderColor="#888"
-                          activeColor="#000"
-                          aria-controls={null}
-                          aria-expanded={false}
-                          aria-label="Help on the Snippet Preview"
-                          backgroundColor="#f7f7f7"
-                          borderColor="#ccc"
-                          boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
-                          focusBackgroundColor="#fff"
-                          focusBorderColor="#0066cd"
-                          focusColor="#000"
-                          hoverBackgroundColor="#fff"
-                          hoverBorderColor="#888"
-                          hoverColor="#000"
-                          onClick={[Function]}
-                          textColor="#555"
-                          type="button"
-                        >
-                          <Button
-                            activeBackgroundColor="#f7f7f7"
-                            activeBorderColor="#888"
-                            activeColor="#000"
-                            aria-controls={null}
-                            aria-expanded={false}
-                            aria-label="Help on the Snippet Preview"
-                            backgroundColor="#f7f7f7"
-                            borderColor="#ccc"
-                            boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            focusBackgroundColor="#fff"
-                            focusBorderColor="#0066cd"
-                            focusColor="#000"
-                            hoverBackgroundColor="#fff"
-                            hoverBorderColor="#888"
-                            hoverColor="#000"
-                            onClick={[Function]}
-                            textColor="#555"
-                            type="button"
-                          >
-                            <Button
-                              activeBackgroundColor="#f7f7f7"
-                              activeBorderColor="#888"
-                              activeColor="#000"
-                              aria-controls={null}
-                              aria-expanded={false}
-                              aria-label="Help on the Snippet Preview"
-                              backgroundColor="#f7f7f7"
-                              borderColor="#ccc"
-                              boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              focusBackgroundColor="#fff"
-                              focusBorderColor="#0066cd"
-                              focusColor="#000"
-                              hoverBackgroundColor="#fff"
-                              hoverBorderColor="#888"
-                              hoverColor="#000"
-                              onClick={[Function]}
-                              textColor="#555"
-                              type="button"
-                            >
-                              <Button__BaseButton
-                                activeBackgroundColor="#f7f7f7"
-                                activeBorderColor="#888"
-                                activeColor="#000"
-                                aria-controls={null}
-                                aria-expanded={false}
-                                aria-label="Help on the Snippet Preview"
-                                backgroundColor="#f7f7f7"
-                                borderColor="#ccc"
-                                boxShadowColor="#ccc"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                focusBackgroundColor="#fff"
-                                focusBorderColor="#0066cd"
-                                focusColor="#000"
-                                hoverBackgroundColor="#fff"
-                                hoverBorderColor="#888"
-                                hoverColor="#000"
-                                onClick={[Function]}
-                                textColor="#555"
-                                type="button"
-                              >
-                                <button
-                                  aria-controls={null}
-                                  aria-expanded={false}
-                                  aria-label="Help on the Snippet Preview"
-                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <HelpTextWrapper__StyledSvg
-                                    color="#646464"
-                                    icon="question-circle"
-                                    size="16px"
-                                  >
-                                    <SvgIcon
-                                      className="c8"
-                                      color="#646464"
-                                      icon="question-circle"
-                                      size="16px"
-                                    >
-                                      <SvgIcon__StyledSvg
-                                        aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                        fill="#646464"
-                                        focusable="false"
-                                        role="img"
-                                        size="16px"
-                                        viewBox="0 0 1792 1792"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-                                          fill="#646464"
-                                          focusable="false"
-                                          role="img"
-                                          size="16px"
-                                          viewBox="0 0 1792 1792"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                          />
-                                        </svg>
-                                      </SvgIcon__StyledSvg>
-                                    </SvgIcon>
-                                  </HelpTextWrapper__StyledSvg>
-                                </button>
-                              </Button__BaseButton>
-                            </Button>
-                          </Button>
-                        </Button>
-                      </Button>
-                    </Button>
-                  </HelpTextWrapper__HelpTextButton>
-                  <YoastSlideToggle
-                    duration={300}
-                    isOpen={false}
-                  >
-                    <animations__YoastSlideToggleContainer
-                      duration={300}
-                    >
-                      <div
-                        className="c10"
-                      >
-                        <CSSTransition
-                          classNames="slide"
-                          in={false}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExiting={[Function]}
-                          timeout={300}
-                          unmountOnExit={true}
-                        >
-                          <Transition
-                            appear={false}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            timeout={300}
-                            unmountOnExit={true}
-                          />
-                        </CSSTransition>
-                      </div>
-                    </animations__YoastSlideToggleContainer>
-                  </YoastSlideToggle>
-                </div>
-              </HelpTextWrapper__HelpTextContainer>
-            </HelpTextWrapper>
-          </div>
           <SnippetPreview__MobileContainer
             padding={20}
             width={640}
           >
             <div
-              className="c11"
+              className="c0"
               width={640}
             >
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -8131,23 +6893,23 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     onMouseUp={[Function]}
                   >
                     <div
-                      className="c13"
+                      className="c2"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <SnippetPreview__TitleBounded>
                         <SnippetPreview__Title
-                          className="c14"
+                          className="c3"
                         >
                           <div
-                            className="c14 c15"
+                            className="c3 c4"
                           >
                             <SnippetPreview__TitleUnboundedMobile
                               innerRef={[Function]}
                             >
                               <span
-                                className="c16"
+                                className="c5"
                               >
                                 Test title
                               </span>
@@ -8175,7 +6937,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   </ScreenReaderText>
                   <SnippetPreview__BaseUrl>
                     <div
-                      className="c17"
+                      className="c6"
                     >
                       <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
@@ -8183,7 +6945,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         onMouseUp={[Function]}
                       >
                         <div
-                          className="c18"
+                          className="c7"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           onMouseUp={[Function]}
@@ -8197,12 +6959,12 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               </SnippetPreview__MobilePartContainer>
               <SnippetPreview__Separator>
                 <hr
-                  className="c19"
+                  className="c8"
                 />
               </SnippetPreview__Separator>
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -8227,14 +6989,14 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     onMouseUp={[Function]}
                   >
                     <SnippetPreview__DesktopDescription
-                      className="c20"
+                      className="c9"
                       isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <div
-                        className="c20 c21"
+                        className="c9 c10"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
@@ -8244,12 +7006,12 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                           isDescriptionPlaceholder={false}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c20"
+                            className="c9"
                             innerRef={[Function]}
                             isDescriptionPlaceholder={false}
                           >
                             <div
-                              className="c20 c21"
+                              className="c9 c10"
                             >
                               Test description, %%replacement_variable%%
                             </div>
@@ -8270,7 +7032,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
       >
         <ModeSwitcher__Switcher>
           <div
-            className="c22"
+            className="c11"
           >
             <ModeSwitcher__SwitcherButton
               aria-pressed={true}
@@ -8279,7 +7041,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             >
               <Button
                 aria-pressed={true}
-                className="c23"
+                className="c12"
                 isActive={true}
                 onClick={[Function]}
               >
@@ -8291,7 +7053,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2"
+                  className="c12 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -8311,7 +7073,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3"
+                    className="c12 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -8331,7 +7093,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -8351,7 +7113,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -8371,7 +7133,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -8385,7 +7147,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         >
                           <button
                             aria-pressed={true}
-                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -8406,7 +7168,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c19"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -8451,7 +7213,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             >
               <Button
                 aria-pressed={false}
-                className="c25"
+                className="c20"
                 isActive={false}
                 onClick={[Function]}
               >
@@ -8463,7 +7225,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2"
+                  className="c20 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -8483,7 +7245,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3"
+                    className="c20 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -8503,7 +7265,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -8523,7 +7285,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -8543,7 +7305,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -8557,7 +7319,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         >
                           <button
                             aria-pressed={false}
-                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -8578,7 +7340,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c21"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -8632,7 +7394,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27"
+          className="c22"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -8652,7 +7414,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3"
+            className="c22 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -8672,7 +7434,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -8692,7 +7454,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -8712,7 +7474,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -8726,7 +7488,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 >
                   <button
                     aria-expanded={true}
-                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -8745,7 +7507,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       >
                         <svg
                           aria-hidden={true}
-                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          className="yoast-svg-icon yoast-svg-icon-edit c23"
                           focusable="false"
                           role="img"
                           size="16px"
@@ -8802,11 +7564,11 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           padding="0 20px"
         >
           <section
-            className="c28"
+            className="c24"
           >
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test title"
@@ -8823,12 +7585,12 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="13"
+                    id="5"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="13"
+                      className="c26"
+                      id="5"
                       onClick={[Function]}
                     >
                       SEO title
@@ -8838,7 +7600,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -8848,7 +7610,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -8866,7 +7628,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -8884,7 +7646,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -8902,7 +7664,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -8920,7 +7682,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -8932,7 +7694,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -8951,7 +7713,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -8980,12 +7742,12 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     onClick={[Function]}
                   >
                     <div
-                      className="c32"
+                      className="c28"
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="13"
+                        ariaLabelledBy="5"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -8995,7 +7757,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="13"
+                          ariaLabelledBy="5"
                           content="Test title"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -9020,7 +7782,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c33"
+                    className="c29"
                     max={600}
                     value={0}
                   />
@@ -9029,15 +7791,15 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-12-slug"
+                  id="snippet-editor-field-4-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c30"
-                    id="snippet-editor-field-12-slug"
+                    className="c26"
+                    id="snippet-editor-field-4-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -9049,11 +7811,11 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   onClick={[Function]}
                 >
                   <div
-                    className="c34"
+                    className="c30"
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-12-slug"
+                      aria-labelledby="snippet-editor-field-4-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -9062,8 +7824,8 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-12-slug"
-                        className="c35"
+                        aria-labelledby="snippet-editor-field-4-slug"
+                        className="c31"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -9077,7 +7839,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
@@ -9096,12 +7858,12 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="14"
+                    id="6"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="14"
+                      className="c26"
+                      id="6"
                       onClick={[Function]}
                     >
                       Meta description
@@ -9111,7 +7873,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -9121,7 +7883,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -9139,7 +7901,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -9157,7 +7919,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -9175,7 +7937,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -9193,7 +7955,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -9205,7 +7967,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -9224,7 +7986,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -9253,12 +8015,12 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                     onClick={[Function]}
                   >
                     <div
-                      className="c36"
+                      className="c32"
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="14"
+                        ariaLabelledBy="6"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -9269,7 +8031,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="14"
+                          ariaLabelledBy="6"
                           content="Test description, %%replacement_variable%%"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -9295,7 +8057,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c37"
+                    className="c33"
                     max={156}
                     value={42}
                   />
@@ -9315,7 +8077,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38"
+          className="c34"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -9333,7 +8095,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3"
+            className="c34 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -9351,7 +8113,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c34 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -9369,7 +8131,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -9387,7 +8149,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -9399,7 +8161,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                   type="button"
                 >
                   <button
-                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -9417,18 +8179,18 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 `;
 
 exports[`SnippetEditor closes when calling close() 2`] = `
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -9457,23 +8219,23 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -9481,14 +8243,14 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -9499,61 +8261,11 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -9563,12 +8275,12 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -9583,13 +8295,13 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -9598,7 +8310,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -9608,7 +8320,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -9621,7 +8333,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -9629,22 +8341,22 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -9658,8 +8370,8 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -9668,7 +8380,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -9682,8 +8394,8 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -9692,7 +8404,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -9701,15 +8413,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -9717,7 +8421,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -9725,8 +8429,16 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -9812,256 +8524,17 @@ exports[`SnippetEditor closes when calling close() 2`] = `
         url="example.org/test-slug"
       >
         <section>
-          <div>
-            <HelpTextWrapper
-              className="yoast-help"
-              helpText={
-                Array [
-                  "This is a rendering of what this post might look like in Google's search results. ",
-                  <OutboundLink
-                    href="https://yoa.st/snippet-preview"
-                  >
-                    Learn more about the Snippet Preview.
-                  </OutboundLink>,
-                ]
-              }
-              helpTextButtonLabel="Help on the Snippet Preview"
-              panelMaxWidth="400px"
-            >
-              <HelpTextWrapper__HelpTextContainer
-                className="yoast-help"
-              >
-                <div
-                  className="yoast-help c0"
-                >
-                  <HelpTextWrapper__HelpTextButton
-                    aria-controls={null}
-                    aria-expanded={false}
-                    aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button"
-                    onClick={[Function]}
-                  >
-                    <Button
-                      aria-controls={null}
-                      aria-expanded={false}
-                      aria-label="Help on the Snippet Preview"
-                      className="yoast-help__button c1"
-                      onClick={[Function]}
-                    >
-                      <Button
-                        activeBackgroundColor="#f7f7f7"
-                        activeBorderColor="#888"
-                        activeColor="#000"
-                        aria-controls={null}
-                        aria-expanded={false}
-                        aria-label="Help on the Snippet Preview"
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2"
-                        focusBackgroundColor="#fff"
-                        focusBorderColor="#0066cd"
-                        focusColor="#000"
-                        hoverBackgroundColor="#fff"
-                        hoverBorderColor="#888"
-                        hoverColor="#000"
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <Button
-                          activeBackgroundColor="#f7f7f7"
-                          activeBorderColor="#888"
-                          activeColor="#000"
-                          aria-controls={null}
-                          aria-expanded={false}
-                          aria-label="Help on the Snippet Preview"
-                          backgroundColor="#f7f7f7"
-                          borderColor="#ccc"
-                          boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
-                          focusBackgroundColor="#fff"
-                          focusBorderColor="#0066cd"
-                          focusColor="#000"
-                          hoverBackgroundColor="#fff"
-                          hoverBorderColor="#888"
-                          hoverColor="#000"
-                          onClick={[Function]}
-                          textColor="#555"
-                          type="button"
-                        >
-                          <Button
-                            activeBackgroundColor="#f7f7f7"
-                            activeBorderColor="#888"
-                            activeColor="#000"
-                            aria-controls={null}
-                            aria-expanded={false}
-                            aria-label="Help on the Snippet Preview"
-                            backgroundColor="#f7f7f7"
-                            borderColor="#ccc"
-                            boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            focusBackgroundColor="#fff"
-                            focusBorderColor="#0066cd"
-                            focusColor="#000"
-                            hoverBackgroundColor="#fff"
-                            hoverBorderColor="#888"
-                            hoverColor="#000"
-                            onClick={[Function]}
-                            textColor="#555"
-                            type="button"
-                          >
-                            <Button
-                              activeBackgroundColor="#f7f7f7"
-                              activeBorderColor="#888"
-                              activeColor="#000"
-                              aria-controls={null}
-                              aria-expanded={false}
-                              aria-label="Help on the Snippet Preview"
-                              backgroundColor="#f7f7f7"
-                              borderColor="#ccc"
-                              boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              focusBackgroundColor="#fff"
-                              focusBorderColor="#0066cd"
-                              focusColor="#000"
-                              hoverBackgroundColor="#fff"
-                              hoverBorderColor="#888"
-                              hoverColor="#000"
-                              onClick={[Function]}
-                              textColor="#555"
-                              type="button"
-                            >
-                              <Button__BaseButton
-                                activeBackgroundColor="#f7f7f7"
-                                activeBorderColor="#888"
-                                activeColor="#000"
-                                aria-controls={null}
-                                aria-expanded={false}
-                                aria-label="Help on the Snippet Preview"
-                                backgroundColor="#f7f7f7"
-                                borderColor="#ccc"
-                                boxShadowColor="#ccc"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                focusBackgroundColor="#fff"
-                                focusBorderColor="#0066cd"
-                                focusColor="#000"
-                                hoverBackgroundColor="#fff"
-                                hoverBorderColor="#888"
-                                hoverColor="#000"
-                                onClick={[Function]}
-                                textColor="#555"
-                                type="button"
-                              >
-                                <button
-                                  aria-controls={null}
-                                  aria-expanded={false}
-                                  aria-label="Help on the Snippet Preview"
-                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <HelpTextWrapper__StyledSvg
-                                    color="#646464"
-                                    icon="question-circle"
-                                    size="16px"
-                                  >
-                                    <SvgIcon
-                                      className="c8"
-                                      color="#646464"
-                                      icon="question-circle"
-                                      size="16px"
-                                    >
-                                      <SvgIcon__StyledSvg
-                                        aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                        fill="#646464"
-                                        focusable="false"
-                                        role="img"
-                                        size="16px"
-                                        viewBox="0 0 1792 1792"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-                                          fill="#646464"
-                                          focusable="false"
-                                          role="img"
-                                          size="16px"
-                                          viewBox="0 0 1792 1792"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                          />
-                                        </svg>
-                                      </SvgIcon__StyledSvg>
-                                    </SvgIcon>
-                                  </HelpTextWrapper__StyledSvg>
-                                </button>
-                              </Button__BaseButton>
-                            </Button>
-                          </Button>
-                        </Button>
-                      </Button>
-                    </Button>
-                  </HelpTextWrapper__HelpTextButton>
-                  <YoastSlideToggle
-                    duration={300}
-                    isOpen={false}
-                  >
-                    <animations__YoastSlideToggleContainer
-                      duration={300}
-                    >
-                      <div
-                        className="c10"
-                      >
-                        <CSSTransition
-                          classNames="slide"
-                          in={false}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExiting={[Function]}
-                          timeout={300}
-                          unmountOnExit={true}
-                        >
-                          <Transition
-                            appear={false}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            timeout={300}
-                            unmountOnExit={true}
-                          />
-                        </CSSTransition>
-                      </div>
-                    </animations__YoastSlideToggleContainer>
-                  </YoastSlideToggle>
-                </div>
-              </HelpTextWrapper__HelpTextContainer>
-            </HelpTextWrapper>
-          </div>
           <SnippetPreview__MobileContainer
             padding={20}
             width={640}
           >
             <div
-              className="c11"
+              className="c0"
               width={640}
             >
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -10085,23 +8558,23 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     onMouseUp={[Function]}
                   >
                     <div
-                      className="c13"
+                      className="c2"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <SnippetPreview__TitleBounded>
                         <SnippetPreview__Title
-                          className="c14"
+                          className="c3"
                         >
                           <div
-                            className="c14 c15"
+                            className="c3 c4"
                           >
                             <SnippetPreview__TitleUnboundedMobile
                               innerRef={[Function]}
                             >
                               <span
-                                className="c16"
+                                className="c5"
                               >
                                 Test title
                               </span>
@@ -10129,7 +8602,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                   </ScreenReaderText>
                   <SnippetPreview__BaseUrl>
                     <div
-                      className="c17"
+                      className="c6"
                     >
                       <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
@@ -10137,7 +8610,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                         onMouseUp={[Function]}
                       >
                         <div
-                          className="c18"
+                          className="c7"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           onMouseUp={[Function]}
@@ -10151,12 +8624,12 @@ exports[`SnippetEditor closes when calling close() 2`] = `
               </SnippetPreview__MobilePartContainer>
               <SnippetPreview__Separator>
                 <hr
-                  className="c19"
+                  className="c8"
                 />
               </SnippetPreview__Separator>
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -10181,14 +8654,14 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     onMouseUp={[Function]}
                   >
                     <SnippetPreview__DesktopDescription
-                      className="c20"
+                      className="c9"
                       isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <div
-                        className="c20 c21"
+                        className="c9 c10"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
@@ -10198,12 +8671,12 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                           isDescriptionPlaceholder={false}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c20"
+                            className="c9"
                             innerRef={[Function]}
                             isDescriptionPlaceholder={false}
                           >
                             <div
-                              className="c20 c21"
+                              className="c9 c10"
                             >
                               Test description, %%replacement_variable%%
                             </div>
@@ -10224,7 +8697,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
       >
         <ModeSwitcher__Switcher>
           <div
-            className="c22"
+            className="c11"
           >
             <ModeSwitcher__SwitcherButton
               aria-pressed={true}
@@ -10233,7 +8706,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
             >
               <Button
                 aria-pressed={true}
-                className="c23"
+                className="c12"
                 isActive={true}
                 onClick={[Function]}
               >
@@ -10245,7 +8718,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2"
+                  className="c12 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -10265,7 +8738,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3"
+                    className="c12 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -10285,7 +8758,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -10305,7 +8778,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -10325,7 +8798,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -10339,7 +8812,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                         >
                           <button
                             aria-pressed={true}
-                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -10360,7 +8833,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c19"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -10405,7 +8878,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
             >
               <Button
                 aria-pressed={false}
-                className="c25"
+                className="c20"
                 isActive={false}
                 onClick={[Function]}
               >
@@ -10417,7 +8890,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2"
+                  className="c20 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -10437,7 +8910,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3"
+                    className="c20 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -10457,7 +8930,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -10477,7 +8950,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -10497,7 +8970,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -10511,7 +8984,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                         >
                           <button
                             aria-pressed={false}
-                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -10532,7 +9005,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c21"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -10586,7 +9059,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27"
+          className="c22"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -10606,7 +9079,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3"
+            className="c22 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -10626,7 +9099,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -10646,7 +9119,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -10666,7 +9139,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -10680,7 +9153,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                 >
                   <button
                     aria-expanded={false}
-                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -10699,7 +9172,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                       >
                         <svg
                           aria-hidden={true}
-                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          className="yoast-svg-icon yoast-svg-icon-edit c23"
                           focusable="false"
                           role="img"
                           size="16px"
@@ -10726,18 +9199,18 @@ exports[`SnippetEditor closes when calling close() 2`] = `
 `;
 
 exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -10766,23 +9239,23 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -10790,14 +9263,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -10808,11 +9281,11 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c34 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -10821,57 +9294,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   margin-top: 24px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
-.c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c32 {
+.c28 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -10890,11 +9313,11 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   cursor: text;
 }
 
-.c32 .public-DraftStyleDefault-block {
+.c28 .public-DraftStyleDefault-block {
   line-height: 24px;
 }
 
-.c32::before {
+.c28::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -10906,7 +9329,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   content: "";
 }
 
-.c34 {
+.c30 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -10925,7 +9348,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   cursor: text;
 }
 
-.c34::before {
+.c30::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -10937,7 +9360,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   content: "";
 }
 
-.c36 {
+.c32 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -10959,15 +9382,15 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   line-height: 24px;
 }
 
-.c36 .public-DraftEditorPlaceholder-root {
+.c32 .public-DraftEditorPlaceholder-root {
   color: #646464;
 }
 
-.c36 .public-DraftEditorPlaceholder-hasFocus {
+.c32 .public-DraftEditorPlaceholder-hasFocus {
   color: #646464;
 }
 
-.c36::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -10979,7 +9402,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   content: "";
 }
 
-.c29 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10998,11 +9421,11 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   margin: 24px 0 0 0;
 }
 
-.c28 {
+.c24 {
   padding: 0 20px;
 }
 
-.c30 {
+.c26 {
   -webkit-flex: 1 1 200px;
   -ms-flex: 1 1 200px;
   flex: 1 1 200px;
@@ -11013,7 +9436,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   margin: 4px 0;
 }
 
-.c31 {
+.c27 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   padding-left: 8px;
@@ -11022,12 +9445,12 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   font-size: 13px;
 }
 
-.c31 svg {
+.c27 svg {
   margin-right: 7px;
   fill: #555;
 }
 
-.c11 {
+.c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -11037,12 +9460,12 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -11057,13 +9480,13 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -11072,7 +9495,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -11082,7 +9505,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -11095,7 +9518,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -11103,19 +9526,51 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c29::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
 }
 
 .c33 {
@@ -11136,53 +9591,21 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 }
 
 .c33::-webkit-progress-value {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c33::-moz-progress-bar {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
 }
 
 .c33::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
   background-color: #ee7c1b;
   border: 0;
 }
 
-.c35 {
+.c31 {
   border: none;
   width: 100%;
   height: inherit;
@@ -11192,11 +9615,11 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   color: inherit;
 }
 
-.c35:focus {
+.c31:focus {
   outline: 0;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -11210,8 +9633,8 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -11220,7 +9643,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -11234,8 +9657,8 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -11244,7 +9667,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -11253,15 +9676,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -11269,7 +9684,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -11277,8 +9692,16 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -11364,256 +9787,17 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         url="example.org/test-slug"
       >
         <section>
-          <div>
-            <HelpTextWrapper
-              className="yoast-help"
-              helpText={
-                Array [
-                  "This is a rendering of what this post might look like in Google's search results. ",
-                  <OutboundLink
-                    href="https://yoa.st/snippet-preview"
-                  >
-                    Learn more about the Snippet Preview.
-                  </OutboundLink>,
-                ]
-              }
-              helpTextButtonLabel="Help on the Snippet Preview"
-              panelMaxWidth="400px"
-            >
-              <HelpTextWrapper__HelpTextContainer
-                className="yoast-help"
-              >
-                <div
-                  className="yoast-help c0"
-                >
-                  <HelpTextWrapper__HelpTextButton
-                    aria-controls={null}
-                    aria-expanded={false}
-                    aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button"
-                    onClick={[Function]}
-                  >
-                    <Button
-                      aria-controls={null}
-                      aria-expanded={false}
-                      aria-label="Help on the Snippet Preview"
-                      className="yoast-help__button c1"
-                      onClick={[Function]}
-                    >
-                      <Button
-                        activeBackgroundColor="#f7f7f7"
-                        activeBorderColor="#888"
-                        activeColor="#000"
-                        aria-controls={null}
-                        aria-expanded={false}
-                        aria-label="Help on the Snippet Preview"
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2"
-                        focusBackgroundColor="#fff"
-                        focusBorderColor="#0066cd"
-                        focusColor="#000"
-                        hoverBackgroundColor="#fff"
-                        hoverBorderColor="#888"
-                        hoverColor="#000"
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <Button
-                          activeBackgroundColor="#f7f7f7"
-                          activeBorderColor="#888"
-                          activeColor="#000"
-                          aria-controls={null}
-                          aria-expanded={false}
-                          aria-label="Help on the Snippet Preview"
-                          backgroundColor="#f7f7f7"
-                          borderColor="#ccc"
-                          boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
-                          focusBackgroundColor="#fff"
-                          focusBorderColor="#0066cd"
-                          focusColor="#000"
-                          hoverBackgroundColor="#fff"
-                          hoverBorderColor="#888"
-                          hoverColor="#000"
-                          onClick={[Function]}
-                          textColor="#555"
-                          type="button"
-                        >
-                          <Button
-                            activeBackgroundColor="#f7f7f7"
-                            activeBorderColor="#888"
-                            activeColor="#000"
-                            aria-controls={null}
-                            aria-expanded={false}
-                            aria-label="Help on the Snippet Preview"
-                            backgroundColor="#f7f7f7"
-                            borderColor="#ccc"
-                            boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            focusBackgroundColor="#fff"
-                            focusBorderColor="#0066cd"
-                            focusColor="#000"
-                            hoverBackgroundColor="#fff"
-                            hoverBorderColor="#888"
-                            hoverColor="#000"
-                            onClick={[Function]}
-                            textColor="#555"
-                            type="button"
-                          >
-                            <Button
-                              activeBackgroundColor="#f7f7f7"
-                              activeBorderColor="#888"
-                              activeColor="#000"
-                              aria-controls={null}
-                              aria-expanded={false}
-                              aria-label="Help on the Snippet Preview"
-                              backgroundColor="#f7f7f7"
-                              borderColor="#ccc"
-                              boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              focusBackgroundColor="#fff"
-                              focusBorderColor="#0066cd"
-                              focusColor="#000"
-                              hoverBackgroundColor="#fff"
-                              hoverBorderColor="#888"
-                              hoverColor="#000"
-                              onClick={[Function]}
-                              textColor="#555"
-                              type="button"
-                            >
-                              <Button__BaseButton
-                                activeBackgroundColor="#f7f7f7"
-                                activeBorderColor="#888"
-                                activeColor="#000"
-                                aria-controls={null}
-                                aria-expanded={false}
-                                aria-label="Help on the Snippet Preview"
-                                backgroundColor="#f7f7f7"
-                                borderColor="#ccc"
-                                boxShadowColor="#ccc"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                focusBackgroundColor="#fff"
-                                focusBorderColor="#0066cd"
-                                focusColor="#000"
-                                hoverBackgroundColor="#fff"
-                                hoverBorderColor="#888"
-                                hoverColor="#000"
-                                onClick={[Function]}
-                                textColor="#555"
-                                type="button"
-                              >
-                                <button
-                                  aria-controls={null}
-                                  aria-expanded={false}
-                                  aria-label="Help on the Snippet Preview"
-                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <HelpTextWrapper__StyledSvg
-                                    color="#646464"
-                                    icon="question-circle"
-                                    size="16px"
-                                  >
-                                    <SvgIcon
-                                      className="c8"
-                                      color="#646464"
-                                      icon="question-circle"
-                                      size="16px"
-                                    >
-                                      <SvgIcon__StyledSvg
-                                        aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                        fill="#646464"
-                                        focusable="false"
-                                        role="img"
-                                        size="16px"
-                                        viewBox="0 0 1792 1792"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-                                          fill="#646464"
-                                          focusable="false"
-                                          role="img"
-                                          size="16px"
-                                          viewBox="0 0 1792 1792"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                          />
-                                        </svg>
-                                      </SvgIcon__StyledSvg>
-                                    </SvgIcon>
-                                  </HelpTextWrapper__StyledSvg>
-                                </button>
-                              </Button__BaseButton>
-                            </Button>
-                          </Button>
-                        </Button>
-                      </Button>
-                    </Button>
-                  </HelpTextWrapper__HelpTextButton>
-                  <YoastSlideToggle
-                    duration={300}
-                    isOpen={false}
-                  >
-                    <animations__YoastSlideToggleContainer
-                      duration={300}
-                    >
-                      <div
-                        className="c10"
-                      >
-                        <CSSTransition
-                          classNames="slide"
-                          in={false}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExiting={[Function]}
-                          timeout={300}
-                          unmountOnExit={true}
-                        >
-                          <Transition
-                            appear={false}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            timeout={300}
-                            unmountOnExit={true}
-                          />
-                        </CSSTransition>
-                      </div>
-                    </animations__YoastSlideToggleContainer>
-                  </YoastSlideToggle>
-                </div>
-              </HelpTextWrapper__HelpTextContainer>
-            </HelpTextWrapper>
-          </div>
           <SnippetPreview__MobileContainer
             padding={20}
             width={640}
           >
             <div
-              className="c11"
+              className="c0"
               width={640}
             >
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -11637,23 +9821,23 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     onMouseUp={[Function]}
                   >
                     <div
-                      className="c13"
+                      className="c2"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <SnippetPreview__TitleBounded>
                         <SnippetPreview__Title
-                          className="c14"
+                          className="c3"
                         >
                           <div
-                            className="c14 c15"
+                            className="c3 c4"
                           >
                             <SnippetPreview__TitleUnboundedMobile
                               innerRef={[Function]}
                             >
                               <span
-                                className="c16"
+                                className="c5"
                               >
                                 Test title
                               </span>
@@ -11681,7 +9865,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   </ScreenReaderText>
                   <SnippetPreview__BaseUrl>
                     <div
-                      className="c17"
+                      className="c6"
                     >
                       <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
@@ -11689,7 +9873,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         onMouseUp={[Function]}
                       >
                         <div
-                          className="c18"
+                          className="c7"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           onMouseUp={[Function]}
@@ -11703,12 +9887,12 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               </SnippetPreview__MobilePartContainer>
               <SnippetPreview__Separator>
                 <hr
-                  className="c19"
+                  className="c8"
                 />
               </SnippetPreview__Separator>
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -11733,14 +9917,14 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     onMouseUp={[Function]}
                   >
                     <SnippetPreview__DesktopDescription
-                      className="c20"
+                      className="c9"
                       isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <div
-                        className="c20 c21"
+                        className="c9 c10"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
@@ -11750,12 +9934,12 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                           isDescriptionPlaceholder={false}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c20"
+                            className="c9"
                             innerRef={[Function]}
                             isDescriptionPlaceholder={false}
                           >
                             <div
-                              className="c20 c21"
+                              className="c9 c10"
                             >
                               Test description, %%replacement_variable%%
                             </div>
@@ -11776,7 +9960,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
       >
         <ModeSwitcher__Switcher>
           <div
-            className="c22"
+            className="c11"
           >
             <ModeSwitcher__SwitcherButton
               aria-pressed={true}
@@ -11785,7 +9969,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             >
               <Button
                 aria-pressed={true}
-                className="c23"
+                className="c12"
                 isActive={true}
                 onClick={[Function]}
               >
@@ -11797,7 +9981,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2"
+                  className="c12 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -11817,7 +10001,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3"
+                    className="c12 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -11837,7 +10021,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -11857,7 +10041,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -11877,7 +10061,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -11891,7 +10075,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         >
                           <button
                             aria-pressed={true}
-                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -11912,7 +10096,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c19"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -11957,7 +10141,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             >
               <Button
                 aria-pressed={false}
-                className="c25"
+                className="c20"
                 isActive={false}
                 onClick={[Function]}
               >
@@ -11969,7 +10153,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2"
+                  className="c20 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -11989,7 +10173,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3"
+                    className="c20 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -12009,7 +10193,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -12029,7 +10213,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -12049,7 +10233,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -12063,7 +10247,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         >
                           <button
                             aria-pressed={false}
-                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -12084,7 +10268,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c21"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -12138,7 +10322,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27"
+          className="c22"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -12158,7 +10342,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3"
+            className="c22 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -12178,7 +10362,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -12198,7 +10382,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -12218,7 +10402,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -12232,7 +10416,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 >
                   <button
                     aria-expanded={true}
-                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -12251,7 +10435,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       >
                         <svg
                           aria-hidden={true}
-                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          className="yoast-svg-icon yoast-svg-icon-edit c23"
                           focusable="false"
                           role="img"
                           size="16px"
@@ -12308,11 +10492,11 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           padding="0 20px"
         >
           <section
-            className="c28"
+            className="c24"
           >
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test title"
@@ -12329,12 +10513,12 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="42"
+                    id="26"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="42"
+                      className="c26"
+                      id="26"
                       onClick={[Function]}
                     >
                       SEO title
@@ -12344,7 +10528,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -12354,7 +10538,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -12372,7 +10556,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -12390,7 +10574,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -12408,7 +10592,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -12426,7 +10610,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -12438,7 +10622,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -12457,7 +10641,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -12486,12 +10670,12 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     onClick={[Function]}
                   >
                     <div
-                      className="c32"
+                      className="c28"
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="42"
+                        ariaLabelledBy="26"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -12501,7 +10685,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="42"
+                          ariaLabelledBy="26"
                           content="Test title"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -12526,7 +10710,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c33"
+                    className="c29"
                     max={600}
                     value={0}
                   />
@@ -12535,15 +10719,15 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-41-slug"
+                  id="snippet-editor-field-25-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c30"
-                    id="snippet-editor-field-41-slug"
+                    className="c26"
+                    id="snippet-editor-field-25-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -12555,11 +10739,11 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   onClick={[Function]}
                 >
                   <div
-                    className="c34"
+                    className="c30"
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-41-slug"
+                      aria-labelledby="snippet-editor-field-25-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -12568,8 +10752,8 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-41-slug"
-                        className="c35"
+                        aria-labelledby="snippet-editor-field-25-slug"
+                        className="c31"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -12583,7 +10767,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
@@ -12602,12 +10786,12 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="43"
+                    id="27"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="43"
+                      className="c26"
+                      id="27"
                       onClick={[Function]}
                     >
                       Meta description
@@ -12617,7 +10801,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -12627,7 +10811,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -12645,7 +10829,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -12663,7 +10847,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -12681,7 +10865,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -12699,7 +10883,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -12711,7 +10895,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -12730,7 +10914,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -12759,12 +10943,12 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                     onClick={[Function]}
                   >
                     <div
-                      className="c36"
+                      className="c32"
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="43"
+                        ariaLabelledBy="27"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -12775,7 +10959,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="43"
+                          ariaLabelledBy="27"
                           content="Test description, %%replacement_variable%%"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -12801,7 +10985,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c37"
+                    className="c33"
                     max={156}
                     value={42}
                   />
@@ -12821,7 +11005,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38"
+          className="c34"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -12839,7 +11023,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3"
+            className="c34 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -12857,7 +11041,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c34 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -12875,7 +11059,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -12893,7 +11077,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -12905,7 +11089,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                   type="button"
                 >
                   <button
-                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -12923,18 +11107,18 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 `;
 
 exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = `
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -12963,23 +11147,23 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -12987,14 +11171,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -13005,11 +11189,11 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c34 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -13018,57 +11202,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   margin-top: 24px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
-.c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c32 {
+.c28 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -13087,11 +11221,11 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   cursor: text;
 }
 
-.c32 .public-DraftStyleDefault-block {
+.c28 .public-DraftStyleDefault-block {
   line-height: 24px;
 }
 
-.c32::before {
+.c28::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -13103,7 +11237,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   content: "";
 }
 
-.c34 {
+.c30 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -13122,7 +11256,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   cursor: text;
 }
 
-.c34::before {
+.c30::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -13134,7 +11268,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   content: "";
 }
 
-.c36 {
+.c32 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -13156,15 +11290,15 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   line-height: 24px;
 }
 
-.c36 .public-DraftEditorPlaceholder-root {
+.c32 .public-DraftEditorPlaceholder-root {
   color: #646464;
 }
 
-.c36 .public-DraftEditorPlaceholder-hasFocus {
+.c32 .public-DraftEditorPlaceholder-hasFocus {
   color: #646464;
 }
 
-.c36::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -13176,7 +11310,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   content: "";
 }
 
-.c29 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13195,11 +11329,11 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   margin: 24px 0 0 0;
 }
 
-.c28 {
+.c24 {
   padding: 0 20px;
 }
 
-.c30 {
+.c26 {
   -webkit-flex: 1 1 200px;
   -ms-flex: 1 1 200px;
   flex: 1 1 200px;
@@ -13210,7 +11344,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   margin: 4px 0;
 }
 
-.c31 {
+.c27 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   padding-left: 8px;
@@ -13219,12 +11353,12 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   font-size: 13px;
 }
 
-.c31 svg {
+.c27 svg {
   margin-right: 7px;
   fill: #555;
 }
 
-.c11 {
+.c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -13234,12 +11368,12 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -13254,13 +11388,13 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -13269,7 +11403,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -13279,7 +11413,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -13292,7 +11426,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -13300,19 +11434,51 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c29::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
 }
 
 .c33 {
@@ -13333,53 +11499,21 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 }
 
 .c33::-webkit-progress-value {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c33::-moz-progress-bar {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
 }
 
 .c33::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
   background-color: #ee7c1b;
   border: 0;
 }
 
-.c35 {
+.c31 {
   border: none;
   width: 100%;
   height: inherit;
@@ -13389,11 +11523,11 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   color: inherit;
 }
 
-.c35:focus {
+.c31:focus {
   outline: 0;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -13407,8 +11541,8 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -13417,7 +11551,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -13431,8 +11565,8 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -13441,7 +11575,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -13450,15 +11584,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -13466,7 +11592,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -13474,8 +11600,16 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -13561,256 +11695,17 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         url="example.org/test-slug"
       >
         <section>
-          <div>
-            <HelpTextWrapper
-              className="yoast-help"
-              helpText={
-                Array [
-                  "This is a rendering of what this post might look like in Google's search results. ",
-                  <OutboundLink
-                    href="https://yoa.st/snippet-preview"
-                  >
-                    Learn more about the Snippet Preview.
-                  </OutboundLink>,
-                ]
-              }
-              helpTextButtonLabel="Help on the Snippet Preview"
-              panelMaxWidth="400px"
-            >
-              <HelpTextWrapper__HelpTextContainer
-                className="yoast-help"
-              >
-                <div
-                  className="yoast-help c0"
-                >
-                  <HelpTextWrapper__HelpTextButton
-                    aria-controls={null}
-                    aria-expanded={false}
-                    aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button"
-                    onClick={[Function]}
-                  >
-                    <Button
-                      aria-controls={null}
-                      aria-expanded={false}
-                      aria-label="Help on the Snippet Preview"
-                      className="yoast-help__button c1"
-                      onClick={[Function]}
-                    >
-                      <Button
-                        activeBackgroundColor="#f7f7f7"
-                        activeBorderColor="#888"
-                        activeColor="#000"
-                        aria-controls={null}
-                        aria-expanded={false}
-                        aria-label="Help on the Snippet Preview"
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2"
-                        focusBackgroundColor="#fff"
-                        focusBorderColor="#0066cd"
-                        focusColor="#000"
-                        hoverBackgroundColor="#fff"
-                        hoverBorderColor="#888"
-                        hoverColor="#000"
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <Button
-                          activeBackgroundColor="#f7f7f7"
-                          activeBorderColor="#888"
-                          activeColor="#000"
-                          aria-controls={null}
-                          aria-expanded={false}
-                          aria-label="Help on the Snippet Preview"
-                          backgroundColor="#f7f7f7"
-                          borderColor="#ccc"
-                          boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
-                          focusBackgroundColor="#fff"
-                          focusBorderColor="#0066cd"
-                          focusColor="#000"
-                          hoverBackgroundColor="#fff"
-                          hoverBorderColor="#888"
-                          hoverColor="#000"
-                          onClick={[Function]}
-                          textColor="#555"
-                          type="button"
-                        >
-                          <Button
-                            activeBackgroundColor="#f7f7f7"
-                            activeBorderColor="#888"
-                            activeColor="#000"
-                            aria-controls={null}
-                            aria-expanded={false}
-                            aria-label="Help on the Snippet Preview"
-                            backgroundColor="#f7f7f7"
-                            borderColor="#ccc"
-                            boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            focusBackgroundColor="#fff"
-                            focusBorderColor="#0066cd"
-                            focusColor="#000"
-                            hoverBackgroundColor="#fff"
-                            hoverBorderColor="#888"
-                            hoverColor="#000"
-                            onClick={[Function]}
-                            textColor="#555"
-                            type="button"
-                          >
-                            <Button
-                              activeBackgroundColor="#f7f7f7"
-                              activeBorderColor="#888"
-                              activeColor="#000"
-                              aria-controls={null}
-                              aria-expanded={false}
-                              aria-label="Help on the Snippet Preview"
-                              backgroundColor="#f7f7f7"
-                              borderColor="#ccc"
-                              boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              focusBackgroundColor="#fff"
-                              focusBorderColor="#0066cd"
-                              focusColor="#000"
-                              hoverBackgroundColor="#fff"
-                              hoverBorderColor="#888"
-                              hoverColor="#000"
-                              onClick={[Function]}
-                              textColor="#555"
-                              type="button"
-                            >
-                              <Button__BaseButton
-                                activeBackgroundColor="#f7f7f7"
-                                activeBorderColor="#888"
-                                activeColor="#000"
-                                aria-controls={null}
-                                aria-expanded={false}
-                                aria-label="Help on the Snippet Preview"
-                                backgroundColor="#f7f7f7"
-                                borderColor="#ccc"
-                                boxShadowColor="#ccc"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                focusBackgroundColor="#fff"
-                                focusBorderColor="#0066cd"
-                                focusColor="#000"
-                                hoverBackgroundColor="#fff"
-                                hoverBorderColor="#888"
-                                hoverColor="#000"
-                                onClick={[Function]}
-                                textColor="#555"
-                                type="button"
-                              >
-                                <button
-                                  aria-controls={null}
-                                  aria-expanded={false}
-                                  aria-label="Help on the Snippet Preview"
-                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <HelpTextWrapper__StyledSvg
-                                    color="#646464"
-                                    icon="question-circle"
-                                    size="16px"
-                                  >
-                                    <SvgIcon
-                                      className="c8"
-                                      color="#646464"
-                                      icon="question-circle"
-                                      size="16px"
-                                    >
-                                      <SvgIcon__StyledSvg
-                                        aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                        fill="#646464"
-                                        focusable="false"
-                                        role="img"
-                                        size="16px"
-                                        viewBox="0 0 1792 1792"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-                                          fill="#646464"
-                                          focusable="false"
-                                          role="img"
-                                          size="16px"
-                                          viewBox="0 0 1792 1792"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                          />
-                                        </svg>
-                                      </SvgIcon__StyledSvg>
-                                    </SvgIcon>
-                                  </HelpTextWrapper__StyledSvg>
-                                </button>
-                              </Button__BaseButton>
-                            </Button>
-                          </Button>
-                        </Button>
-                      </Button>
-                    </Button>
-                  </HelpTextWrapper__HelpTextButton>
-                  <YoastSlideToggle
-                    duration={300}
-                    isOpen={false}
-                  >
-                    <animations__YoastSlideToggleContainer
-                      duration={300}
-                    >
-                      <div
-                        className="c10"
-                      >
-                        <CSSTransition
-                          classNames="slide"
-                          in={false}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExiting={[Function]}
-                          timeout={300}
-                          unmountOnExit={true}
-                        >
-                          <Transition
-                            appear={false}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            timeout={300}
-                            unmountOnExit={true}
-                          />
-                        </CSSTransition>
-                      </div>
-                    </animations__YoastSlideToggleContainer>
-                  </YoastSlideToggle>
-                </div>
-              </HelpTextWrapper__HelpTextContainer>
-            </HelpTextWrapper>
-          </div>
           <SnippetPreview__MobileContainer
             padding={20}
             width={640}
           >
             <div
-              className="c11"
+              className="c0"
               width={640}
             >
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -13834,23 +11729,23 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     onMouseUp={[Function]}
                   >
                     <div
-                      className="c13"
+                      className="c2"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <SnippetPreview__TitleBounded>
                         <SnippetPreview__Title
-                          className="c14"
+                          className="c3"
                         >
                           <div
-                            className="c14 c15"
+                            className="c3 c4"
                           >
                             <SnippetPreview__TitleUnboundedMobile
                               innerRef={[Function]}
                             >
                               <span
-                                className="c16"
+                                className="c5"
                               >
                                 Test title
                               </span>
@@ -13878,7 +11773,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   </ScreenReaderText>
                   <SnippetPreview__BaseUrl>
                     <div
-                      className="c17"
+                      className="c6"
                     >
                       <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
@@ -13886,7 +11781,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         onMouseUp={[Function]}
                       >
                         <div
-                          className="c18"
+                          className="c7"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           onMouseUp={[Function]}
@@ -13900,12 +11795,12 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               </SnippetPreview__MobilePartContainer>
               <SnippetPreview__Separator>
                 <hr
-                  className="c19"
+                  className="c8"
                 />
               </SnippetPreview__Separator>
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -13930,14 +11825,14 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     onMouseUp={[Function]}
                   >
                     <SnippetPreview__DesktopDescription
-                      className="c20"
+                      className="c9"
                       isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <div
-                        className="c20 c21"
+                        className="c9 c10"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
@@ -13947,12 +11842,12 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                           isDescriptionPlaceholder={false}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c20"
+                            className="c9"
                             innerRef={[Function]}
                             isDescriptionPlaceholder={false}
                           >
                             <div
-                              className="c20 c21"
+                              className="c9 c10"
                             >
                               Test description, %%replacement_variable%%
                             </div>
@@ -13973,7 +11868,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
       >
         <ModeSwitcher__Switcher>
           <div
-            className="c22"
+            className="c11"
           >
             <ModeSwitcher__SwitcherButton
               aria-pressed={true}
@@ -13982,7 +11877,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             >
               <Button
                 aria-pressed={true}
-                className="c23"
+                className="c12"
                 isActive={true}
                 onClick={[Function]}
               >
@@ -13994,7 +11889,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2"
+                  className="c12 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -14014,7 +11909,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3"
+                    className="c12 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -14034,7 +11929,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -14054,7 +11949,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -14074,7 +11969,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -14088,7 +11983,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         >
                           <button
                             aria-pressed={true}
-                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -14109,7 +12004,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c19"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -14154,7 +12049,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             >
               <Button
                 aria-pressed={false}
-                className="c25"
+                className="c20"
                 isActive={false}
                 onClick={[Function]}
               >
@@ -14166,7 +12061,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2"
+                  className="c20 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -14186,7 +12081,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3"
+                    className="c20 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -14206,7 +12101,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -14226,7 +12121,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -14246,7 +12141,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -14260,7 +12155,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         >
                           <button
                             aria-pressed={false}
-                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -14281,7 +12176,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c21"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -14335,7 +12230,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27"
+          className="c22"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -14355,7 +12250,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3"
+            className="c22 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -14375,7 +12270,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -14395,7 +12290,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -14415,7 +12310,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -14429,7 +12324,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 >
                   <button
                     aria-expanded={true}
-                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -14448,7 +12343,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       >
                         <svg
                           aria-hidden={true}
-                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          className="yoast-svg-icon yoast-svg-icon-edit c23"
                           focusable="false"
                           role="img"
                           size="16px"
@@ -14505,11 +12400,11 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           padding="0 20px"
         >
           <section
-            className="c28"
+            className="c24"
           >
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test title"
@@ -14526,12 +12421,12 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="38"
+                    id="23"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="38"
+                      className="c26"
+                      id="23"
                       onClick={[Function]}
                     >
                       SEO title
@@ -14541,7 +12436,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -14551,7 +12446,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -14569,7 +12464,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -14587,7 +12482,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -14605,7 +12500,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -14623,7 +12518,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -14635,7 +12530,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -14654,7 +12549,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -14683,12 +12578,12 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     onClick={[Function]}
                   >
                     <div
-                      className="c32"
+                      className="c28"
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="38"
+                        ariaLabelledBy="23"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -14698,7 +12593,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="38"
+                          ariaLabelledBy="23"
                           content="Test title"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -14723,7 +12618,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 >
                   <progress
                     aria-hidden="true"
-                    className="c33"
+                    className="c29"
                     max={600}
                     value={0}
                   />
@@ -14732,15 +12627,15 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-37-slug"
+                  id="snippet-editor-field-22-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c30"
-                    id="snippet-editor-field-37-slug"
+                    className="c26"
+                    id="snippet-editor-field-22-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -14752,11 +12647,11 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   onClick={[Function]}
                 >
                   <div
-                    className="c34"
+                    className="c30"
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-37-slug"
+                      aria-labelledby="snippet-editor-field-22-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -14765,8 +12660,8 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-37-slug"
-                        className="c35"
+                        aria-labelledby="snippet-editor-field-22-slug"
+                        className="c31"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -14780,7 +12675,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
@@ -14799,12 +12694,12 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="39"
+                    id="24"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="39"
+                      className="c26"
+                      id="24"
                       onClick={[Function]}
                     >
                       Meta description
@@ -14814,7 +12709,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -14824,7 +12719,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -14842,7 +12737,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -14860,7 +12755,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -14878,7 +12773,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -14896,7 +12791,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -14908,7 +12803,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -14927,7 +12822,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -14956,12 +12851,12 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                     onClick={[Function]}
                   >
                     <div
-                      className="c36"
+                      className="c32"
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="39"
+                        ariaLabelledBy="24"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -14972,7 +12867,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="39"
+                          ariaLabelledBy="24"
                           content="Test description, %%replacement_variable%%"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -14998,7 +12893,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 >
                   <progress
                     aria-hidden="true"
-                    className="c37"
+                    className="c33"
                     max={156}
                     value={42}
                   />
@@ -15018,7 +12913,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38"
+          className="c34"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -15036,7 +12931,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3"
+            className="c34 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -15054,7 +12949,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c34 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -15072,7 +12967,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -15090,7 +12985,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -15102,7 +12997,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                   type="button"
                 >
                   <button
-                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -15120,18 +13015,18 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 `;
 
 exports[`SnippetEditor highlights a focused field 1`] = `
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -15160,23 +13055,23 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -15184,14 +13079,14 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -15202,61 +13097,11 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -15266,12 +13111,12 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -15286,13 +13131,13 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -15301,7 +13146,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -15311,7 +13156,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -15324,7 +13169,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -15332,22 +13177,22 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -15361,8 +13206,8 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -15371,7 +13216,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -15385,8 +13230,8 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -15395,7 +13240,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -15404,15 +13249,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -15420,7 +13257,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -15428,8 +13265,16 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -15438,45 +13283,13 @@ exports[`SnippetEditor highlights a focused field 1`] = `
 
 <div>
   <section>
-    <div>
-      <div
-        className="yoast-help c0"
-      >
-        <button
-          aria-controls={null}
-          aria-expanded={false}
-          aria-label="Help on the Snippet Preview"
-          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-          onClick={[Function]}
-          type="button"
-        >
-          <svg
-            aria-hidden={true}
-            className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-            fill="#646464"
-            focusable="false"
-            role="img"
-            size="16px"
-            viewBox="0 0 1792 1792"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-            />
-          </svg>
-        </button>
-        <div
-          className="c10"
-        />
-      </div>
-    </div>
     <div
-      className="c11"
+      className="c0"
       onMouseLeave={undefined}
       width={640}
     >
       <div
-        className="c12"
+        className="c1"
       >
         <span
           className="screen-reader-text"
@@ -15493,16 +13306,16 @@ exports[`SnippetEditor highlights a focused field 1`] = `
           SEO title preview:
         </span>
         <div
-          className="c13"
+          className="c2"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c14 c15"
+            className="c3 c4"
           >
             <span
-              className="c16"
+              className="c5"
             >
               Test title
             </span>
@@ -15523,10 +13336,10 @@ exports[`SnippetEditor highlights a focused field 1`] = `
           Url preview:
         </span>
         <div
-          className="c17"
+          className="c6"
         >
           <div
-            className="c18"
+            className="c7"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -15536,10 +13349,10 @@ exports[`SnippetEditor highlights a focused field 1`] = `
         </div>
       </div>
       <hr
-        className="c19"
+        className="c8"
       />
       <div
-        className="c12"
+        className="c1"
       >
         <span
           className="screen-reader-text"
@@ -15556,13 +13369,13 @@ exports[`SnippetEditor highlights a focused field 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c20 c21"
+          className="c9 c10"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c20 c21"
+            className="c9 c10"
           >
             Test description, %%replacement_variable%%
           </div>
@@ -15571,17 +13384,17 @@ exports[`SnippetEditor highlights a focused field 1`] = `
     </div>
   </section>
   <div
-    className="c22"
+    className="c11"
   >
     <button
       aria-pressed={true}
-      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c24"
+        className="yoast-svg-icon yoast-svg-icon-mobile c19"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -15610,13 +13423,13 @@ exports[`SnippetEditor highlights a focused field 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c26"
+        className="yoast-svg-icon yoast-svg-icon-desktop c21"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -15646,13 +13459,13 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
     onClick={[Function]}
     type="button"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c9"
+      className="yoast-svg-icon yoast-svg-icon-edit c23"
       fill={undefined}
       focusable="false"
       role="img"
@@ -15670,18 +13483,18 @@ exports[`SnippetEditor highlights a focused field 1`] = `
 `;
 
 exports[`SnippetEditor highlights a hovered field 1`] = `
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -15710,23 +13523,23 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -15734,14 +13547,14 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -15752,61 +13565,11 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -15816,12 +13579,12 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -15836,13 +13599,13 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -15851,7 +13614,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -15861,7 +13624,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -15874,7 +13637,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -15882,22 +13645,22 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -15911,8 +13674,8 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -15921,7 +13684,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -15935,8 +13698,8 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -15945,7 +13708,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -15954,15 +13717,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -15970,7 +13725,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -15978,8 +13733,16 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -15988,45 +13751,13 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
 
 <div>
   <section>
-    <div>
-      <div
-        className="yoast-help c0"
-      >
-        <button
-          aria-controls={null}
-          aria-expanded={false}
-          aria-label="Help on the Snippet Preview"
-          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-          onClick={[Function]}
-          type="button"
-        >
-          <svg
-            aria-hidden={true}
-            className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-            fill="#646464"
-            focusable="false"
-            role="img"
-            size="16px"
-            viewBox="0 0 1792 1792"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-            />
-          </svg>
-        </button>
-        <div
-          className="c10"
-        />
-      </div>
-    </div>
     <div
-      className="c11"
+      className="c0"
       onMouseLeave={undefined}
       width={640}
     >
       <div
-        className="c12"
+        className="c1"
       >
         <span
           className="screen-reader-text"
@@ -16043,16 +13774,16 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
           SEO title preview:
         </span>
         <div
-          className="c13"
+          className="c2"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c14 c15"
+            className="c3 c4"
           >
             <span
-              className="c16"
+              className="c5"
             >
               Test title
             </span>
@@ -16073,10 +13804,10 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
           Url preview:
         </span>
         <div
-          className="c17"
+          className="c6"
         >
           <div
-            className="c18"
+            className="c7"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -16086,10 +13817,10 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
         </div>
       </div>
       <hr
-        className="c19"
+        className="c8"
       />
       <div
-        className="c12"
+        className="c1"
       >
         <span
           className="screen-reader-text"
@@ -16106,13 +13837,13 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c20 c21"
+          className="c9 c10"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c20 c21"
+            className="c9 c10"
           >
             Test description, %%replacement_variable%%
           </div>
@@ -16121,17 +13852,17 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
     </div>
   </section>
   <div
-    className="c22"
+    className="c11"
   >
     <button
       aria-pressed={true}
-      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c24"
+        className="yoast-svg-icon yoast-svg-icon-mobile c19"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -16160,13 +13891,13 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c26"
+        className="yoast-svg-icon yoast-svg-icon-desktop c21"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -16196,13 +13927,13 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
     onClick={[Function]}
     type="button"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c9"
+      className="yoast-svg-icon yoast-svg-icon-edit c23"
       fill={undefined}
       focusable="false"
       role="img"
@@ -16220,18 +13951,18 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
 `;
 
 exports[`SnippetEditor highlights the active ReplacementVariableEditor when calling setFieldFocus 1`] = `
-.c7 {
+.c19 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c14 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c15 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -16260,23 +13991,23 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   min-height: 32px;
 }
 
-.c3 svg {
+.c15 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c16:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c17::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c17:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -16284,14 +14015,14 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c18:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c28 {
+.c23 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -16302,11 +14033,11 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   padding-left: 8px;
 }
 
-.c28 svg {
+.c23 svg {
   margin-right: 7px;
 }
 
-.c39 {
+.c35 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -16315,57 +14046,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   margin-top: 24px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
-.c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c33 {
+.c29 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -16384,11 +14065,11 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   cursor: text;
 }
 
-.c33 .public-DraftStyleDefault-block {
+.c29 .public-DraftStyleDefault-block {
   line-height: 24px;
 }
 
-.c33::before {
+.c29::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -16400,7 +14081,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   content: "";
 }
 
-.c35 {
+.c31 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -16419,7 +14100,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   cursor: text;
 }
 
-.c35::before {
+.c31::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -16431,7 +14112,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   content: "";
 }
 
-.c37 {
+.c33 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -16453,15 +14134,15 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   line-height: 24px;
 }
 
-.c37 .public-DraftEditorPlaceholder-root {
+.c33 .public-DraftEditorPlaceholder-root {
   color: #646464;
 }
 
-.c37 .public-DraftEditorPlaceholder-hasFocus {
+.c33 .public-DraftEditorPlaceholder-hasFocus {
   color: #646464;
 }
 
-.c37::before {
+.c33::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -16473,7 +14154,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   content: "";
 }
 
-.c30 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -16492,11 +14173,11 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   margin: 24px 0 0 0;
 }
 
-.c29 {
+.c25 {
   padding: 0 20px;
 }
 
-.c31 {
+.c27 {
   -webkit-flex: 1 1 200px;
   -ms-flex: 1 1 200px;
   flex: 1 1 200px;
@@ -16507,7 +14188,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   margin: 4px 0;
 }
 
-.c32 {
+.c28 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   padding-left: 8px;
@@ -16516,12 +14197,12 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   font-size: 13px;
 }
 
-.c32 svg {
+.c28 svg {
   margin-right: 7px;
   fill: #555;
 }
 
-.c11 {
+.c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -16531,12 +14212,12 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -16551,13 +14232,13 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -16566,7 +14247,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -16576,7 +14257,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -16589,7 +14270,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   max-width: 100%;
 }
 
-.c22 {
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -16597,19 +14278,51 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   font-size: 13px;
 }
 
-.c21 {
+.c10 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
+}
+
+.c30 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c30::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c30::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c30::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c30::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
 }
 
 .c34 {
@@ -16630,53 +14343,21 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 }
 
 .c34::-webkit-progress-value {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c34::-moz-progress-bar {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
 }
 
 .c34::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c38 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c38::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c38::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c38::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c38::-ms-fill {
   background-color: #ee7c1b;
   border: 0;
 }
 
-.c36 {
+.c32 {
   border: none;
   width: 100%;
   height: inherit;
@@ -16686,11 +14367,11 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   color: inherit;
 }
 
-.c36:focus {
+.c32:focus {
   outline: 0;
 }
 
-.c24 {
+.c13 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -16704,8 +14385,8 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   border-radius: 3px 0 0 3px;
 }
 
-.c24:hover,
-.c24:focus {
+.c13:hover,
+.c13:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -16714,7 +14395,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   box-shadow: none;
 }
 
-.c26 {
+.c21 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -16728,8 +14409,8 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   border-radius: 0 3px 3px 0;
 }
 
-.c26:hover,
-.c26:focus {
+.c21:hover,
+.c21:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -16738,7 +14419,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   box-shadow: none;
 }
 
-.c23 {
+.c12 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -16747,15 +14428,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c25 {
+.c20 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -16763,7 +14436,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   flex: none;
 }
 
-.c27 {
+.c22 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -16771,7 +14444,15 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   flex: none;
 }
 
-.c20::before {
+.c24 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c9::before {
   display: block;
   position: absolute;
   top: -3px;
@@ -16784,7 +14465,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 }
 
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c15::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -16870,256 +14551,17 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
         url="example.org/test-slug"
       >
         <section>
-          <div>
-            <HelpTextWrapper
-              className="yoast-help"
-              helpText={
-                Array [
-                  "This is a rendering of what this post might look like in Google's search results. ",
-                  <OutboundLink
-                    href="https://yoa.st/snippet-preview"
-                  >
-                    Learn more about the Snippet Preview.
-                  </OutboundLink>,
-                ]
-              }
-              helpTextButtonLabel="Help on the Snippet Preview"
-              panelMaxWidth="400px"
-            >
-              <HelpTextWrapper__HelpTextContainer
-                className="yoast-help"
-              >
-                <div
-                  className="yoast-help c0"
-                >
-                  <HelpTextWrapper__HelpTextButton
-                    aria-controls={null}
-                    aria-expanded={false}
-                    aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button"
-                    onClick={[Function]}
-                  >
-                    <Button
-                      aria-controls={null}
-                      aria-expanded={false}
-                      aria-label="Help on the Snippet Preview"
-                      className="yoast-help__button c1"
-                      onClick={[Function]}
-                    >
-                      <Button
-                        activeBackgroundColor="#f7f7f7"
-                        activeBorderColor="#888"
-                        activeColor="#000"
-                        aria-controls={null}
-                        aria-expanded={false}
-                        aria-label="Help on the Snippet Preview"
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2"
-                        focusBackgroundColor="#fff"
-                        focusBorderColor="#0066cd"
-                        focusColor="#000"
-                        hoverBackgroundColor="#fff"
-                        hoverBorderColor="#888"
-                        hoverColor="#000"
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <Button
-                          activeBackgroundColor="#f7f7f7"
-                          activeBorderColor="#888"
-                          activeColor="#000"
-                          aria-controls={null}
-                          aria-expanded={false}
-                          aria-label="Help on the Snippet Preview"
-                          backgroundColor="#f7f7f7"
-                          borderColor="#ccc"
-                          boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
-                          focusBackgroundColor="#fff"
-                          focusBorderColor="#0066cd"
-                          focusColor="#000"
-                          hoverBackgroundColor="#fff"
-                          hoverBorderColor="#888"
-                          hoverColor="#000"
-                          onClick={[Function]}
-                          textColor="#555"
-                          type="button"
-                        >
-                          <Button
-                            activeBackgroundColor="#f7f7f7"
-                            activeBorderColor="#888"
-                            activeColor="#000"
-                            aria-controls={null}
-                            aria-expanded={false}
-                            aria-label="Help on the Snippet Preview"
-                            backgroundColor="#f7f7f7"
-                            borderColor="#ccc"
-                            boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            focusBackgroundColor="#fff"
-                            focusBorderColor="#0066cd"
-                            focusColor="#000"
-                            hoverBackgroundColor="#fff"
-                            hoverBorderColor="#888"
-                            hoverColor="#000"
-                            onClick={[Function]}
-                            textColor="#555"
-                            type="button"
-                          >
-                            <Button
-                              activeBackgroundColor="#f7f7f7"
-                              activeBorderColor="#888"
-                              activeColor="#000"
-                              aria-controls={null}
-                              aria-expanded={false}
-                              aria-label="Help on the Snippet Preview"
-                              backgroundColor="#f7f7f7"
-                              borderColor="#ccc"
-                              boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              focusBackgroundColor="#fff"
-                              focusBorderColor="#0066cd"
-                              focusColor="#000"
-                              hoverBackgroundColor="#fff"
-                              hoverBorderColor="#888"
-                              hoverColor="#000"
-                              onClick={[Function]}
-                              textColor="#555"
-                              type="button"
-                            >
-                              <Button__BaseButton
-                                activeBackgroundColor="#f7f7f7"
-                                activeBorderColor="#888"
-                                activeColor="#000"
-                                aria-controls={null}
-                                aria-expanded={false}
-                                aria-label="Help on the Snippet Preview"
-                                backgroundColor="#f7f7f7"
-                                borderColor="#ccc"
-                                boxShadowColor="#ccc"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                focusBackgroundColor="#fff"
-                                focusBorderColor="#0066cd"
-                                focusColor="#000"
-                                hoverBackgroundColor="#fff"
-                                hoverBorderColor="#888"
-                                hoverColor="#000"
-                                onClick={[Function]}
-                                textColor="#555"
-                                type="button"
-                              >
-                                <button
-                                  aria-controls={null}
-                                  aria-expanded={false}
-                                  aria-label="Help on the Snippet Preview"
-                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <HelpTextWrapper__StyledSvg
-                                    color="#646464"
-                                    icon="question-circle"
-                                    size="16px"
-                                  >
-                                    <SvgIcon
-                                      className="c8"
-                                      color="#646464"
-                                      icon="question-circle"
-                                      size="16px"
-                                    >
-                                      <SvgIcon__StyledSvg
-                                        aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                        fill="#646464"
-                                        focusable="false"
-                                        role="img"
-                                        size="16px"
-                                        viewBox="0 0 1792 1792"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-                                          fill="#646464"
-                                          focusable="false"
-                                          role="img"
-                                          size="16px"
-                                          viewBox="0 0 1792 1792"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                          />
-                                        </svg>
-                                      </SvgIcon__StyledSvg>
-                                    </SvgIcon>
-                                  </HelpTextWrapper__StyledSvg>
-                                </button>
-                              </Button__BaseButton>
-                            </Button>
-                          </Button>
-                        </Button>
-                      </Button>
-                    </Button>
-                  </HelpTextWrapper__HelpTextButton>
-                  <YoastSlideToggle
-                    duration={300}
-                    isOpen={false}
-                  >
-                    <animations__YoastSlideToggleContainer
-                      duration={300}
-                    >
-                      <div
-                        className="c10"
-                      >
-                        <CSSTransition
-                          classNames="slide"
-                          in={false}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExiting={[Function]}
-                          timeout={300}
-                          unmountOnExit={true}
-                        >
-                          <Transition
-                            appear={false}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            timeout={300}
-                            unmountOnExit={true}
-                          />
-                        </CSSTransition>
-                      </div>
-                    </animations__YoastSlideToggleContainer>
-                  </YoastSlideToggle>
-                </div>
-              </HelpTextWrapper__HelpTextContainer>
-            </HelpTextWrapper>
-          </div>
           <SnippetPreview__MobileContainer
             padding={20}
             width={640}
           >
             <div
-              className="c11"
+              className="c0"
               width={640}
             >
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -17143,23 +14585,23 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     onMouseUp={[Function]}
                   >
                     <div
-                      className="c13"
+                      className="c2"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <SnippetPreview__TitleBounded>
                         <SnippetPreview__Title
-                          className="c14"
+                          className="c3"
                         >
                           <div
-                            className="c14 c15"
+                            className="c3 c4"
                           >
                             <SnippetPreview__TitleUnboundedMobile
                               innerRef={[Function]}
                             >
                               <span
-                                className="c16"
+                                className="c5"
                               >
                                 Test title
                               </span>
@@ -17187,7 +14629,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   </ScreenReaderText>
                   <SnippetPreview__BaseUrl>
                     <div
-                      className="c17"
+                      className="c6"
                     >
                       <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
@@ -17195,7 +14637,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         onMouseUp={[Function]}
                       >
                         <div
-                          className="c18"
+                          className="c7"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           onMouseUp={[Function]}
@@ -17209,12 +14651,12 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
               </SnippetPreview__MobilePartContainer>
               <SnippetPreview__Separator>
                 <hr
-                  className="c19"
+                  className="c8"
                 />
               </SnippetPreview__Separator>
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -17239,21 +14681,21 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     onMouseUp={[Function]}
                   >
                     <SnippetPreview__MobileDescription
-                      className="c20"
+                      className="c9"
                       isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <SnippetPreview__DesktopDescription
-                        className="c20 c21"
+                        className="c9 c10"
                         isDescriptionPlaceholder={false}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
                         <div
-                          className="c20 c21 c22"
+                          className="c9 c10 c11"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           onMouseUp={[Function]}
@@ -17263,12 +14705,12 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                             isDescriptionPlaceholder={false}
                           >
                             <SnippetPreview__DesktopDescription
-                              className="c21"
+                              className="c10"
                               innerRef={[Function]}
                               isDescriptionPlaceholder={false}
                             >
                               <div
-                                className="c21 c22"
+                                className="c10 c11"
                               >
                                 Test description, %%replacement_variable%%
                               </div>
@@ -17290,7 +14732,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
       >
         <ModeSwitcher__Switcher>
           <div
-            className="c23"
+            className="c12"
           >
             <ModeSwitcher__SwitcherButton
               aria-pressed={true}
@@ -17299,7 +14741,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
             >
               <Button
                 aria-pressed={true}
-                className="c24"
+                className="c13"
                 isActive={true}
                 onClick={[Function]}
               >
@@ -17311,7 +14753,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c24 c2"
+                  className="c13 c14"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -17331,7 +14773,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c24 c2 Button-kDSBcD c3"
+                    className="c13 c14 Button-kDSBcD c15"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -17351,7 +14793,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -17371,7 +14813,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -17391,7 +14833,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -17405,7 +14847,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         >
                           <button
                             aria-pressed={true}
-                            className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                             onClick={[Function]}
                             type="button"
                           >
@@ -17426,7 +14868,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-mobile c25"
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c20"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -17471,7 +14913,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
             >
               <Button
                 aria-pressed={false}
-                className="c26"
+                className="c21"
                 isActive={false}
                 onClick={[Function]}
               >
@@ -17483,7 +14925,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c26 c2"
+                  className="c21 c14"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -17503,7 +14945,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c26 c2 Button-kDSBcD c3"
+                    className="c21 c14 Button-kDSBcD c15"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -17523,7 +14965,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -17543,7 +14985,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -17563,7 +15005,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -17577,7 +15019,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         >
                           <button
                             aria-pressed={false}
-                            className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                             onClick={[Function]}
                             type="button"
                           >
@@ -17598,7 +15040,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-desktop c27"
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c22"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -17652,7 +15094,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c28"
+          className="c23"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -17672,7 +15114,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c28 Button-kDSBcD c3"
+            className="c23 Button-kDSBcD c15"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -17692,7 +15134,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c23 Button-kDSBcD c15 Button-kDSBcD c16"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -17712,7 +15154,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -17732,7 +15174,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -17746,7 +15188,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 >
                   <button
                     aria-expanded={true}
-                    className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                     onClick={[Function]}
                     type="button"
                   >
@@ -17765,7 +15207,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       >
                         <svg
                           aria-hidden={true}
-                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          className="yoast-svg-icon yoast-svg-icon-edit c24"
                           focusable="false"
                           role="img"
                           size="16px"
@@ -17822,11 +15264,11 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           padding="0 20px"
         >
           <section
-            className="c29"
+            className="c25"
           >
             <Shared__FormSection>
               <div
-                className="c30"
+                className="c26"
               >
                 <ReplacementVariableEditor
                   content="Test title"
@@ -17843,12 +15285,12 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="21"
+                    id="11"
                     onClick={[Function]}
                   >
                     <div
-                      className="c31"
-                      id="21"
+                      className="c27"
+                      id="11"
                       onClick={[Function]}
                     >
                       SEO title
@@ -17858,7 +15300,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     onClick={[Function]}
                   >
                     <Button
-                      className="c32"
+                      className="c28"
                       onClick={[Function]}
                     >
                       <Button
@@ -17868,7 +15310,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c32 c2"
+                        className="c28 c14"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -17886,7 +15328,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c32 c2 Button-kDSBcD c3"
+                          className="c28 c14 Button-kDSBcD c15"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -17904,7 +15346,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -17922,7 +15364,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -17940,7 +15382,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -17952,7 +15394,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                 type="button"
                               >
                                 <button
-                                  className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -17971,7 +15413,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c24"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -18000,12 +15442,12 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     onClick={[Function]}
                   >
                     <div
-                      className="c33"
+                      className="c29"
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="21"
+                        ariaLabelledBy="11"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -18015,7 +15457,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="21"
+                          ariaLabelledBy="11"
                           content="Test title"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -18040,7 +15482,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 >
                   <progress
                     aria-hidden="true"
-                    className="c34"
+                    className="c30"
                     max={600}
                     value={0}
                   />
@@ -18049,15 +15491,15 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c30"
+                className="c26"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-20-slug"
+                  id="snippet-editor-field-10-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c31"
-                    id="snippet-editor-field-20-slug"
+                    className="c27"
+                    id="snippet-editor-field-10-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -18069,11 +15511,11 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   onClick={[Function]}
                 >
                   <div
-                    className="c35"
+                    className="c31"
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-20-slug"
+                      aria-labelledby="snippet-editor-field-10-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -18082,8 +15524,8 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-20-slug"
-                        className="c36"
+                        aria-labelledby="snippet-editor-field-10-slug"
+                        className="c32"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -18097,7 +15539,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c30"
+                className="c26"
               >
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
@@ -18116,12 +15558,12 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="22"
+                    id="12"
                     onClick={[Function]}
                   >
                     <div
-                      className="c31"
-                      id="22"
+                      className="c27"
+                      id="12"
                       onClick={[Function]}
                     >
                       Meta description
@@ -18131,7 +15573,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     onClick={[Function]}
                   >
                     <Button
-                      className="c32"
+                      className="c28"
                       onClick={[Function]}
                     >
                       <Button
@@ -18141,7 +15583,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c32 c2"
+                        className="c28 c14"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -18159,7 +15601,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c32 c2 Button-kDSBcD c3"
+                          className="c28 c14 Button-kDSBcD c15"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -18177,7 +15619,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -18195,7 +15637,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -18213,7 +15655,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -18225,7 +15667,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                 type="button"
                               >
                                 <button
-                                  className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -18244,7 +15686,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c24"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -18273,12 +15715,12 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                     onClick={[Function]}
                   >
                     <div
-                      className="c37"
+                      className="c33"
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="22"
+                        ariaLabelledBy="12"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -18289,7 +15731,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="22"
+                          ariaLabelledBy="12"
                           content="Test description, %%replacement_variable%%"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -18315,7 +15757,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 >
                   <progress
                     aria-hidden="true"
-                    className="c38"
+                    className="c34"
                     max={156}
                     value={42}
                   />
@@ -18335,7 +15777,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c39"
+          className="c35"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -18353,7 +15795,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c39 Button-kDSBcD c3"
+            className="c35 Button-kDSBcD c15"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -18371,7 +15813,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c39 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c35 Button-kDSBcD c15 Button-kDSBcD c16"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -18389,7 +15831,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c35 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -18407,7 +15849,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c35 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -18419,7 +15861,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                   type="button"
                 >
                   <button
-                    className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c35 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                     onClick={[Function]}
                     type="button"
                   >
@@ -18437,18 +15879,18 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 `;
 
 exports[`SnippetEditor highlights the hovered field when onMouseEnter() is called 1`] = `
-.c7 {
+.c19 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c14 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c15 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -18477,23 +15919,23 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   min-height: 32px;
 }
 
-.c3 svg {
+.c15 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c16:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c17::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c17:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -18501,14 +15943,14 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c18:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c28 {
+.c23 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -18519,11 +15961,11 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   padding-left: 8px;
 }
 
-.c28 svg {
+.c23 svg {
   margin-right: 7px;
 }
 
-.c39 {
+.c35 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -18532,57 +15974,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   margin-top: 24px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
-.c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c33 {
+.c29 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -18601,11 +15993,11 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   cursor: text;
 }
 
-.c33 .public-DraftStyleDefault-block {
+.c29 .public-DraftStyleDefault-block {
   line-height: 24px;
 }
 
-.c33::before {
+.c29::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -18617,7 +16009,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   content: "";
 }
 
-.c35 {
+.c31 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -18636,7 +16028,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   cursor: text;
 }
 
-.c35::before {
+.c31::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -18648,7 +16040,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   content: "";
 }
 
-.c37 {
+.c33 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -18670,15 +16062,15 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   line-height: 24px;
 }
 
-.c37 .public-DraftEditorPlaceholder-root {
+.c33 .public-DraftEditorPlaceholder-root {
   color: #646464;
 }
 
-.c37 .public-DraftEditorPlaceholder-hasFocus {
+.c33 .public-DraftEditorPlaceholder-hasFocus {
   color: #646464;
 }
 
-.c37::before {
+.c33::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -18690,7 +16082,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   content: "";
 }
 
-.c30 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -18709,11 +16101,11 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   margin: 24px 0 0 0;
 }
 
-.c29 {
+.c25 {
   padding: 0 20px;
 }
 
-.c31 {
+.c27 {
   -webkit-flex: 1 1 200px;
   -ms-flex: 1 1 200px;
   flex: 1 1 200px;
@@ -18724,7 +16116,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   margin: 4px 0;
 }
 
-.c32 {
+.c28 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   padding-left: 8px;
@@ -18733,12 +16125,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   font-size: 13px;
 }
 
-.c32 svg {
+.c28 svg {
   margin-right: 7px;
   fill: #555;
 }
 
-.c11 {
+.c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -18748,12 +16140,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -18768,13 +16160,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -18783,7 +16175,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -18793,7 +16185,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -18806,7 +16198,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   max-width: 100%;
 }
 
-.c22 {
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -18814,19 +16206,51 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   font-size: 13px;
 }
 
-.c21 {
+.c10 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
+}
+
+.c30 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c30::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c30::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c30::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c30::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
 }
 
 .c34 {
@@ -18847,53 +16271,21 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 }
 
 .c34::-webkit-progress-value {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c34::-moz-progress-bar {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
 }
 
 .c34::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c38 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c38::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c38::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c38::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c38::-ms-fill {
   background-color: #ee7c1b;
   border: 0;
 }
 
-.c36 {
+.c32 {
   border: none;
   width: 100%;
   height: inherit;
@@ -18903,11 +16295,11 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   color: inherit;
 }
 
-.c36:focus {
+.c32:focus {
   outline: 0;
 }
 
-.c24 {
+.c13 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -18921,8 +16313,8 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   border-radius: 3px 0 0 3px;
 }
 
-.c24:hover,
-.c24:focus {
+.c13:hover,
+.c13:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -18931,7 +16323,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   box-shadow: none;
 }
 
-.c26 {
+.c21 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -18945,8 +16337,8 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   border-radius: 0 3px 3px 0;
 }
 
-.c26:hover,
-.c26:focus {
+.c21:hover,
+.c21:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -18955,7 +16347,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   box-shadow: none;
 }
 
-.c23 {
+.c12 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -18964,15 +16356,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c25 {
+.c20 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -18980,7 +16364,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   flex: none;
 }
 
-.c27 {
+.c22 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -18988,7 +16372,15 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   flex: none;
 }
 
-.c20::before {
+.c24 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c9::before {
   display: block;
   position: absolute;
   top: -3px;
@@ -19001,7 +16393,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 }
 
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c15::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -19087,256 +16479,17 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
         url="example.org/test-slug"
       >
         <section>
-          <div>
-            <HelpTextWrapper
-              className="yoast-help"
-              helpText={
-                Array [
-                  "This is a rendering of what this post might look like in Google's search results. ",
-                  <OutboundLink
-                    href="https://yoa.st/snippet-preview"
-                  >
-                    Learn more about the Snippet Preview.
-                  </OutboundLink>,
-                ]
-              }
-              helpTextButtonLabel="Help on the Snippet Preview"
-              panelMaxWidth="400px"
-            >
-              <HelpTextWrapper__HelpTextContainer
-                className="yoast-help"
-              >
-                <div
-                  className="yoast-help c0"
-                >
-                  <HelpTextWrapper__HelpTextButton
-                    aria-controls={null}
-                    aria-expanded={false}
-                    aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button"
-                    onClick={[Function]}
-                  >
-                    <Button
-                      aria-controls={null}
-                      aria-expanded={false}
-                      aria-label="Help on the Snippet Preview"
-                      className="yoast-help__button c1"
-                      onClick={[Function]}
-                    >
-                      <Button
-                        activeBackgroundColor="#f7f7f7"
-                        activeBorderColor="#888"
-                        activeColor="#000"
-                        aria-controls={null}
-                        aria-expanded={false}
-                        aria-label="Help on the Snippet Preview"
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2"
-                        focusBackgroundColor="#fff"
-                        focusBorderColor="#0066cd"
-                        focusColor="#000"
-                        hoverBackgroundColor="#fff"
-                        hoverBorderColor="#888"
-                        hoverColor="#000"
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <Button
-                          activeBackgroundColor="#f7f7f7"
-                          activeBorderColor="#888"
-                          activeColor="#000"
-                          aria-controls={null}
-                          aria-expanded={false}
-                          aria-label="Help on the Snippet Preview"
-                          backgroundColor="#f7f7f7"
-                          borderColor="#ccc"
-                          boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
-                          focusBackgroundColor="#fff"
-                          focusBorderColor="#0066cd"
-                          focusColor="#000"
-                          hoverBackgroundColor="#fff"
-                          hoverBorderColor="#888"
-                          hoverColor="#000"
-                          onClick={[Function]}
-                          textColor="#555"
-                          type="button"
-                        >
-                          <Button
-                            activeBackgroundColor="#f7f7f7"
-                            activeBorderColor="#888"
-                            activeColor="#000"
-                            aria-controls={null}
-                            aria-expanded={false}
-                            aria-label="Help on the Snippet Preview"
-                            backgroundColor="#f7f7f7"
-                            borderColor="#ccc"
-                            boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            focusBackgroundColor="#fff"
-                            focusBorderColor="#0066cd"
-                            focusColor="#000"
-                            hoverBackgroundColor="#fff"
-                            hoverBorderColor="#888"
-                            hoverColor="#000"
-                            onClick={[Function]}
-                            textColor="#555"
-                            type="button"
-                          >
-                            <Button
-                              activeBackgroundColor="#f7f7f7"
-                              activeBorderColor="#888"
-                              activeColor="#000"
-                              aria-controls={null}
-                              aria-expanded={false}
-                              aria-label="Help on the Snippet Preview"
-                              backgroundColor="#f7f7f7"
-                              borderColor="#ccc"
-                              boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              focusBackgroundColor="#fff"
-                              focusBorderColor="#0066cd"
-                              focusColor="#000"
-                              hoverBackgroundColor="#fff"
-                              hoverBorderColor="#888"
-                              hoverColor="#000"
-                              onClick={[Function]}
-                              textColor="#555"
-                              type="button"
-                            >
-                              <Button__BaseButton
-                                activeBackgroundColor="#f7f7f7"
-                                activeBorderColor="#888"
-                                activeColor="#000"
-                                aria-controls={null}
-                                aria-expanded={false}
-                                aria-label="Help on the Snippet Preview"
-                                backgroundColor="#f7f7f7"
-                                borderColor="#ccc"
-                                boxShadowColor="#ccc"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                focusBackgroundColor="#fff"
-                                focusBorderColor="#0066cd"
-                                focusColor="#000"
-                                hoverBackgroundColor="#fff"
-                                hoverBorderColor="#888"
-                                hoverColor="#000"
-                                onClick={[Function]}
-                                textColor="#555"
-                                type="button"
-                              >
-                                <button
-                                  aria-controls={null}
-                                  aria-expanded={false}
-                                  aria-label="Help on the Snippet Preview"
-                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <HelpTextWrapper__StyledSvg
-                                    color="#646464"
-                                    icon="question-circle"
-                                    size="16px"
-                                  >
-                                    <SvgIcon
-                                      className="c8"
-                                      color="#646464"
-                                      icon="question-circle"
-                                      size="16px"
-                                    >
-                                      <SvgIcon__StyledSvg
-                                        aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                        fill="#646464"
-                                        focusable="false"
-                                        role="img"
-                                        size="16px"
-                                        viewBox="0 0 1792 1792"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-                                          fill="#646464"
-                                          focusable="false"
-                                          role="img"
-                                          size="16px"
-                                          viewBox="0 0 1792 1792"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                          />
-                                        </svg>
-                                      </SvgIcon__StyledSvg>
-                                    </SvgIcon>
-                                  </HelpTextWrapper__StyledSvg>
-                                </button>
-                              </Button__BaseButton>
-                            </Button>
-                          </Button>
-                        </Button>
-                      </Button>
-                    </Button>
-                  </HelpTextWrapper__HelpTextButton>
-                  <YoastSlideToggle
-                    duration={300}
-                    isOpen={false}
-                  >
-                    <animations__YoastSlideToggleContainer
-                      duration={300}
-                    >
-                      <div
-                        className="c10"
-                      >
-                        <CSSTransition
-                          classNames="slide"
-                          in={false}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExiting={[Function]}
-                          timeout={300}
-                          unmountOnExit={true}
-                        >
-                          <Transition
-                            appear={false}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            timeout={300}
-                            unmountOnExit={true}
-                          />
-                        </CSSTransition>
-                      </div>
-                    </animations__YoastSlideToggleContainer>
-                  </YoastSlideToggle>
-                </div>
-              </HelpTextWrapper__HelpTextContainer>
-            </HelpTextWrapper>
-          </div>
           <SnippetPreview__MobileContainer
             padding={20}
             width={640}
           >
             <div
-              className="c11"
+              className="c0"
               width={640}
             >
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -19360,23 +16513,23 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     onMouseUp={[Function]}
                   >
                     <div
-                      className="c13"
+                      className="c2"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <SnippetPreview__TitleBounded>
                         <SnippetPreview__Title
-                          className="c14"
+                          className="c3"
                         >
                           <div
-                            className="c14 c15"
+                            className="c3 c4"
                           >
                             <SnippetPreview__TitleUnboundedMobile
                               innerRef={[Function]}
                             >
                               <span
-                                className="c16"
+                                className="c5"
                               >
                                 Test title
                               </span>
@@ -19404,7 +16557,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   </ScreenReaderText>
                   <SnippetPreview__BaseUrl>
                     <div
-                      className="c17"
+                      className="c6"
                     >
                       <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
@@ -19412,7 +16565,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         onMouseUp={[Function]}
                       >
                         <div
-                          className="c18"
+                          className="c7"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           onMouseUp={[Function]}
@@ -19426,12 +16579,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
               </SnippetPreview__MobilePartContainer>
               <SnippetPreview__Separator>
                 <hr
-                  className="c19"
+                  className="c8"
                 />
               </SnippetPreview__Separator>
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -19456,21 +16609,21 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     onMouseUp={[Function]}
                   >
                     <SnippetPreview__MobileDescription
-                      className="c20"
+                      className="c9"
                       isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <SnippetPreview__DesktopDescription
-                        className="c20 c21"
+                        className="c9 c10"
                         isDescriptionPlaceholder={false}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
                       >
                         <div
-                          className="c20 c21 c22"
+                          className="c9 c10 c11"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           onMouseUp={[Function]}
@@ -19480,12 +16633,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                             isDescriptionPlaceholder={false}
                           >
                             <SnippetPreview__DesktopDescription
-                              className="c21"
+                              className="c10"
                               innerRef={[Function]}
                               isDescriptionPlaceholder={false}
                             >
                               <div
-                                className="c21 c22"
+                                className="c10 c11"
                               >
                                 Test description, %%replacement_variable%%
                               </div>
@@ -19507,7 +16660,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
       >
         <ModeSwitcher__Switcher>
           <div
-            className="c23"
+            className="c12"
           >
             <ModeSwitcher__SwitcherButton
               aria-pressed={true}
@@ -19516,7 +16669,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
             >
               <Button
                 aria-pressed={true}
-                className="c24"
+                className="c13"
                 isActive={true}
                 onClick={[Function]}
               >
@@ -19528,7 +16681,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c24 c2"
+                  className="c13 c14"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -19548,7 +16701,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c24 c2 Button-kDSBcD c3"
+                    className="c13 c14 Button-kDSBcD c15"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -19568,7 +16721,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -19588,7 +16741,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -19608,7 +16761,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -19622,7 +16775,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         >
                           <button
                             aria-pressed={true}
-                            className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                             onClick={[Function]}
                             type="button"
                           >
@@ -19643,7 +16796,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-mobile c25"
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c20"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -19688,7 +16841,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
             >
               <Button
                 aria-pressed={false}
-                className="c26"
+                className="c21"
                 isActive={false}
                 onClick={[Function]}
               >
@@ -19700,7 +16853,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c26 c2"
+                  className="c21 c14"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -19720,7 +16873,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c26 c2 Button-kDSBcD c3"
+                    className="c21 c14 Button-kDSBcD c15"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -19740,7 +16893,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -19760,7 +16913,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -19780,7 +16933,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -19794,7 +16947,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         >
                           <button
                             aria-pressed={false}
-                            className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                             onClick={[Function]}
                             type="button"
                           >
@@ -19815,7 +16968,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-desktop c27"
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c22"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -19869,7 +17022,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c28"
+          className="c23"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -19889,7 +17042,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c28 Button-kDSBcD c3"
+            className="c23 Button-kDSBcD c15"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -19909,7 +17062,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c28 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c23 Button-kDSBcD c15 Button-kDSBcD c16"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -19929,7 +17082,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -19949,7 +17102,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -19963,7 +17116,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                 >
                   <button
                     aria-expanded={true}
-                    className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                     onClick={[Function]}
                     type="button"
                   >
@@ -19982,7 +17135,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                       >
                         <svg
                           aria-hidden={true}
-                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          className="yoast-svg-icon yoast-svg-icon-edit c24"
                           focusable="false"
                           role="img"
                           size="16px"
@@ -20039,11 +17192,11 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
           padding="0 20px"
         >
           <section
-            className="c29"
+            className="c25"
           >
             <Shared__FormSection>
               <div
-                className="c30"
+                className="c26"
               >
                 <ReplacementVariableEditor
                   content="Test title"
@@ -20060,12 +17213,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="17"
+                    id="8"
                     onClick={[Function]}
                   >
                     <div
-                      className="c31"
-                      id="17"
+                      className="c27"
+                      id="8"
                       onClick={[Function]}
                     >
                       SEO title
@@ -20075,7 +17228,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     onClick={[Function]}
                   >
                     <Button
-                      className="c32"
+                      className="c28"
                       onClick={[Function]}
                     >
                       <Button
@@ -20085,7 +17238,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c32 c2"
+                        className="c28 c14"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -20103,7 +17256,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c32 c2 Button-kDSBcD c3"
+                          className="c28 c14 Button-kDSBcD c15"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -20121,7 +17274,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -20139,7 +17292,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -20157,7 +17310,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -20169,7 +17322,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                 type="button"
                               >
                                 <button
-                                  className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -20188,7 +17341,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c24"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -20217,12 +17370,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     onClick={[Function]}
                   >
                     <div
-                      className="c33"
+                      className="c29"
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="17"
+                        ariaLabelledBy="8"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -20232,7 +17385,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="17"
+                          ariaLabelledBy="8"
                           content="Test title"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -20257,7 +17410,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                 >
                   <progress
                     aria-hidden="true"
-                    className="c34"
+                    className="c30"
                     max={600}
                     value={0}
                   />
@@ -20266,15 +17419,15 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c30"
+                className="c26"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-16-slug"
+                  id="snippet-editor-field-7-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c31"
-                    id="snippet-editor-field-16-slug"
+                    className="c27"
+                    id="snippet-editor-field-7-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -20286,11 +17439,11 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   onClick={[Function]}
                 >
                   <div
-                    className="c35"
+                    className="c31"
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-16-slug"
+                      aria-labelledby="snippet-editor-field-7-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -20299,8 +17452,8 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-16-slug"
-                        className="c36"
+                        aria-labelledby="snippet-editor-field-7-slug"
+                        className="c32"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -20314,7 +17467,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c30"
+                className="c26"
               >
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
@@ -20333,12 +17486,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="18"
+                    id="9"
                     onClick={[Function]}
                   >
                     <div
-                      className="c31"
-                      id="18"
+                      className="c27"
+                      id="9"
                       onClick={[Function]}
                     >
                       Meta description
@@ -20348,7 +17501,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     onClick={[Function]}
                   >
                     <Button
-                      className="c32"
+                      className="c28"
                       onClick={[Function]}
                     >
                       <Button
@@ -20358,7 +17511,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c32 c2"
+                        className="c28 c14"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -20376,7 +17529,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c32 c2 Button-kDSBcD c3"
+                          className="c28 c14 Button-kDSBcD c15"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -20394,7 +17547,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -20412,7 +17565,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -20430,7 +17583,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -20442,7 +17595,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                 type="button"
                               >
                                 <button
-                                  className="c32 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c28 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -20461,7 +17614,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c24"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -20490,12 +17643,12 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                     onClick={[Function]}
                   >
                     <div
-                      className="c37"
+                      className="c33"
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="18"
+                        ariaLabelledBy="9"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -20506,7 +17659,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="18"
+                          ariaLabelledBy="9"
                           content="Test description, %%replacement_variable%%"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -20532,7 +17685,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                 >
                   <progress
                     aria-hidden="true"
-                    className="c38"
+                    className="c34"
                     max={156}
                     value={42}
                   />
@@ -20552,7 +17705,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c39"
+          className="c35"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -20570,7 +17723,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c39 Button-kDSBcD c3"
+            className="c35 Button-kDSBcD c15"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -20588,7 +17741,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c39 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c35 Button-kDSBcD c15 Button-kDSBcD c16"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -20606,7 +17759,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c35 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -20624,7 +17777,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c35 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -20636,7 +17789,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                   type="button"
                 >
                   <button
-                    className="c39 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c35 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
                     onClick={[Function]}
                     type="button"
                   >
@@ -20654,18 +17807,18 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 `;
 
 exports[`SnippetEditor opens when calling open() 1`] = `
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -20694,23 +17847,23 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -20718,14 +17871,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -20736,11 +17889,11 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c34 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -20749,57 +17902,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   margin-top: 24px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
-.c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c32 {
+.c28 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -20818,11 +17921,11 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   cursor: text;
 }
 
-.c32 .public-DraftStyleDefault-block {
+.c28 .public-DraftStyleDefault-block {
   line-height: 24px;
 }
 
-.c32::before {
+.c28::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -20834,7 +17937,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   content: "";
 }
 
-.c34 {
+.c30 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -20853,7 +17956,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   cursor: text;
 }
 
-.c34::before {
+.c30::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -20865,7 +17968,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   content: "";
 }
 
-.c36 {
+.c32 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -20887,15 +17990,15 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   line-height: 24px;
 }
 
-.c36 .public-DraftEditorPlaceholder-root {
+.c32 .public-DraftEditorPlaceholder-root {
   color: #646464;
 }
 
-.c36 .public-DraftEditorPlaceholder-hasFocus {
+.c32 .public-DraftEditorPlaceholder-hasFocus {
   color: #646464;
 }
 
-.c36::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -20907,7 +18010,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   content: "";
 }
 
-.c29 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20926,11 +18029,11 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   margin: 24px 0 0 0;
 }
 
-.c28 {
+.c24 {
   padding: 0 20px;
 }
 
-.c30 {
+.c26 {
   -webkit-flex: 1 1 200px;
   -ms-flex: 1 1 200px;
   flex: 1 1 200px;
@@ -20941,7 +18044,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   margin: 4px 0;
 }
 
-.c31 {
+.c27 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   padding-left: 8px;
@@ -20950,12 +18053,12 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   font-size: 13px;
 }
 
-.c31 svg {
+.c27 svg {
   margin-right: 7px;
   fill: #555;
 }
 
-.c11 {
+.c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -20965,12 +18068,12 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -20985,13 +18088,13 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -21000,7 +18103,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -21010,7 +18113,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -21023,7 +18126,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -21031,19 +18134,51 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c29::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
 }
 
 .c33 {
@@ -21064,53 +18199,21 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 }
 
 .c33::-webkit-progress-value {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c33::-moz-progress-bar {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
 }
 
 .c33::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
   background-color: #ee7c1b;
   border: 0;
 }
 
-.c35 {
+.c31 {
   border: none;
   width: 100%;
   height: inherit;
@@ -21120,11 +18223,11 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   color: inherit;
 }
 
-.c35:focus {
+.c31:focus {
   outline: 0;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -21138,8 +18241,8 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -21148,7 +18251,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -21162,8 +18265,8 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -21172,7 +18275,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -21181,15 +18284,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -21197,7 +18292,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -21205,8 +18300,16 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -21292,256 +18395,17 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         url="example.org/test-slug"
       >
         <section>
-          <div>
-            <HelpTextWrapper
-              className="yoast-help"
-              helpText={
-                Array [
-                  "This is a rendering of what this post might look like in Google's search results. ",
-                  <OutboundLink
-                    href="https://yoa.st/snippet-preview"
-                  >
-                    Learn more about the Snippet Preview.
-                  </OutboundLink>,
-                ]
-              }
-              helpTextButtonLabel="Help on the Snippet Preview"
-              panelMaxWidth="400px"
-            >
-              <HelpTextWrapper__HelpTextContainer
-                className="yoast-help"
-              >
-                <div
-                  className="yoast-help c0"
-                >
-                  <HelpTextWrapper__HelpTextButton
-                    aria-controls={null}
-                    aria-expanded={false}
-                    aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button"
-                    onClick={[Function]}
-                  >
-                    <Button
-                      aria-controls={null}
-                      aria-expanded={false}
-                      aria-label="Help on the Snippet Preview"
-                      className="yoast-help__button c1"
-                      onClick={[Function]}
-                    >
-                      <Button
-                        activeBackgroundColor="#f7f7f7"
-                        activeBorderColor="#888"
-                        activeColor="#000"
-                        aria-controls={null}
-                        aria-expanded={false}
-                        aria-label="Help on the Snippet Preview"
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2"
-                        focusBackgroundColor="#fff"
-                        focusBorderColor="#0066cd"
-                        focusColor="#000"
-                        hoverBackgroundColor="#fff"
-                        hoverBorderColor="#888"
-                        hoverColor="#000"
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <Button
-                          activeBackgroundColor="#f7f7f7"
-                          activeBorderColor="#888"
-                          activeColor="#000"
-                          aria-controls={null}
-                          aria-expanded={false}
-                          aria-label="Help on the Snippet Preview"
-                          backgroundColor="#f7f7f7"
-                          borderColor="#ccc"
-                          boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
-                          focusBackgroundColor="#fff"
-                          focusBorderColor="#0066cd"
-                          focusColor="#000"
-                          hoverBackgroundColor="#fff"
-                          hoverBorderColor="#888"
-                          hoverColor="#000"
-                          onClick={[Function]}
-                          textColor="#555"
-                          type="button"
-                        >
-                          <Button
-                            activeBackgroundColor="#f7f7f7"
-                            activeBorderColor="#888"
-                            activeColor="#000"
-                            aria-controls={null}
-                            aria-expanded={false}
-                            aria-label="Help on the Snippet Preview"
-                            backgroundColor="#f7f7f7"
-                            borderColor="#ccc"
-                            boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            focusBackgroundColor="#fff"
-                            focusBorderColor="#0066cd"
-                            focusColor="#000"
-                            hoverBackgroundColor="#fff"
-                            hoverBorderColor="#888"
-                            hoverColor="#000"
-                            onClick={[Function]}
-                            textColor="#555"
-                            type="button"
-                          >
-                            <Button
-                              activeBackgroundColor="#f7f7f7"
-                              activeBorderColor="#888"
-                              activeColor="#000"
-                              aria-controls={null}
-                              aria-expanded={false}
-                              aria-label="Help on the Snippet Preview"
-                              backgroundColor="#f7f7f7"
-                              borderColor="#ccc"
-                              boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              focusBackgroundColor="#fff"
-                              focusBorderColor="#0066cd"
-                              focusColor="#000"
-                              hoverBackgroundColor="#fff"
-                              hoverBorderColor="#888"
-                              hoverColor="#000"
-                              onClick={[Function]}
-                              textColor="#555"
-                              type="button"
-                            >
-                              <Button__BaseButton
-                                activeBackgroundColor="#f7f7f7"
-                                activeBorderColor="#888"
-                                activeColor="#000"
-                                aria-controls={null}
-                                aria-expanded={false}
-                                aria-label="Help on the Snippet Preview"
-                                backgroundColor="#f7f7f7"
-                                borderColor="#ccc"
-                                boxShadowColor="#ccc"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                focusBackgroundColor="#fff"
-                                focusBorderColor="#0066cd"
-                                focusColor="#000"
-                                hoverBackgroundColor="#fff"
-                                hoverBorderColor="#888"
-                                hoverColor="#000"
-                                onClick={[Function]}
-                                textColor="#555"
-                                type="button"
-                              >
-                                <button
-                                  aria-controls={null}
-                                  aria-expanded={false}
-                                  aria-label="Help on the Snippet Preview"
-                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <HelpTextWrapper__StyledSvg
-                                    color="#646464"
-                                    icon="question-circle"
-                                    size="16px"
-                                  >
-                                    <SvgIcon
-                                      className="c8"
-                                      color="#646464"
-                                      icon="question-circle"
-                                      size="16px"
-                                    >
-                                      <SvgIcon__StyledSvg
-                                        aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                        fill="#646464"
-                                        focusable="false"
-                                        role="img"
-                                        size="16px"
-                                        viewBox="0 0 1792 1792"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-                                          fill="#646464"
-                                          focusable="false"
-                                          role="img"
-                                          size="16px"
-                                          viewBox="0 0 1792 1792"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                          />
-                                        </svg>
-                                      </SvgIcon__StyledSvg>
-                                    </SvgIcon>
-                                  </HelpTextWrapper__StyledSvg>
-                                </button>
-                              </Button__BaseButton>
-                            </Button>
-                          </Button>
-                        </Button>
-                      </Button>
-                    </Button>
-                  </HelpTextWrapper__HelpTextButton>
-                  <YoastSlideToggle
-                    duration={300}
-                    isOpen={false}
-                  >
-                    <animations__YoastSlideToggleContainer
-                      duration={300}
-                    >
-                      <div
-                        className="c10"
-                      >
-                        <CSSTransition
-                          classNames="slide"
-                          in={false}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExiting={[Function]}
-                          timeout={300}
-                          unmountOnExit={true}
-                        >
-                          <Transition
-                            appear={false}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            timeout={300}
-                            unmountOnExit={true}
-                          />
-                        </CSSTransition>
-                      </div>
-                    </animations__YoastSlideToggleContainer>
-                  </YoastSlideToggle>
-                </div>
-              </HelpTextWrapper__HelpTextContainer>
-            </HelpTextWrapper>
-          </div>
           <SnippetPreview__MobileContainer
             padding={20}
             width={640}
           >
             <div
-              className="c11"
+              className="c0"
               width={640}
             >
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -21565,23 +18429,23 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     onMouseUp={[Function]}
                   >
                     <div
-                      className="c13"
+                      className="c2"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <SnippetPreview__TitleBounded>
                         <SnippetPreview__Title
-                          className="c14"
+                          className="c3"
                         >
                           <div
-                            className="c14 c15"
+                            className="c3 c4"
                           >
                             <SnippetPreview__TitleUnboundedMobile
                               innerRef={[Function]}
                             >
                               <span
-                                className="c16"
+                                className="c5"
                               >
                                 Test title
                               </span>
@@ -21609,7 +18473,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   </ScreenReaderText>
                   <SnippetPreview__BaseUrl>
                     <div
-                      className="c17"
+                      className="c6"
                     >
                       <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
@@ -21617,7 +18481,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         onMouseUp={[Function]}
                       >
                         <div
-                          className="c18"
+                          className="c7"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           onMouseUp={[Function]}
@@ -21631,12 +18495,12 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               </SnippetPreview__MobilePartContainer>
               <SnippetPreview__Separator>
                 <hr
-                  className="c19"
+                  className="c8"
                 />
               </SnippetPreview__Separator>
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -21661,14 +18525,14 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     onMouseUp={[Function]}
                   >
                     <SnippetPreview__DesktopDescription
-                      className="c20"
+                      className="c9"
                       isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <div
-                        className="c20 c21"
+                        className="c9 c10"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
@@ -21678,12 +18542,12 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                           isDescriptionPlaceholder={false}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c20"
+                            className="c9"
                             innerRef={[Function]}
                             isDescriptionPlaceholder={false}
                           >
                             <div
-                              className="c20 c21"
+                              className="c9 c10"
                             >
                               Test description, %%replacement_variable%%
                             </div>
@@ -21704,7 +18568,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
       >
         <ModeSwitcher__Switcher>
           <div
-            className="c22"
+            className="c11"
           >
             <ModeSwitcher__SwitcherButton
               aria-pressed={true}
@@ -21713,7 +18577,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             >
               <Button
                 aria-pressed={true}
-                className="c23"
+                className="c12"
                 isActive={true}
                 onClick={[Function]}
               >
@@ -21725,7 +18589,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2"
+                  className="c12 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -21745,7 +18609,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3"
+                    className="c12 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -21765,7 +18629,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -21785,7 +18649,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -21805,7 +18669,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -21819,7 +18683,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         >
                           <button
                             aria-pressed={true}
-                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -21840,7 +18704,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c19"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -21885,7 +18749,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             >
               <Button
                 aria-pressed={false}
-                className="c25"
+                className="c20"
                 isActive={false}
                 onClick={[Function]}
               >
@@ -21897,7 +18761,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2"
+                  className="c20 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -21917,7 +18781,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3"
+                    className="c20 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -21937,7 +18801,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -21957,7 +18821,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -21977,7 +18841,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -21991,7 +18855,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         >
                           <button
                             aria-pressed={false}
-                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -22012,7 +18876,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c21"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -22066,7 +18930,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27"
+          className="c22"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -22086,7 +18950,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3"
+            className="c22 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -22106,7 +18970,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -22126,7 +18990,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -22146,7 +19010,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -22160,7 +19024,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 >
                   <button
                     aria-expanded={true}
-                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -22179,7 +19043,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       >
                         <svg
                           aria-hidden={true}
-                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          className="yoast-svg-icon yoast-svg-icon-edit c23"
                           focusable="false"
                           role="img"
                           size="16px"
@@ -22236,11 +19100,11 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           padding="0 20px"
         >
           <section
-            className="c28"
+            className="c24"
           >
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test title"
@@ -22257,12 +19121,12 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="9"
+                    id="2"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="9"
+                      className="c26"
+                      id="2"
                       onClick={[Function]}
                     >
                       SEO title
@@ -22272,7 +19136,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -22282,7 +19146,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -22300,7 +19164,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -22318,7 +19182,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -22336,7 +19200,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -22354,7 +19218,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -22366,7 +19230,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -22385,7 +19249,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -22414,12 +19278,12 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     onClick={[Function]}
                   >
                     <div
-                      className="c32"
+                      className="c28"
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="9"
+                        ariaLabelledBy="2"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -22429,7 +19293,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="9"
+                          ariaLabelledBy="2"
                           content="Test title"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -22454,7 +19318,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c33"
+                    className="c29"
                     max={600}
                     value={0}
                   />
@@ -22463,15 +19327,15 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-8-slug"
+                  id="snippet-editor-field-1-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c30"
-                    id="snippet-editor-field-8-slug"
+                    className="c26"
+                    id="snippet-editor-field-1-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -22483,11 +19347,11 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   onClick={[Function]}
                 >
                   <div
-                    className="c34"
+                    className="c30"
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-8-slug"
+                      aria-labelledby="snippet-editor-field-1-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -22496,8 +19360,8 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-8-slug"
-                        className="c35"
+                        aria-labelledby="snippet-editor-field-1-slug"
+                        className="c31"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -22511,7 +19375,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
@@ -22530,12 +19394,12 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="10"
+                    id="3"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="10"
+                      className="c26"
+                      id="3"
                       onClick={[Function]}
                     >
                       Meta description
@@ -22545,7 +19409,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -22555,7 +19419,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -22573,7 +19437,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -22591,7 +19455,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -22609,7 +19473,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -22627,7 +19491,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -22639,7 +19503,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -22658,7 +19522,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -22687,12 +19551,12 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                     onClick={[Function]}
                   >
                     <div
-                      className="c36"
+                      className="c32"
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="10"
+                        ariaLabelledBy="3"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -22703,7 +19567,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="10"
+                          ariaLabelledBy="3"
                           content="Test description, %%replacement_variable%%"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -22729,7 +19593,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 >
                   <progress
                     aria-hidden="true"
-                    className="c37"
+                    className="c33"
                     max={156}
                     value={42}
                   />
@@ -22749,7 +19613,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38"
+          className="c34"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -22767,7 +19631,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3"
+            className="c34 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -22785,7 +19649,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c34 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -22803,7 +19667,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -22821,7 +19685,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -22833,7 +19697,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                   type="button"
                 >
                   <button
-                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -22851,18 +19715,18 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 `;
 
 exports[`SnippetEditor passes replacement variables to the title and description editor 1`] = `
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -22891,23 +19755,23 @@ exports[`SnippetEditor passes replacement variables to the title and description
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -22915,14 +19779,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -22933,11 +19797,11 @@ exports[`SnippetEditor passes replacement variables to the title and description
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c34 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -22946,57 +19810,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   margin-top: 24px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
-.c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c32 {
+.c28 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -23015,11 +19829,11 @@ exports[`SnippetEditor passes replacement variables to the title and description
   cursor: text;
 }
 
-.c32 .public-DraftStyleDefault-block {
+.c28 .public-DraftStyleDefault-block {
   line-height: 24px;
 }
 
-.c32::before {
+.c28::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -23031,7 +19845,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   content: "";
 }
 
-.c34 {
+.c30 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -23050,7 +19864,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   cursor: text;
 }
 
-.c34::before {
+.c30::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -23062,7 +19876,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   content: "";
 }
 
-.c36 {
+.c32 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -23084,15 +19898,15 @@ exports[`SnippetEditor passes replacement variables to the title and description
   line-height: 24px;
 }
 
-.c36 .public-DraftEditorPlaceholder-root {
+.c32 .public-DraftEditorPlaceholder-root {
   color: #646464;
 }
 
-.c36 .public-DraftEditorPlaceholder-hasFocus {
+.c32 .public-DraftEditorPlaceholder-hasFocus {
   color: #646464;
 }
 
-.c36::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -23104,7 +19918,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   content: "";
 }
 
-.c29 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -23123,11 +19937,11 @@ exports[`SnippetEditor passes replacement variables to the title and description
   margin: 24px 0 0 0;
 }
 
-.c28 {
+.c24 {
   padding: 0 20px;
 }
 
-.c30 {
+.c26 {
   -webkit-flex: 1 1 200px;
   -ms-flex: 1 1 200px;
   flex: 1 1 200px;
@@ -23138,7 +19952,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   margin: 4px 0;
 }
 
-.c31 {
+.c27 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   padding-left: 8px;
@@ -23147,12 +19961,12 @@ exports[`SnippetEditor passes replacement variables to the title and description
   font-size: 13px;
 }
 
-.c31 svg {
+.c27 svg {
   margin-right: 7px;
   fill: #555;
 }
 
-.c11 {
+.c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -23162,12 +19976,12 @@ exports[`SnippetEditor passes replacement variables to the title and description
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -23182,13 +19996,13 @@ exports[`SnippetEditor passes replacement variables to the title and description
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -23197,7 +20011,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -23207,7 +20021,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -23220,7 +20034,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -23228,19 +20042,51 @@ exports[`SnippetEditor passes replacement variables to the title and description
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c29::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
 }
 
 .c33 {
@@ -23261,53 +20107,21 @@ exports[`SnippetEditor passes replacement variables to the title and description
 }
 
 .c33::-webkit-progress-value {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c33::-moz-progress-bar {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
 }
 
 .c33::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
   background-color: #ee7c1b;
   border: 0;
 }
 
-.c35 {
+.c31 {
   border: none;
   width: 100%;
   height: inherit;
@@ -23317,11 +20131,11 @@ exports[`SnippetEditor passes replacement variables to the title and description
   color: inherit;
 }
 
-.c35:focus {
+.c31:focus {
   outline: 0;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -23335,8 +20149,8 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -23345,7 +20159,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -23359,8 +20173,8 @@ exports[`SnippetEditor passes replacement variables to the title and description
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -23369,7 +20183,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -23378,15 +20192,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -23394,7 +20200,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -23402,8 +20208,16 @@ exports[`SnippetEditor passes replacement variables to the title and description
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -23500,256 +20314,17 @@ exports[`SnippetEditor passes replacement variables to the title and description
         url="example.org/test-slug"
       >
         <section>
-          <div>
-            <HelpTextWrapper
-              className="yoast-help"
-              helpText={
-                Array [
-                  "This is a rendering of what this post might look like in Google's search results. ",
-                  <OutboundLink
-                    href="https://yoa.st/snippet-preview"
-                  >
-                    Learn more about the Snippet Preview.
-                  </OutboundLink>,
-                ]
-              }
-              helpTextButtonLabel="Help on the Snippet Preview"
-              panelMaxWidth="400px"
-            >
-              <HelpTextWrapper__HelpTextContainer
-                className="yoast-help"
-              >
-                <div
-                  className="yoast-help c0"
-                >
-                  <HelpTextWrapper__HelpTextButton
-                    aria-controls={null}
-                    aria-expanded={false}
-                    aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button"
-                    onClick={[Function]}
-                  >
-                    <Button
-                      aria-controls={null}
-                      aria-expanded={false}
-                      aria-label="Help on the Snippet Preview"
-                      className="yoast-help__button c1"
-                      onClick={[Function]}
-                    >
-                      <Button
-                        activeBackgroundColor="#f7f7f7"
-                        activeBorderColor="#888"
-                        activeColor="#000"
-                        aria-controls={null}
-                        aria-expanded={false}
-                        aria-label="Help on the Snippet Preview"
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2"
-                        focusBackgroundColor="#fff"
-                        focusBorderColor="#0066cd"
-                        focusColor="#000"
-                        hoverBackgroundColor="#fff"
-                        hoverBorderColor="#888"
-                        hoverColor="#000"
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <Button
-                          activeBackgroundColor="#f7f7f7"
-                          activeBorderColor="#888"
-                          activeColor="#000"
-                          aria-controls={null}
-                          aria-expanded={false}
-                          aria-label="Help on the Snippet Preview"
-                          backgroundColor="#f7f7f7"
-                          borderColor="#ccc"
-                          boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
-                          focusBackgroundColor="#fff"
-                          focusBorderColor="#0066cd"
-                          focusColor="#000"
-                          hoverBackgroundColor="#fff"
-                          hoverBorderColor="#888"
-                          hoverColor="#000"
-                          onClick={[Function]}
-                          textColor="#555"
-                          type="button"
-                        >
-                          <Button
-                            activeBackgroundColor="#f7f7f7"
-                            activeBorderColor="#888"
-                            activeColor="#000"
-                            aria-controls={null}
-                            aria-expanded={false}
-                            aria-label="Help on the Snippet Preview"
-                            backgroundColor="#f7f7f7"
-                            borderColor="#ccc"
-                            boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            focusBackgroundColor="#fff"
-                            focusBorderColor="#0066cd"
-                            focusColor="#000"
-                            hoverBackgroundColor="#fff"
-                            hoverBorderColor="#888"
-                            hoverColor="#000"
-                            onClick={[Function]}
-                            textColor="#555"
-                            type="button"
-                          >
-                            <Button
-                              activeBackgroundColor="#f7f7f7"
-                              activeBorderColor="#888"
-                              activeColor="#000"
-                              aria-controls={null}
-                              aria-expanded={false}
-                              aria-label="Help on the Snippet Preview"
-                              backgroundColor="#f7f7f7"
-                              borderColor="#ccc"
-                              boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              focusBackgroundColor="#fff"
-                              focusBorderColor="#0066cd"
-                              focusColor="#000"
-                              hoverBackgroundColor="#fff"
-                              hoverBorderColor="#888"
-                              hoverColor="#000"
-                              onClick={[Function]}
-                              textColor="#555"
-                              type="button"
-                            >
-                              <Button__BaseButton
-                                activeBackgroundColor="#f7f7f7"
-                                activeBorderColor="#888"
-                                activeColor="#000"
-                                aria-controls={null}
-                                aria-expanded={false}
-                                aria-label="Help on the Snippet Preview"
-                                backgroundColor="#f7f7f7"
-                                borderColor="#ccc"
-                                boxShadowColor="#ccc"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                focusBackgroundColor="#fff"
-                                focusBorderColor="#0066cd"
-                                focusColor="#000"
-                                hoverBackgroundColor="#fff"
-                                hoverBorderColor="#888"
-                                hoverColor="#000"
-                                onClick={[Function]}
-                                textColor="#555"
-                                type="button"
-                              >
-                                <button
-                                  aria-controls={null}
-                                  aria-expanded={false}
-                                  aria-label="Help on the Snippet Preview"
-                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <HelpTextWrapper__StyledSvg
-                                    color="#646464"
-                                    icon="question-circle"
-                                    size="16px"
-                                  >
-                                    <SvgIcon
-                                      className="c8"
-                                      color="#646464"
-                                      icon="question-circle"
-                                      size="16px"
-                                    >
-                                      <SvgIcon__StyledSvg
-                                        aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                        fill="#646464"
-                                        focusable="false"
-                                        role="img"
-                                        size="16px"
-                                        viewBox="0 0 1792 1792"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-                                          fill="#646464"
-                                          focusable="false"
-                                          role="img"
-                                          size="16px"
-                                          viewBox="0 0 1792 1792"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                          />
-                                        </svg>
-                                      </SvgIcon__StyledSvg>
-                                    </SvgIcon>
-                                  </HelpTextWrapper__StyledSvg>
-                                </button>
-                              </Button__BaseButton>
-                            </Button>
-                          </Button>
-                        </Button>
-                      </Button>
-                    </Button>
-                  </HelpTextWrapper__HelpTextButton>
-                  <YoastSlideToggle
-                    duration={300}
-                    isOpen={false}
-                  >
-                    <animations__YoastSlideToggleContainer
-                      duration={300}
-                    >
-                      <div
-                        className="c10"
-                      >
-                        <CSSTransition
-                          classNames="slide"
-                          in={false}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExiting={[Function]}
-                          timeout={300}
-                          unmountOnExit={true}
-                        >
-                          <Transition
-                            appear={false}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            timeout={300}
-                            unmountOnExit={true}
-                          />
-                        </CSSTransition>
-                      </div>
-                    </animations__YoastSlideToggleContainer>
-                  </YoastSlideToggle>
-                </div>
-              </HelpTextWrapper__HelpTextContainer>
-            </HelpTextWrapper>
-          </div>
           <SnippetPreview__MobileContainer
             padding={20}
             width={640}
           >
             <div
-              className="c11"
+              className="c0"
               width={640}
             >
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -23773,23 +20348,23 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     onMouseUp={[Function]}
                   >
                     <div
-                      className="c13"
+                      className="c2"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <SnippetPreview__TitleBounded>
                         <SnippetPreview__Title
-                          className="c14"
+                          className="c3"
                         >
                           <div
-                            className="c14 c15"
+                            className="c3 c4"
                           >
                             <SnippetPreview__TitleUnboundedMobile
                               innerRef={[Function]}
                             >
                               <span
-                                className="c16"
+                                className="c5"
                               >
                                 Test title
                               </span>
@@ -23817,7 +20392,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   </ScreenReaderText>
                   <SnippetPreview__BaseUrl>
                     <div
-                      className="c17"
+                      className="c6"
                     >
                       <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
@@ -23825,7 +20400,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         onMouseUp={[Function]}
                       >
                         <div
-                          className="c18"
+                          className="c7"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           onMouseUp={[Function]}
@@ -23839,12 +20414,12 @@ exports[`SnippetEditor passes replacement variables to the title and description
               </SnippetPreview__MobilePartContainer>
               <SnippetPreview__Separator>
                 <hr
-                  className="c19"
+                  className="c8"
                 />
               </SnippetPreview__Separator>
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -23869,14 +20444,14 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     onMouseUp={[Function]}
                   >
                     <SnippetPreview__DesktopDescription
-                      className="c20"
+                      className="c9"
                       isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <div
-                        className="c20 c21"
+                        className="c9 c10"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
@@ -23886,12 +20461,12 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           isDescriptionPlaceholder={false}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c20"
+                            className="c9"
                             innerRef={[Function]}
                             isDescriptionPlaceholder={false}
                           >
                             <div
-                              className="c20 c21"
+                              className="c9 c10"
                             >
                               Test description, %%replacement_variable%%
                             </div>
@@ -23912,7 +20487,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
       >
         <ModeSwitcher__Switcher>
           <div
-            className="c22"
+            className="c11"
           >
             <ModeSwitcher__SwitcherButton
               aria-pressed={true}
@@ -23921,7 +20496,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             >
               <Button
                 aria-pressed={true}
-                className="c23"
+                className="c12"
                 isActive={true}
                 onClick={[Function]}
               >
@@ -23933,7 +20508,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2"
+                  className="c12 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -23953,7 +20528,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3"
+                    className="c12 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -23973,7 +20548,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -23993,7 +20568,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -24013,7 +20588,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -24027,7 +20602,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         >
                           <button
                             aria-pressed={true}
-                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -24048,7 +20623,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c19"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -24093,7 +20668,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             >
               <Button
                 aria-pressed={false}
-                className="c25"
+                className="c20"
                 isActive={false}
                 onClick={[Function]}
               >
@@ -24105,7 +20680,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2"
+                  className="c20 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -24125,7 +20700,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3"
+                    className="c20 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -24145,7 +20720,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -24165,7 +20740,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -24185,7 +20760,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -24199,7 +20774,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         >
                           <button
                             aria-pressed={false}
-                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -24220,7 +20795,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c21"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -24274,7 +20849,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27"
+          className="c22"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -24294,7 +20869,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3"
+            className="c22 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -24314,7 +20889,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -24334,7 +20909,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -24354,7 +20929,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -24368,7 +20943,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 >
                   <button
                     aria-expanded={true}
-                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -24387,7 +20962,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       >
                         <svg
                           aria-hidden={true}
-                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          className="yoast-svg-icon yoast-svg-icon-edit c23"
                           focusable="false"
                           role="img"
                           size="16px"
@@ -24455,11 +21030,11 @@ exports[`SnippetEditor passes replacement variables to the title and description
           padding="0 20px"
         >
           <section
-            className="c28"
+            className="c24"
           >
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test title"
@@ -24487,12 +21062,12 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="34"
+                    id="20"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="34"
+                      className="c26"
+                      id="20"
                       onClick={[Function]}
                     >
                       SEO title
@@ -24502,7 +21077,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -24512,7 +21087,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -24530,7 +21105,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -24548,7 +21123,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -24566,7 +21141,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -24584,7 +21159,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -24596,7 +21171,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -24615,7 +21190,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -24644,12 +21219,12 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     onClick={[Function]}
                   >
                     <div
-                      className="c32"
+                      className="c28"
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="34"
+                        ariaLabelledBy="20"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -24670,7 +21245,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         }
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="34"
+                          ariaLabelledBy="20"
                           content="Test title"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -24706,7 +21281,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 >
                   <progress
                     aria-hidden="true"
-                    className="c33"
+                    className="c29"
                     max={600}
                     value={0}
                   />
@@ -24715,15 +21290,15 @@ exports[`SnippetEditor passes replacement variables to the title and description
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-33-slug"
+                  id="snippet-editor-field-19-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c30"
-                    id="snippet-editor-field-33-slug"
+                    className="c26"
+                    id="snippet-editor-field-19-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -24735,11 +21310,11 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   onClick={[Function]}
                 >
                   <div
-                    className="c34"
+                    className="c30"
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-33-slug"
+                      aria-labelledby="snippet-editor-field-19-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -24748,8 +21323,8 @@ exports[`SnippetEditor passes replacement variables to the title and description
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-33-slug"
-                        className="c35"
+                        aria-labelledby="snippet-editor-field-19-slug"
+                        className="c31"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -24763,7 +21338,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
@@ -24793,12 +21368,12 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="35"
+                    id="21"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="35"
+                      className="c26"
+                      id="21"
                       onClick={[Function]}
                     >
                       Meta description
@@ -24808,7 +21383,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -24818,7 +21393,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -24836,7 +21411,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -24854,7 +21429,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -24872,7 +21447,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -24890,7 +21465,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -24902,7 +21477,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -24921,7 +21496,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -24950,12 +21525,12 @@ exports[`SnippetEditor passes replacement variables to the title and description
                     onClick={[Function]}
                   >
                     <div
-                      className="c36"
+                      className="c32"
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="35"
+                        ariaLabelledBy="21"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -24977,7 +21552,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                         }
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="35"
+                          ariaLabelledBy="21"
                           content="Test description, %%replacement_variable%%"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -25014,7 +21589,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 >
                   <progress
                     aria-hidden="true"
-                    className="c37"
+                    className="c33"
                     max={156}
                     value={42}
                   />
@@ -25034,7 +21609,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38"
+          className="c34"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -25052,7 +21627,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3"
+            className="c34 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -25070,7 +21645,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c34 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -25088,7 +21663,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -25106,7 +21681,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -25118,7 +21693,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                   type="button"
                 >
                   <button
-                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -25136,18 +21711,18 @@ exports[`SnippetEditor passes replacement variables to the title and description
 `;
 
 exports[`SnippetEditor passes the date prop 1`] = `
-.c7 {
+.c19 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c14 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c15 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -25176,23 +21751,23 @@ exports[`SnippetEditor passes the date prop 1`] = `
   min-height: 32px;
 }
 
-.c3 svg {
+.c15 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c16:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c17::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c17:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -25200,14 +21775,14 @@ exports[`SnippetEditor passes the date prop 1`] = `
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c18:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c28 {
+.c23 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -25218,61 +21793,11 @@ exports[`SnippetEditor passes the date prop 1`] = `
   padding-left: 8px;
 }
 
-.c28 svg {
+.c23 svg {
   margin-right: 7px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -25282,12 +21807,12 @@ exports[`SnippetEditor passes the date prop 1`] = `
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -25302,13 +21827,13 @@ exports[`SnippetEditor passes the date prop 1`] = `
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -25317,7 +21842,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -25327,7 +21852,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -25340,7 +21865,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -25348,26 +21873,26 @@ exports[`SnippetEditor passes the date prop 1`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c22 {
+.c11 {
   color: #808080;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
 }
 
-.c24 {
+.c13 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -25381,8 +21906,8 @@ exports[`SnippetEditor passes the date prop 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c24:hover,
-.c24:focus {
+.c13:hover,
+.c13:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -25391,7 +21916,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   box-shadow: none;
 }
 
-.c26 {
+.c21 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -25405,8 +21930,8 @@ exports[`SnippetEditor passes the date prop 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c26:hover,
-.c26:focus {
+.c21:hover,
+.c21:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -25415,7 +21940,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   box-shadow: none;
 }
 
-.c23 {
+.c12 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -25424,15 +21949,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c25 {
+.c20 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -25440,7 +21957,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   flex: none;
 }
 
-.c27 {
+.c22 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -25448,8 +21965,16 @@ exports[`SnippetEditor passes the date prop 1`] = `
   flex: none;
 }
 
+.c24 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c15::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -25458,45 +21983,13 @@ exports[`SnippetEditor passes the date prop 1`] = `
 
 <div>
   <section>
-    <div>
-      <div
-        className="yoast-help c0"
-      >
-        <button
-          aria-controls={null}
-          aria-expanded={false}
-          aria-label="Help on the Snippet Preview"
-          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-          onClick={[Function]}
-          type="button"
-        >
-          <svg
-            aria-hidden={true}
-            className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-            fill="#646464"
-            focusable="false"
-            role="img"
-            size="16px"
-            viewBox="0 0 1792 1792"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-            />
-          </svg>
-        </button>
-        <div
-          className="c10"
-        />
-      </div>
-    </div>
     <div
-      className="c11"
+      className="c0"
       onMouseLeave={undefined}
       width={640}
     >
       <div
-        className="c12"
+        className="c1"
       >
         <span
           className="screen-reader-text"
@@ -25513,16 +22006,16 @@ exports[`SnippetEditor passes the date prop 1`] = `
           SEO title preview:
         </span>
         <div
-          className="c13"
+          className="c2"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c14 c15"
+            className="c3 c4"
           >
             <span
-              className="c16"
+              className="c5"
             >
               Test title
             </span>
@@ -25543,10 +22036,10 @@ exports[`SnippetEditor passes the date prop 1`] = `
           Url preview:
         </span>
         <div
-          className="c17"
+          className="c6"
         >
           <div
-            className="c18"
+            className="c7"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -25556,10 +22049,10 @@ exports[`SnippetEditor passes the date prop 1`] = `
         </div>
       </div>
       <hr
-        className="c19"
+        className="c8"
       />
       <div
-        className="c12"
+        className="c1"
       >
         <span
           className="screen-reader-text"
@@ -25576,16 +22069,16 @@ exports[`SnippetEditor passes the date prop 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c20 c21"
+          className="c9 c10"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c20 c21"
+            className="c9 c10"
           >
             <span
-              className="c22"
+              className="c11"
             >
               date string
                - 
@@ -25597,17 +22090,17 @@ exports[`SnippetEditor passes the date prop 1`] = `
     </div>
   </section>
   <div
-    className="c23"
+    className="c12"
   >
     <button
       aria-pressed={true}
-      className="c24 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c13 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c25"
+        className="yoast-svg-icon yoast-svg-icon-mobile c20"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -25636,13 +22129,13 @@ exports[`SnippetEditor passes the date prop 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c26 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c21 c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c27"
+        className="yoast-svg-icon yoast-svg-icon-desktop c22"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -25672,13 +22165,13 @@ exports[`SnippetEditor passes the date prop 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c28 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+    className="c23 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 Button-kDSBcD c18 c19"
     onClick={[Function]}
     type="button"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c9"
+      className="yoast-svg-icon yoast-svg-icon-edit c24"
       fill={undefined}
       focusable="false"
       role="img"
@@ -25774,18 +22267,18 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
 `;
 
 exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = `
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -25814,23 +22307,23 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -25838,14 +22331,14 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -25856,11 +22349,11 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c38 {
+.c34 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -25869,57 +22362,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   margin-top: 24px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
-.c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c32 {
+.c28 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -25938,11 +22381,11 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   cursor: text;
 }
 
-.c32 .public-DraftStyleDefault-block {
+.c28 .public-DraftStyleDefault-block {
   line-height: 24px;
 }
 
-.c32::before {
+.c28::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -25954,7 +22397,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   content: "";
 }
 
-.c34 {
+.c30 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -25973,7 +22416,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   cursor: text;
 }
 
-.c34::before {
+.c30::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -25985,7 +22428,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   content: "";
 }
 
-.c36 {
+.c32 {
   -webkit-flex: 0 1 100%;
   -ms-flex: 0 1 100%;
   flex: 0 1 100%;
@@ -26007,15 +22450,15 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   line-height: 24px;
 }
 
-.c36 .public-DraftEditorPlaceholder-root {
+.c32 .public-DraftEditorPlaceholder-root {
   color: #646464;
 }
 
-.c36 .public-DraftEditorPlaceholder-hasFocus {
+.c32 .public-DraftEditorPlaceholder-hasFocus {
   color: #646464;
 }
 
-.c36::before {
+.c32::before {
   display: block;
   position: absolute;
   top: -1px;
@@ -26027,7 +22470,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   content: "";
 }
 
-.c29 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -26046,11 +22489,11 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   margin: 24px 0 0 0;
 }
 
-.c28 {
+.c24 {
   padding: 0 20px;
 }
 
-.c30 {
+.c26 {
   -webkit-flex: 1 1 200px;
   -ms-flex: 1 1 200px;
   flex: 1 1 200px;
@@ -26061,7 +22504,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   margin: 4px 0;
 }
 
-.c31 {
+.c27 {
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
   padding-left: 8px;
@@ -26070,12 +22513,12 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   font-size: 13px;
 }
 
-.c31 svg {
+.c27 svg {
   margin-right: 7px;
   fill: #555;
 }
 
-.c11 {
+.c0 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -26085,12 +22528,12 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -26105,13 +22548,13 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -26120,7 +22563,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -26130,7 +22573,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -26143,7 +22586,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -26151,19 +22594,51 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
+}
+
+.c29 {
+  box-sizing: border-box;
+  width: 100%;
+  height: 8px;
+  display: block;
+  margin-top: 8px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+}
+
+.c29::-webkit-progress-bar {
+  background-color: #f7f7f7;
+}
+
+.c29::-webkit-progress-value {
+  background-color: #dc3232;
+  -webkit-transition: width 250ms;
+  transition: width 250ms;
+}
+
+.c29::-moz-progress-bar {
+  background-color: #dc3232;
+}
+
+.c29::-ms-fill {
+  background-color: #dc3232;
+  border: 0;
 }
 
 .c33 {
@@ -26184,53 +22659,21 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 }
 
 .c33::-webkit-progress-value {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
   -webkit-transition: width 250ms;
   transition: width 250ms;
 }
 
 .c33::-moz-progress-bar {
-  background-color: #dc3232;
+  background-color: #ee7c1b;
 }
 
 .c33::-ms-fill {
-  background-color: #dc3232;
-  border: 0;
-}
-
-.c37 {
-  box-sizing: border-box;
-  width: 100%;
-  height: 8px;
-  display: block;
-  margin-top: 8px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #f7f7f7;
-  border: 1px solid #ddd;
-}
-
-.c37::-webkit-progress-bar {
-  background-color: #f7f7f7;
-}
-
-.c37::-webkit-progress-value {
-  background-color: #ee7c1b;
-  -webkit-transition: width 250ms;
-  transition: width 250ms;
-}
-
-.c37::-moz-progress-bar {
-  background-color: #ee7c1b;
-}
-
-.c37::-ms-fill {
   background-color: #ee7c1b;
   border: 0;
 }
 
-.c35 {
+.c31 {
   border: none;
   width: 100%;
   height: inherit;
@@ -26240,11 +22683,11 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   color: inherit;
 }
 
-.c35:focus {
+.c31:focus {
   outline: 0;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -26258,8 +22701,8 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -26268,7 +22711,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -26282,8 +22725,8 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -26292,7 +22735,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -26301,15 +22744,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -26317,7 +22752,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -26325,8 +22760,16 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -26412,256 +22855,17 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
         url="example.org/test-slug"
       >
         <section>
-          <div>
-            <HelpTextWrapper
-              className="yoast-help"
-              helpText={
-                Array [
-                  "This is a rendering of what this post might look like in Google's search results. ",
-                  <OutboundLink
-                    href="https://yoa.st/snippet-preview"
-                  >
-                    Learn more about the Snippet Preview.
-                  </OutboundLink>,
-                ]
-              }
-              helpTextButtonLabel="Help on the Snippet Preview"
-              panelMaxWidth="400px"
-            >
-              <HelpTextWrapper__HelpTextContainer
-                className="yoast-help"
-              >
-                <div
-                  className="yoast-help c0"
-                >
-                  <HelpTextWrapper__HelpTextButton
-                    aria-controls={null}
-                    aria-expanded={false}
-                    aria-label="Help on the Snippet Preview"
-                    className="yoast-help__button"
-                    onClick={[Function]}
-                  >
-                    <Button
-                      aria-controls={null}
-                      aria-expanded={false}
-                      aria-label="Help on the Snippet Preview"
-                      className="yoast-help__button c1"
-                      onClick={[Function]}
-                    >
-                      <Button
-                        activeBackgroundColor="#f7f7f7"
-                        activeBorderColor="#888"
-                        activeColor="#000"
-                        aria-controls={null}
-                        aria-expanded={false}
-                        aria-label="Help on the Snippet Preview"
-                        backgroundColor="#f7f7f7"
-                        borderColor="#ccc"
-                        boxShadowColor="#ccc"
-                        className="yoast-help__button c1 c2"
-                        focusBackgroundColor="#fff"
-                        focusBorderColor="#0066cd"
-                        focusColor="#000"
-                        hoverBackgroundColor="#fff"
-                        hoverBorderColor="#888"
-                        hoverColor="#000"
-                        onClick={[Function]}
-                        textColor="#555"
-                        type="button"
-                      >
-                        <Button
-                          activeBackgroundColor="#f7f7f7"
-                          activeBorderColor="#888"
-                          activeColor="#000"
-                          aria-controls={null}
-                          aria-expanded={false}
-                          aria-label="Help on the Snippet Preview"
-                          backgroundColor="#f7f7f7"
-                          borderColor="#ccc"
-                          boxShadowColor="#ccc"
-                          className="yoast-help__button c1 c2 Button-kDSBcD c3"
-                          focusBackgroundColor="#fff"
-                          focusBorderColor="#0066cd"
-                          focusColor="#000"
-                          hoverBackgroundColor="#fff"
-                          hoverBorderColor="#888"
-                          hoverColor="#000"
-                          onClick={[Function]}
-                          textColor="#555"
-                          type="button"
-                        >
-                          <Button
-                            activeBackgroundColor="#f7f7f7"
-                            activeBorderColor="#888"
-                            activeColor="#000"
-                            aria-controls={null}
-                            aria-expanded={false}
-                            aria-label="Help on the Snippet Preview"
-                            backgroundColor="#f7f7f7"
-                            borderColor="#ccc"
-                            boxShadowColor="#ccc"
-                            className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4"
-                            focusBackgroundColor="#fff"
-                            focusBorderColor="#0066cd"
-                            focusColor="#000"
-                            hoverBackgroundColor="#fff"
-                            hoverBorderColor="#888"
-                            hoverColor="#000"
-                            onClick={[Function]}
-                            textColor="#555"
-                            type="button"
-                          >
-                            <Button
-                              activeBackgroundColor="#f7f7f7"
-                              activeBorderColor="#888"
-                              activeColor="#000"
-                              aria-controls={null}
-                              aria-expanded={false}
-                              aria-label="Help on the Snippet Preview"
-                              backgroundColor="#f7f7f7"
-                              borderColor="#ccc"
-                              boxShadowColor="#ccc"
-                              className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
-                              focusBackgroundColor="#fff"
-                              focusBorderColor="#0066cd"
-                              focusColor="#000"
-                              hoverBackgroundColor="#fff"
-                              hoverBorderColor="#888"
-                              hoverColor="#000"
-                              onClick={[Function]}
-                              textColor="#555"
-                              type="button"
-                            >
-                              <Button__BaseButton
-                                activeBackgroundColor="#f7f7f7"
-                                activeBorderColor="#888"
-                                activeColor="#000"
-                                aria-controls={null}
-                                aria-expanded={false}
-                                aria-label="Help on the Snippet Preview"
-                                backgroundColor="#f7f7f7"
-                                borderColor="#ccc"
-                                boxShadowColor="#ccc"
-                                className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
-                                focusBackgroundColor="#fff"
-                                focusBorderColor="#0066cd"
-                                focusColor="#000"
-                                hoverBackgroundColor="#fff"
-                                hoverBorderColor="#888"
-                                hoverColor="#000"
-                                onClick={[Function]}
-                                textColor="#555"
-                                type="button"
-                              >
-                                <button
-                                  aria-controls={null}
-                                  aria-expanded={false}
-                                  aria-label="Help on the Snippet Preview"
-                                  className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <HelpTextWrapper__StyledSvg
-                                    color="#646464"
-                                    icon="question-circle"
-                                    size="16px"
-                                  >
-                                    <SvgIcon
-                                      className="c8"
-                                      color="#646464"
-                                      icon="question-circle"
-                                      size="16px"
-                                    >
-                                      <SvgIcon__StyledSvg
-                                        aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-question-circle c8"
-                                        fill="#646464"
-                                        focusable="false"
-                                        role="img"
-                                        size="16px"
-                                        viewBox="0 0 1792 1792"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-                                          fill="#646464"
-                                          focusable="false"
-                                          role="img"
-                                          size="16px"
-                                          viewBox="0 0 1792 1792"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-                                          />
-                                        </svg>
-                                      </SvgIcon__StyledSvg>
-                                    </SvgIcon>
-                                  </HelpTextWrapper__StyledSvg>
-                                </button>
-                              </Button__BaseButton>
-                            </Button>
-                          </Button>
-                        </Button>
-                      </Button>
-                    </Button>
-                  </HelpTextWrapper__HelpTextButton>
-                  <YoastSlideToggle
-                    duration={300}
-                    isOpen={false}
-                  >
-                    <animations__YoastSlideToggleContainer
-                      duration={300}
-                    >
-                      <div
-                        className="c10"
-                      >
-                        <CSSTransition
-                          classNames="slide"
-                          in={false}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExiting={[Function]}
-                          timeout={300}
-                          unmountOnExit={true}
-                        >
-                          <Transition
-                            appear={false}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            timeout={300}
-                            unmountOnExit={true}
-                          />
-                        </CSSTransition>
-                      </div>
-                    </animations__YoastSlideToggleContainer>
-                  </YoastSlideToggle>
-                </div>
-              </HelpTextWrapper__HelpTextContainer>
-            </HelpTextWrapper>
-          </div>
           <SnippetPreview__MobileContainer
             padding={20}
             width={640}
           >
             <div
-              className="c11"
+              className="c0"
               width={640}
             >
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -26685,23 +22889,23 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     onMouseUp={[Function]}
                   >
                     <div
-                      className="c13"
+                      className="c2"
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <SnippetPreview__TitleBounded>
                         <SnippetPreview__Title
-                          className="c14"
+                          className="c3"
                         >
                           <div
-                            className="c14 c15"
+                            className="c3 c4"
                           >
                             <SnippetPreview__TitleUnboundedMobile
                               innerRef={[Function]}
                             >
                               <span
-                                className="c16"
+                                className="c5"
                               >
                                 Test title
                               </span>
@@ -26729,7 +22933,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   </ScreenReaderText>
                   <SnippetPreview__BaseUrl>
                     <div
-                      className="c17"
+                      className="c6"
                     >
                       <SnippetPreview__BaseUrlOverflowContainer
                         onMouseEnter={[Function]}
@@ -26737,7 +22941,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         onMouseUp={[Function]}
                       >
                         <div
-                          className="c18"
+                          className="c7"
                           onMouseEnter={[Function]}
                           onMouseLeave={[Function]}
                           onMouseUp={[Function]}
@@ -26751,12 +22955,12 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
               </SnippetPreview__MobilePartContainer>
               <SnippetPreview__Separator>
                 <hr
-                  className="c19"
+                  className="c8"
                 />
               </SnippetPreview__Separator>
               <SnippetPreview__MobilePartContainer>
                 <div
-                  className="c12"
+                  className="c1"
                 >
                   <ScreenReaderText>
                     <span
@@ -26781,14 +22985,14 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     onMouseUp={[Function]}
                   >
                     <SnippetPreview__DesktopDescription
-                      className="c20"
+                      className="c9"
                       isDescriptionPlaceholder={false}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                       onMouseUp={[Function]}
                     >
                       <div
-                        className="c20 c21"
+                        className="c9 c10"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         onMouseUp={[Function]}
@@ -26798,12 +23002,12 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                           isDescriptionPlaceholder={false}
                         >
                           <SnippetPreview__DesktopDescription
-                            className="c20"
+                            className="c9"
                             innerRef={[Function]}
                             isDescriptionPlaceholder={false}
                           >
                             <div
-                              className="c20 c21"
+                              className="c9 c10"
                             >
                               Test description, %%replacement_variable%%
                             </div>
@@ -26824,7 +23028,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
       >
         <ModeSwitcher__Switcher>
           <div
-            className="c22"
+            className="c11"
           >
             <ModeSwitcher__SwitcherButton
               aria-pressed={true}
@@ -26833,7 +23037,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
             >
               <Button
                 aria-pressed={true}
-                className="c23"
+                className="c12"
                 isActive={true}
                 onClick={[Function]}
               >
@@ -26845,7 +23049,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c23 c2"
+                  className="c12 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -26865,7 +23069,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c23 c2 Button-kDSBcD c3"
+                    className="c12 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -26885,7 +23089,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -26905,7 +23109,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -26925,7 +23129,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -26939,7 +23143,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         >
                           <button
                             aria-pressed={true}
-                            className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -26960,7 +23164,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-mobile c24"
+                                  className="yoast-svg-icon yoast-svg-icon-mobile c19"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -27005,7 +23209,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
             >
               <Button
                 aria-pressed={false}
-                className="c25"
+                className="c20"
                 isActive={false}
                 onClick={[Function]}
               >
@@ -27017,7 +23221,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c25 c2"
+                  className="c20 c13"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -27037,7 +23241,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     backgroundColor="#f7f7f7"
                     borderColor="#ccc"
                     boxShadowColor="#ccc"
-                    className="c25 c2 Button-kDSBcD c3"
+                    className="c20 c13 Button-kDSBcD c14"
                     focusBackgroundColor="#fff"
                     focusBorderColor="#0066cd"
                     focusColor="#000"
@@ -27057,7 +23261,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                       backgroundColor="#f7f7f7"
                       borderColor="#ccc"
                       boxShadowColor="#ccc"
-                      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                       focusBackgroundColor="#fff"
                       focusBorderColor="#0066cd"
                       focusColor="#000"
@@ -27077,7 +23281,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                        className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -27097,7 +23301,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                          className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -27111,7 +23315,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         >
                           <button
                             aria-pressed={false}
-                            className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                            className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                             onClick={[Function]}
                             type="button"
                           >
@@ -27132,7 +23336,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                               >
                                 <svg
                                   aria-hidden={true}
-                                  className="yoast-svg-icon yoast-svg-icon-desktop c26"
+                                  className="yoast-svg-icon yoast-svg-icon-desktop c21"
                                   fill="currentColor"
                                   focusable="false"
                                   role="img"
@@ -27186,7 +23390,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c27"
+          className="c22"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -27206,7 +23410,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c27 Button-kDSBcD c3"
+            className="c22 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -27226,7 +23430,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c27 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c22 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -27246,7 +23450,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -27266,7 +23470,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -27280,7 +23484,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                 >
                   <button
                     aria-expanded={true}
-                    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -27299,7 +23503,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                       >
                         <svg
                           aria-hidden={true}
-                          className="yoast-svg-icon yoast-svg-icon-edit c9"
+                          className="yoast-svg-icon yoast-svg-icon-edit c23"
                           focusable="false"
                           role="img"
                           size="16px"
@@ -27356,11 +23560,11 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
           padding="0 20px"
         >
           <section
-            className="c28"
+            className="c24"
           >
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test title"
@@ -27377,12 +23581,12 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="25"
+                    id="14"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="25"
+                      className="c26"
+                      id="14"
                       onClick={[Function]}
                     >
                       SEO title
@@ -27392,7 +23596,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -27402,7 +23606,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -27420,7 +23624,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -27438,7 +23642,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -27456,7 +23660,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -27474,7 +23678,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -27486,7 +23690,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -27505,7 +23709,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -27534,12 +23738,12 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     onClick={[Function]}
                   >
                     <div
-                      className="c32"
+                      className="c28"
                       id="snippet-editor-field-title"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="25"
+                        ariaLabelledBy="14"
                         content="Test title"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -27549,7 +23753,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="25"
+                          ariaLabelledBy="14"
                           content="Test title"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -27574,7 +23778,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                 >
                   <progress
                     aria-hidden="true"
-                    className="c33"
+                    className="c29"
                     max={600}
                     value={0}
                   />
@@ -27583,15 +23787,15 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <Shared__SimulatedLabel
-                  id="snippet-editor-field-24-slug"
+                  id="snippet-editor-field-13-slug"
                   onClick={[Function]}
                 >
                   <div
-                    className="c30"
-                    id="snippet-editor-field-24-slug"
+                    className="c26"
+                    id="snippet-editor-field-13-slug"
                     onClick={[Function]}
                   >
                     Slug
@@ -27603,11 +23807,11 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   onClick={[Function]}
                 >
                   <div
-                    className="c34"
+                    className="c30"
                     onClick={[Function]}
                   >
                     <SnippetEditorFields__SlugInput
-                      aria-labelledby="snippet-editor-field-24-slug"
+                      aria-labelledby="snippet-editor-field-13-slug"
                       id="snippet-editor-field-slug"
                       innerRef={[Function]}
                       onBlur={[Function]}
@@ -27616,8 +23820,8 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                       value="test-slug"
                     >
                       <input
-                        aria-labelledby="snippet-editor-field-24-slug"
-                        className="c35"
+                        aria-labelledby="snippet-editor-field-13-slug"
+                        className="c31"
                         id="snippet-editor-field-slug"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -27631,7 +23835,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
             </Shared__FormSection>
             <Shared__FormSection>
               <div
-                className="c29"
+                className="c25"
               >
                 <ReplacementVariableEditor
                   content="Test description, %%replacement_variable%%"
@@ -27650,12 +23854,12 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   withCaret={true}
                 >
                   <Shared__SimulatedLabel
-                    id="26"
+                    id="15"
                     onClick={[Function]}
                   >
                     <div
-                      className="c30"
-                      id="26"
+                      className="c26"
+                      id="15"
                       onClick={[Function]}
                     >
                       Meta description
@@ -27665,7 +23869,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     onClick={[Function]}
                   >
                     <Button
-                      className="c31"
+                      className="c27"
                       onClick={[Function]}
                     >
                       <Button
@@ -27675,7 +23879,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         backgroundColor="#f7f7f7"
                         borderColor="#ccc"
                         boxShadowColor="#ccc"
-                        className="c31 c2"
+                        className="c27 c13"
                         focusBackgroundColor="#fff"
                         focusBorderColor="#0066cd"
                         focusColor="#000"
@@ -27693,7 +23897,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                           backgroundColor="#f7f7f7"
                           borderColor="#ccc"
                           boxShadowColor="#ccc"
-                          className="c31 c2 Button-kDSBcD c3"
+                          className="c27 c13 Button-kDSBcD c14"
                           focusBackgroundColor="#fff"
                           focusBorderColor="#0066cd"
                           focusColor="#000"
@@ -27711,7 +23915,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                             backgroundColor="#f7f7f7"
                             borderColor="#ccc"
                             boxShadowColor="#ccc"
-                            className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4"
+                            className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15"
                             focusBackgroundColor="#fff"
                             focusBorderColor="#0066cd"
                             focusColor="#000"
@@ -27729,7 +23933,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                               backgroundColor="#f7f7f7"
                               borderColor="#ccc"
                               boxShadowColor="#ccc"
-                              className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                              className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                               focusBackgroundColor="#fff"
                               focusBorderColor="#0066cd"
                               focusColor="#000"
@@ -27747,7 +23951,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                 backgroundColor="#f7f7f7"
                                 borderColor="#ccc"
                                 boxShadowColor="#ccc"
-                                className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                                className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                                 focusBackgroundColor="#fff"
                                 focusBorderColor="#0066cd"
                                 focusColor="#000"
@@ -27759,7 +23963,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                 type="button"
                               >
                                 <button
-                                  className="c31 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                                  className="c27 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                                   onClick={[Function]}
                                   type="button"
                                 >
@@ -27778,7 +23982,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c9"
+                                        className="yoast-svg-icon yoast-svg-icon-plus-circle c23"
                                         focusable="false"
                                         role="img"
                                         size="16px"
@@ -27807,12 +24011,12 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                     onClick={[Function]}
                   >
                     <div
-                      className="c36"
+                      className="c32"
                       id="snippet-editor-field-description"
                       onClick={[Function]}
                     >
                       <Wrapper
-                        ariaLabelledBy="26"
+                        ariaLabelledBy="15"
                         content="Test description, %%replacement_variable%%"
                         innerRef={[Function]}
                         onBlur={[Function]}
@@ -27823,7 +24027,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                         replacementVariables={Array []}
                       >
                         <ReplacementVariableEditorStandalone
-                          ariaLabelledBy="26"
+                          ariaLabelledBy="15"
                           content="Test description, %%replacement_variable%%"
                           innerRef={[Function]}
                           onBlur={[Function]}
@@ -27849,7 +24053,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                 >
                   <progress
                     aria-hidden="true"
-                    className="c37"
+                    className="c33"
                     max={156}
                     value={42}
                   />
@@ -27869,7 +24073,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
           backgroundColor="#f7f7f7"
           borderColor="#ccc"
           boxShadowColor="#ccc"
-          className="c38"
+          className="c34"
           focusBackgroundColor="#fff"
           focusBorderColor="#0066cd"
           focusColor="#000"
@@ -27887,7 +24091,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
             backgroundColor="#f7f7f7"
             borderColor="#ccc"
             boxShadowColor="#ccc"
-            className="c38 Button-kDSBcD c3"
+            className="c34 Button-kDSBcD c14"
             focusBackgroundColor="#fff"
             focusBorderColor="#0066cd"
             focusColor="#000"
@@ -27905,7 +24109,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
               backgroundColor="#f7f7f7"
               borderColor="#ccc"
               boxShadowColor="#ccc"
-              className="c38 Button-kDSBcD c3 Button-kDSBcD c4"
+              className="c34 Button-kDSBcD c14 Button-kDSBcD c15"
               focusBackgroundColor="#fff"
               focusBorderColor="#0066cd"
               focusColor="#000"
@@ -27923,7 +24127,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                 backgroundColor="#f7f7f7"
                 borderColor="#ccc"
                 boxShadowColor="#ccc"
-                className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5"
+                className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16"
                 focusBackgroundColor="#fff"
                 focusBorderColor="#0066cd"
                 focusColor="#000"
@@ -27941,7 +24145,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   backgroundColor="#f7f7f7"
                   borderColor="#ccc"
                   boxShadowColor="#ccc"
-                  className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6"
+                  className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17"
                   focusBackgroundColor="#fff"
                   focusBorderColor="#0066cd"
                   focusColor="#000"
@@ -27953,7 +24157,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                   type="button"
                 >
                   <button
-                    className="c38 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+                    className="c34 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
                     onClick={[Function]}
                     type="button"
                   >
@@ -27971,7 +24175,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 `;
 
 exports[`SnippetEditor renders in desktop mode 1`] = `
-.c12 {
+.c1 {
   overflow: auto;
   width: 640px;
   padding: 0 20px;
@@ -27979,22 +24183,22 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   box-sizing: border-box;
 }
 
-.c13 {
+.c2 {
   width: 600px;
 }
 
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -28023,23 +24227,23 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -28047,14 +24251,14 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -28065,72 +24269,22 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   background-color: white;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
 
-.c14 {
+.c3 {
   cursor: pointer;
   position: relative;
 }
 
-.c16 {
+.c5 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -28145,17 +24299,17 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   text-overflow: ellipsis;
 }
 
-.c15 {
+.c4 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   white-space: nowrap;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -28165,7 +24319,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   font-size: 14px;
 }
 
-.c19 {
+.c8 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -28178,7 +24332,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -28186,7 +24340,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -28196,7 +24350,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   vertical-align: top;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -28210,8 +24364,8 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -28220,7 +24374,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -28234,8 +24388,8 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -28244,7 +24398,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -28253,15 +24407,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -28269,7 +24415,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -28277,8 +24423,16 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -28287,44 +24441,12 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
 
 <div>
   <section>
-    <div>
-      <div
-        className="yoast-help c0"
-      >
-        <button
-          aria-controls={null}
-          aria-expanded={false}
-          aria-label="Help on the Snippet Preview"
-          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-          onClick={[Function]}
-          type="button"
-        >
-          <svg
-            aria-hidden={true}
-            className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-            fill="#646464"
-            focusable="false"
-            role="img"
-            size="16px"
-            viewBox="0 0 1792 1792"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-            />
-          </svg>
-        </button>
-        <div
-          className="c10"
-        />
-      </div>
-    </div>
     <div
-      className="c11 c12"
+      className="c0 c1"
       width={640}
     >
       <div
-        className="c13"
+        className="c2"
         width={600}
       >
         <div
@@ -28345,16 +24467,16 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
             SEO title preview:
           </span>
           <div
-            className="c14"
+            className="c3"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
           >
             <div
-              className="c15 c16"
+              className="c4 c5"
             >
               <span
-                className="c17"
+                className="c6"
               >
                 Test title
               </span>
@@ -28375,10 +24497,10 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
             Url preview:
           </span>
           <div
-            className="c18"
+            className="c7"
           >
             <div
-              className="c19"
+              className="c8"
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
               onMouseUp={[Function]}
@@ -28387,7 +24509,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
             </div>
           </div>
           <div
-            className="c20"
+            className="c9"
           />
         </div>
         <div
@@ -28408,7 +24530,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
             Meta description preview:
           </span>
           <div
-            className="c21"
+            className="c10"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -28420,17 +24542,17 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
     </div>
   </section>
   <div
-    className="c22"
+    className="c11"
   >
     <button
       aria-pressed={false}
-      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c24"
+        className="yoast-svg-icon yoast-svg-icon-mobile c19"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -28459,13 +24581,13 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
     </button>
     <button
       aria-pressed={true}
-      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c26"
+        className="yoast-svg-icon yoast-svg-icon-desktop c21"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -28495,13 +24617,13 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
     onClick={[Function]}
     type="button"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c9"
+      className="yoast-svg-icon yoast-svg-icon-edit c23"
       fill={undefined}
       focusable="false"
       role="img"
@@ -28519,18 +24641,18 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
 `;
 
 exports[`SnippetEditor shows the editor 1`] = `
-.c7 {
+.c18 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c2 {
+.c13 {
   font-size: 0.8rem;
 }
 
-.c3 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -28559,23 +24681,23 @@ exports[`SnippetEditor shows the editor 1`] = `
   min-height: 32px;
 }
 
-.c3 svg {
+.c14 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c15:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c5::-moz-focus-inner {
+.c16::-moz-focus-inner {
   border-width: 0;
 }
 
-.c5:focus {
+.c16:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -28583,14 +24705,14 @@ exports[`SnippetEditor shows the editor 1`] = `
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c6:active {
+.c17:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c27 {
+.c22 {
   font-size: 0.8rem;
   height: 33px;
   border: 1px solid #dbdbdb;
@@ -28601,61 +24723,11 @@ exports[`SnippetEditor shows the editor 1`] = `
   padding-left: 8px;
 }
 
-.c27 svg {
+.c22 svg {
   margin-right: 7px;
 }
 
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -28665,12 +24737,12 @@ exports[`SnippetEditor shows the editor 1`] = `
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -28685,13 +24757,13 @@ exports[`SnippetEditor shows the editor 1`] = `
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -28700,7 +24772,7 @@ exports[`SnippetEditor shows the editor 1`] = `
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -28710,7 +24782,7 @@ exports[`SnippetEditor shows the editor 1`] = `
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -28723,7 +24795,7 @@ exports[`SnippetEditor shows the editor 1`] = `
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -28731,22 +24803,22 @@ exports[`SnippetEditor shows the editor 1`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
 }
 
-.c23 {
+.c12 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -28760,8 +24832,8 @@ exports[`SnippetEditor shows the editor 1`] = `
   border-radius: 3px 0 0 3px;
 }
 
-.c23:hover,
-.c23:focus {
+.c12:hover,
+.c12:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -28770,7 +24842,7 @@ exports[`SnippetEditor shows the editor 1`] = `
   box-shadow: none;
 }
 
-.c25 {
+.c20 {
   border: none;
   border-bottom: 4px solid transparent;
   width: 31px;
@@ -28784,8 +24856,8 @@ exports[`SnippetEditor shows the editor 1`] = `
   border-radius: 0 3px 3px 0;
 }
 
-.c25:hover,
-.c25:focus {
+.c20:hover,
+.c20:focus {
   background-color: #fff;
   border: none;
   border-bottom: 4px solid transparent;
@@ -28794,7 +24866,7 @@ exports[`SnippetEditor shows the editor 1`] = `
   box-shadow: none;
 }
 
-.c22 {
+.c11 {
   display: inline-block;
   margin-top: 10px;
   border: 1px solid #dbdbdb;
@@ -28803,15 +24875,7 @@ exports[`SnippetEditor shows the editor 1`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c24 {
+.c19 {
   width: 22px;
   height: 22px;
   -webkit-flex: none;
@@ -28819,7 +24883,7 @@ exports[`SnippetEditor shows the editor 1`] = `
   flex: none;
 }
 
-.c26 {
+.c21 {
   width: 18px;
   height: 18px;
   -webkit-flex: none;
@@ -28827,8 +24891,16 @@ exports[`SnippetEditor shows the editor 1`] = `
   flex: none;
 }
 
+.c23 {
+  width: 16px;
+  height: 16px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c14::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -28837,45 +24909,13 @@ exports[`SnippetEditor shows the editor 1`] = `
 
 <div>
   <section>
-    <div>
-      <div
-        className="yoast-help c0"
-      >
-        <button
-          aria-controls={null}
-          aria-expanded={false}
-          aria-label="Help on the Snippet Preview"
-          className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-          onClick={[Function]}
-          type="button"
-        >
-          <svg
-            aria-hidden={true}
-            className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-            fill="#646464"
-            focusable="false"
-            role="img"
-            size="16px"
-            viewBox="0 0 1792 1792"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-            />
-          </svg>
-        </button>
-        <div
-          className="c10"
-        />
-      </div>
-    </div>
     <div
-      className="c11"
+      className="c0"
       onMouseLeave={undefined}
       width={640}
     >
       <div
-        className="c12"
+        className="c1"
       >
         <span
           className="screen-reader-text"
@@ -28892,16 +24932,16 @@ exports[`SnippetEditor shows the editor 1`] = `
           SEO title preview:
         </span>
         <div
-          className="c13"
+          className="c2"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c14 c15"
+            className="c3 c4"
           >
             <span
-              className="c16"
+              className="c5"
             >
               Test title
             </span>
@@ -28922,10 +24962,10 @@ exports[`SnippetEditor shows the editor 1`] = `
           Url preview:
         </span>
         <div
-          className="c17"
+          className="c6"
         >
           <div
-            className="c18"
+            className="c7"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -28935,10 +24975,10 @@ exports[`SnippetEditor shows the editor 1`] = `
         </div>
       </div>
       <hr
-        className="c19"
+        className="c8"
       />
       <div
-        className="c12"
+        className="c1"
       >
         <span
           className="screen-reader-text"
@@ -28955,13 +24995,13 @@ exports[`SnippetEditor shows the editor 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c20 c21"
+          className="c9 c10"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c20 c21"
+            className="c9 c10"
           >
             Test description, %%replacement_variable%%
           </div>
@@ -28970,17 +25010,17 @@ exports[`SnippetEditor shows the editor 1`] = `
     </div>
   </section>
   <div
-    className="c22"
+    className="c11"
   >
     <button
       aria-pressed={true}
-      className="c23 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c12 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-mobile c24"
+        className="yoast-svg-icon yoast-svg-icon-mobile c19"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -29009,13 +25049,13 @@ exports[`SnippetEditor shows the editor 1`] = `
     </button>
     <button
       aria-pressed={false}
-      className="c25 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+      className="c20 c13 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-desktop c26"
+        className="yoast-svg-icon yoast-svg-icon-desktop c21"
         fill="currentColor"
         focusable="false"
         role="img"
@@ -29045,13 +25085,13 @@ exports[`SnippetEditor shows the editor 1`] = `
   </div>
   <button
     aria-expanded={false}
-    className="c27 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
+    className="c22 Button-kDSBcD c14 Button-kDSBcD c15 Button-kDSBcD c16 Button-kDSBcD c17 c18"
     onClick={[Function]}
     type="button"
   >
     <svg
       aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-edit c9"
+      className="yoast-svg-icon yoast-svg-icon-edit c23"
       fill={undefined}
       focusable="false"
       role="img"

--- a/composites/Plugin/SnippetPreview/components/SnippetPreview.js
+++ b/composites/Plugin/SnippetPreview/components/SnippetPreview.js
@@ -15,8 +15,6 @@ import FixedWidthContainer from "./FixedWidthContainer";
 import colors from "../../../../style-guide/colors";
 import ScreenReaderText from "../../../../a11y/ScreenReaderText";
 import { DEFAULT_MODE, MODE_DESKTOP, MODE_MOBILE, MODES } from "../constants";
-import HelpTextWrapper from "../components/HelpTextWrapper";
-import { makeOutboundLink } from "../../../../utils/makeOutboundLink";
 import { angleLeft, angleRight } from "../../SnippetEditor/components/Shared";
 import { getRtlStyle } from "../../../../utils/helpers/styled-components";
 
@@ -54,8 +52,6 @@ export const BaseTitle = styled.div`
 	cursor: pointer;
 	position: relative;
 `;
-
-const HelpTextLink = makeOutboundLink();
 
 /**
  * Adds caret styles to a component.
@@ -634,14 +630,6 @@ export default class SnippetPreview extends PureComponent {
 		const downArrow = mode === MODE_DESKTOP ? <UrlDownArrow/> : null;
 		const amp       = mode === MODE_DESKTOP || ! isAmp ? null : <Amp/>;
 
-		const helpText = [
-			__( "This is a rendering of what this post might look like in Google's search results. ", "yoast-components" ),
-			<HelpTextLink key="1" href="https://yoa.st/snippet-preview">
-				{ __( "Learn more about the Snippet Preview.", "yoast-components" ) }
-			</HelpTextLink>,
-		];
-		const helpTextLabel = __( "Help on the Snippet Preview", "yoast-components" );
-
 		/*
 		 * The jsx-a11y eslint plugin is asking for an onFocus accompanying the onMouseEnter.
 		 * However this is not relevant in this case, because the title and description are
@@ -650,13 +638,6 @@ export default class SnippetPreview extends PureComponent {
 		/* eslint-disable jsx-a11y/mouse-events-have-key-events */
 		return (
 			<section>
-				<div>
-					<HelpTextWrapper
-						helpText={ helpText }
-						helpTextButtonLabel={ helpTextLabel }
-						panelMaxWidth="400px"
-					/>
-				</div>
 				<Container
 					onMouseLeave={ this.onMouseLeave }
 					width={ MAX_WIDTH + ( 2 * WIDTH_PADDING ) }

--- a/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/composites/Plugin/SnippetPreview/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SnippetPreview changes the colors of the description if it was generated 1`] = `
-.c12 {
+.c1 {
   overflow: auto;
   width: 640px;
   padding: 0 20px;
@@ -9,143 +9,22 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   box-sizing: border-box;
 }
 
-.c13 {
+.c2 {
   width: 600px;
 }
 
-.c7 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c2 {
-  font-size: 0.8rem;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c3 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c4:hover {
-  color: #000;
-  background-color: #fff;
-  border-color: #888;
-}
-
-.c5::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #0066cd;
-  color: #000;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c6:active {
-  color: #000;
-  background-color: #f7f7f7;
-  border-color: #888;
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   background-color: white;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
 
-.c14 {
+.c3 {
   cursor: pointer;
   position: relative;
 }
 
-.c16 {
+.c5 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -160,17 +39,17 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   text-overflow: ellipsis;
 }
 
-.c15 {
+.c4 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   white-space: nowrap;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -180,7 +59,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   font-size: 14px;
 }
 
-.c19 {
+.c8 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -193,7 +72,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -201,7 +80,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -211,61 +90,13 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
 <section>
-  <div>
-    <div
-      className="yoast-help c0"
-    >
-      <button
-        aria-controls={null}
-        aria-expanded={false}
-        aria-label="Help on the Snippet Preview"
-        className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-          fill="#646464"
-          focusable="false"
-          role="img"
-          size="16px"
-          viewBox="0 0 1792 1792"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-          />
-        </svg>
-      </button>
-      <div
-        className="c10"
-      />
-    </div>
-  </div>
   <div
-    className="c11 c12"
+    className="c0 c1"
     width={640}
   >
     <div
-      className="c13"
+      className="c2"
       width={600}
     >
       <div
@@ -286,16 +117,16 @@ exports[`SnippetPreview changes the colors of the description if it was generate
           SEO title preview:
         </span>
         <div
-          className="c14"
+          className="c3"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c15 c16"
+            className="c4 c5"
           >
             <span
-              className="c17"
+              className="c6"
             >
               Title
             </span>
@@ -316,10 +147,10 @@ exports[`SnippetPreview changes the colors of the description if it was generate
           Url preview:
         </span>
         <div
-          className="c18"
+          className="c7"
         >
           <div
-            className="c19"
+            className="c8"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -328,7 +159,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
           </div>
         </div>
         <div
-          className="c20"
+          className="c9"
         />
       </div>
       <div
@@ -349,7 +180,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
           Meta description preview:
         </span>
         <div
-          className="c21"
+          className="c10"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
@@ -363,7 +194,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
 `;
 
 exports[`SnippetPreview highlights keywords even if they are transliterated 1`] = `
-.c12 {
+.c1 {
   overflow: auto;
   width: 640px;
   padding: 0 20px;
@@ -371,143 +202,22 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   box-sizing: border-box;
 }
 
-.c13 {
+.c2 {
   width: 600px;
 }
 
-.c7 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c2 {
-  font-size: 0.8rem;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c3 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c4:hover {
-  color: #000;
-  background-color: #fff;
-  border-color: #888;
-}
-
-.c5::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #0066cd;
-  color: #000;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c6:active {
-  color: #000;
-  background-color: #f7f7f7;
-  border-color: #888;
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   background-color: white;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
 
-.c14 {
+.c3 {
   cursor: pointer;
   position: relative;
 }
 
-.c16 {
+.c5 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -522,17 +232,17 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   text-overflow: ellipsis;
 }
 
-.c15 {
+.c4 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   white-space: nowrap;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -542,7 +252,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   font-size: 14px;
 }
 
-.c19 {
+.c8 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -555,7 +265,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -563,7 +273,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -573,61 +283,13 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
 <section>
-  <div>
-    <div
-      className="yoast-help c0"
-    >
-      <button
-        aria-controls={null}
-        aria-expanded={false}
-        aria-label="Help on the Snippet Preview"
-        className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-          fill="#646464"
-          focusable="false"
-          role="img"
-          size="16px"
-          viewBox="0 0 1792 1792"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-          />
-        </svg>
-      </button>
-      <div
-        className="c10"
-      />
-    </div>
-  </div>
   <div
-    className="c11 c12"
+    className="c0 c1"
     width={640}
   >
     <div
-      className="c13"
+      className="c2"
       width={600}
     >
       <div
@@ -648,16 +310,16 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
           SEO title preview:
         </span>
         <div
-          className="c14"
+          className="c3"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c15 c16"
+            className="c4 c5"
           >
             <span
-              className="c17"
+              className="c6"
             >
               Title
             </span>
@@ -678,10 +340,10 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
           Url preview:
         </span>
         <div
-          className="c18"
+          className="c7"
         >
           <div
-            className="c19"
+            className="c8"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -690,7 +352,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
           </div>
         </div>
         <div
-          className="c20"
+          className="c9"
         />
       </div>
       <div
@@ -711,7 +373,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
           Meta description preview:
         </span>
         <div
-          className="c21"
+          className="c10"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
@@ -728,7 +390,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
 `;
 
 exports[`SnippetPreview highlights keywords inside the description and url 1`] = `
-.c12 {
+.c1 {
   overflow: auto;
   width: 640px;
   padding: 0 20px;
@@ -736,143 +398,22 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   box-sizing: border-box;
 }
 
-.c13 {
+.c2 {
   width: 600px;
 }
 
-.c7 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c2 {
-  font-size: 0.8rem;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c3 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c4:hover {
-  color: #000;
-  background-color: #fff;
-  border-color: #888;
-}
-
-.c5::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #0066cd;
-  color: #000;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c6:active {
-  color: #000;
-  background-color: #f7f7f7;
-  border-color: #888;
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   background-color: white;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
 
-.c14 {
+.c3 {
   cursor: pointer;
   position: relative;
 }
 
-.c16 {
+.c5 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -887,17 +428,17 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   text-overflow: ellipsis;
 }
 
-.c15 {
+.c4 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   white-space: nowrap;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -907,7 +448,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   font-size: 14px;
 }
 
-.c19 {
+.c8 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -920,7 +461,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -928,7 +469,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -938,61 +479,13 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
 <section>
-  <div>
-    <div
-      className="yoast-help c0"
-    >
-      <button
-        aria-controls={null}
-        aria-expanded={false}
-        aria-label="Help on the Snippet Preview"
-        className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-          fill="#646464"
-          focusable="false"
-          role="img"
-          size="16px"
-          viewBox="0 0 1792 1792"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-          />
-        </svg>
-      </button>
-      <div
-        className="c10"
-      />
-    </div>
-  </div>
   <div
-    className="c11 c12"
+    className="c0 c1"
     width={640}
   >
     <div
-      className="c13"
+      className="c2"
       width={600}
     >
       <div
@@ -1013,16 +506,16 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
           SEO title preview:
         </span>
         <div
-          className="c14"
+          className="c3"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c15 c16"
+            className="c4 c5"
           >
             <span
-              className="c17"
+              className="c6"
             >
               Title
             </span>
@@ -1043,10 +536,10 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
           Url preview:
         </span>
         <div
-          className="c18"
+          className="c7"
         >
           <div
-            className="c19"
+            className="c8"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -1055,7 +548,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
           </div>
         </div>
         <div
-          className="c20"
+          className="c9"
         />
       </div>
       <div
@@ -1076,7 +569,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
           Meta description preview:
         </span>
         <div
-          className="c21"
+          className="c10"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
@@ -1093,128 +586,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
 `;
 
 exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] = `
-.c7 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c2 {
-  font-size: 0.8rem;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c3 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c4:hover {
-  color: #000;
-  background-color: #fff;
-  border-color: #888;
-}
-
-.c5::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #0066cd;
-  color: #000;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c6:active {
-  color: #000;
-  background-color: #f7f7f7;
-  border-color: #888;
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -1224,12 +596,12 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1244,13 +616,13 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -1259,7 +631,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   text-overflow: ellipsis;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -1269,7 +641,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   font-size: 14px;
 }
 
-.c19 {
+.c8 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -1282,7 +654,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   max-width: 100%;
 }
 
-.c22 {
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -1290,22 +662,22 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   font-size: 13px;
 }
 
-.c21 {
+.c10 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c20 {
+.c9 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
 }
 
-.c17 {
+.c6 {
   background-size: 100% 100%;
   display: inline-block;
   height: 12px;
@@ -1316,62 +688,14 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   background-image: url( data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAQAAABLCVATAAABr0lEQVR4AbWWJYCUURhFD04Zi7hrLzgFd4nzV9x6wKHinmYb7g4zq71gIw2LWBnZ3Q8df/fh96Tn/t2HVIw4CVKk+fSFNCkSxInxW1pFkhLmoMRjVvFLmkEX5ocuZuBVPw5jv8hh+iEU5QEmuMK+prz7RN3dPMMEGQYzxpH/lGjzou5jgl7mAvOdZfcbF+jbm3MAbFZ7VX9SJnlL1D8UMyjLe+BrAYDb+jJUr59JrlNWRtcqX9GkrPCR4QBAf4qYJAkQoyQrbKKs8RiaEjEI0GvvQ1mLMC9xaBFFBaZS1TbMSwJSomg39erDF+TxpCCNOXjGQJTCvG6qn4ZPzkcxA61Tjhaf4KMj+6Q3XvW6Lopraa8IozRQxIi0a7NXorULc5JyHX/3F3q+0PsFYytVTaGgjz/AvCyiegE69IUsPxHNBMpa738i6tGWlzkAABjKe/+j9YeRHGVd9oWRnwe2ewDASp/L/UqoPQ5AmFeYZMavBP8dAJz0GWWDHQlzXApMdz4KYUfKICcxkKeOfGmQyrIPcgE9m+g/+kT812/Nr3+0kqzitxQjoKXh6xfor99nlEdFjyvH15gAAAAASUVORK5CYII= );
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
 <section>
-  <div>
-    <div
-      className="yoast-help c0"
-    >
-      <button
-        aria-controls={null}
-        aria-expanded={false}
-        aria-label="Help on the Snippet Preview"
-        className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-          fill="#646464"
-          focusable="false"
-          role="img"
-          size="16px"
-          viewBox="0 0 1792 1792"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-          />
-        </svg>
-      </button>
-      <div
-        className="c10"
-      />
-    </div>
-  </div>
   <div
-    className="c11"
+    className="c0"
     onMouseLeave={undefined}
     width={640}
   >
     <div
-      className="c12"
+      className="c1"
     >
       <span
         className="screen-reader-text"
@@ -1388,16 +712,16 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
         SEO title preview:
       </span>
       <div
-        className="c13"
+        className="c2"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
         onMouseUp={[Function]}
       >
         <div
-          className="c14 c15"
+          className="c3 c4"
         >
           <span
-            className="c16"
+            className="c5"
           >
             Title
           </span>
@@ -1418,13 +742,13 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
         Url preview:
       </span>
       <div
-        className="c17"
+        className="c6"
       />
       <div
-        className="c18"
+        className="c7"
       >
         <div
-          className="c19"
+          className="c8"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
@@ -1434,10 +758,10 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
       </div>
     </div>
     <hr
-      className="c20"
+      className="c9"
     />
     <div
-      className="c12"
+      className="c1"
     >
       <span
         className="screen-reader-text"
@@ -1454,13 +778,13 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
         Meta description preview:
       </span>
       <div
-        className="c21 c22"
+        className="c10 c11"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
         onMouseUp={[Function]}
       >
         <div
-          className="c21 c22"
+          className="c10 c11"
         >
           Description
         </div>
@@ -1471,128 +795,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
 `;
 
 exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
-.c7 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c2 {
-  font-size: 0.8rem;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c3 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c4:hover {
-  color: #000;
-  background-color: #fff;
-  border-color: #888;
-}
-
-.c5::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #0066cd;
-  color: #000;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c6:active {
-  color: #000;
-  background-color: #f7f7f7;
-  border-color: #888;
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -1602,12 +805,12 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1622,13 +825,13 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -1637,7 +840,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -1647,7 +850,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -1660,7 +863,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -1668,77 +871,29 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
 <section>
-  <div>
-    <div
-      className="yoast-help c0"
-    >
-      <button
-        aria-controls={null}
-        aria-expanded={false}
-        aria-label="Help on the Snippet Preview"
-        className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-          fill="#646464"
-          focusable="false"
-          role="img"
-          size="16px"
-          viewBox="0 0 1792 1792"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-          />
-        </svg>
-      </button>
-      <div
-        className="c10"
-      />
-    </div>
-  </div>
   <div
-    className="c11"
+    className="c0"
     onMouseLeave={undefined}
     width={640}
   >
     <div
-      className="c12"
+      className="c1"
     >
       <span
         className="screen-reader-text"
@@ -1755,16 +910,16 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
         SEO title preview:
       </span>
       <div
-        className="c13"
+        className="c2"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
         onMouseUp={[Function]}
       >
         <div
-          className="c14 c15"
+          className="c3 c4"
         >
           <span
-            className="c16"
+            className="c5"
           >
             Title
           </span>
@@ -1785,10 +940,10 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
         Url preview:
       </span>
       <div
-        className="c17"
+        className="c6"
       >
         <div
-          className="c18"
+          className="c7"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
@@ -1798,10 +953,10 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
       </div>
     </div>
     <hr
-      className="c19"
+      className="c8"
     />
     <div
-      className="c12"
+      className="c1"
     >
       <span
         className="screen-reader-text"
@@ -1818,13 +973,13 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
         Meta description preview:
       </span>
       <div
-        className="c20 c21"
+        className="c9 c10"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
         onMouseUp={[Function]}
       >
         <div
-          className="c20 c21"
+          className="c9 c10"
         >
           Description
         </div>
@@ -1835,128 +990,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
 `;
 
 exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
-.c7 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c2 {
-  font-size: 0.8rem;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c3 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c4:hover {
-  color: #000;
-  background-color: #fff;
-  border-color: #888;
-}
-
-.c5::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #0066cd;
-  color: #000;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c6:active {
-  color: #000;
-  background-color: #f7f7f7;
-  border-color: #888;
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   border-bottom: 1px hidden #fff;
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
@@ -1966,12 +1000,12 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   font-size: 14px;
 }
 
-.c13 {
+.c2 {
   cursor: pointer;
   position: relative;
 }
 
-.c15 {
+.c4 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1986,13 +1020,13 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   text-overflow: ellipsis;
 }
 
-.c14 {
+.c3 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   display: inline-block;
   font-size: 16px;
   line-height: 1.2em;
@@ -2001,7 +1035,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -2011,7 +1045,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   font-size: 14px;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -2024,7 +1058,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -2032,77 +1066,29 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c12 {
+.c1 {
   padding: 8px 16px;
 }
 
-.c19 {
+.c8 {
   border: 0;
   border-bottom: 1px solid #DFE1E5;
   margin: 0;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
 <section>
-  <div>
-    <div
-      className="yoast-help c0"
-    >
-      <button
-        aria-controls={null}
-        aria-expanded={false}
-        aria-label="Help on the Snippet Preview"
-        className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-          fill="#646464"
-          focusable="false"
-          role="img"
-          size="16px"
-          viewBox="0 0 1792 1792"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-          />
-        </svg>
-      </button>
-      <div
-        className="c10"
-      />
-    </div>
-  </div>
   <div
-    className="c11"
+    className="c0"
     onMouseLeave={undefined}
     width={640}
   >
     <div
-      className="c12"
+      className="c1"
     >
       <span
         className="screen-reader-text"
@@ -2119,16 +1105,16 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
         SEO title preview:
       </span>
       <div
-        className="c13"
+        className="c2"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
         onMouseUp={[Function]}
       >
         <div
-          className="c14 c15"
+          className="c3 c4"
         >
           <span
-            className="c16"
+            className="c5"
           >
             Title
           </span>
@@ -2149,10 +1135,10 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
         Url preview:
       </span>
       <div
-        className="c17"
+        className="c6"
       >
         <div
-          className="c18"
+          className="c7"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
@@ -2162,10 +1148,10 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
       </div>
     </div>
     <hr
-      className="c19"
+      className="c8"
     />
     <div
-      className="c12"
+      className="c1"
     >
       <span
         className="screen-reader-text"
@@ -2182,13 +1168,13 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
         Meta description preview:
       </span>
       <div
-        className="c20 c21"
+        className="c9 c10"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
         onMouseUp={[Function]}
       >
         <div
-          className="c20 c21"
+          className="c9 c10"
         >
           Description
         </div>
@@ -2199,7 +1185,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
 `;
 
 exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
-.c12 {
+.c1 {
   overflow: auto;
   width: 640px;
   padding: 0 20px;
@@ -2207,143 +1193,22 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   box-sizing: border-box;
 }
 
-.c13 {
+.c2 {
   width: 600px;
 }
 
-.c7 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c2 {
-  font-size: 0.8rem;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c3 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c4:hover {
-  color: #000;
-  background-color: #fff;
-  border-color: #888;
-}
-
-.c5::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #0066cd;
-  color: #000;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c6:active {
-  color: #000;
-  background-color: #f7f7f7;
-  border-color: #888;
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   background-color: white;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
 
-.c14 {
+.c3 {
   cursor: pointer;
   position: relative;
 }
 
-.c16 {
+.c5 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2358,17 +1223,17 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   text-overflow: ellipsis;
 }
 
-.c15 {
+.c4 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   white-space: nowrap;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -2378,7 +1243,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   font-size: 14px;
 }
 
-.c19 {
+.c8 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -2391,7 +1256,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -2399,7 +1264,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -2409,61 +1274,13 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
 <section>
-  <div>
-    <div
-      className="yoast-help c0"
-    >
-      <button
-        aria-controls={null}
-        aria-expanded={false}
-        aria-label="Help on the Snippet Preview"
-        className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-          fill="#646464"
-          focusable="false"
-          role="img"
-          size="16px"
-          viewBox="0 0 1792 1792"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-          />
-        </svg>
-      </button>
-      <div
-        className="c10"
-      />
-    </div>
-  </div>
   <div
-    className="c11 c12"
+    className="c0 c1"
     width={640}
   >
     <div
-      className="c13"
+      className="c2"
       width={600}
     >
       <div
@@ -2484,16 +1301,16 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
           SEO title preview:
         </span>
         <div
-          className="c14"
+          className="c3"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c15 c16"
+            className="c4 c5"
           >
             <span
-              className="c17"
+              className="c6"
             >
               Title
             </span>
@@ -2514,10 +1331,10 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
           Url preview:
         </span>
         <div
-          className="c18"
+          className="c7"
         >
           <div
-            className="c19"
+            className="c8"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -2526,7 +1343,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
           </div>
         </div>
         <div
-          className="c20"
+          className="c9"
         />
       </div>
       <div
@@ -2547,7 +1364,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c21"
+          className="c10"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
@@ -2561,7 +1378,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
 `;
 
 exports[`SnippetPreview renders a caret on activation 1`] = `
-.c12 {
+.c1 {
   overflow: auto;
   width: 640px;
   padding: 0 20px;
@@ -2569,143 +1386,22 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   box-sizing: border-box;
 }
 
-.c13 {
+.c2 {
   width: 600px;
 }
 
-.c7 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c2 {
-  font-size: 0.8rem;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c3 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c4:hover {
-  color: #000;
-  background-color: #fff;
-  border-color: #888;
-}
-
-.c5::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #0066cd;
-  color: #000;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c6:active {
-  color: #000;
-  background-color: #f7f7f7;
-  border-color: #888;
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   background-color: white;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
 
-.c15 {
+.c4 {
   cursor: pointer;
   position: relative;
 }
 
-.c17 {
+.c6 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2720,17 +1416,17 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c18 {
+.c7 {
   white-space: nowrap;
 }
 
-.c19 {
+.c8 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -2740,7 +1436,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   font-size: 14px;
 }
 
-.c20 {
+.c9 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -2753,7 +1449,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -2761,7 +1457,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   font-size: 13px;
 }
 
-.c21 {
+.c10 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -2771,15 +1467,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c14::before {
+.c3::before {
   display: block;
   position: absolute;
   top: -3px;
@@ -2791,53 +1479,13 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   content: "";
 }
 
-@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
 <section>
-  <div>
-    <div
-      className="yoast-help c0"
-    >
-      <button
-        aria-controls={null}
-        aria-expanded={false}
-        aria-label="Help on the Snippet Preview"
-        className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-          fill="#646464"
-          focusable="false"
-          role="img"
-          size="16px"
-          viewBox="0 0 1792 1792"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-          />
-        </svg>
-      </button>
-      <div
-        className="c10"
-      />
-    </div>
-  </div>
   <div
-    className="c11 c12"
+    className="c0 c1"
     width={640}
   >
     <div
-      className="c13"
+      className="c2"
       width={600}
     >
       <div
@@ -2858,16 +1506,16 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
           SEO title preview:
         </span>
         <div
-          className="c14 c15"
+          className="c3 c4"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c16 c17"
+            className="c5 c6"
           >
             <span
-              className="c18"
+              className="c7"
             >
               Title
             </span>
@@ -2888,10 +1536,10 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
           Url preview:
         </span>
         <div
-          className="c19"
+          className="c8"
         >
           <div
-            className="c20"
+            className="c9"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -2900,7 +1548,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
           </div>
         </div>
         <div
-          className="c21"
+          className="c10"
         />
       </div>
       <div
@@ -2921,7 +1569,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c22"
+          className="c11"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
@@ -2935,7 +1583,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
 `;
 
 exports[`SnippetPreview renders a caret on activation 2`] = `
-.c12 {
+.c1 {
   overflow: auto;
   width: 640px;
   padding: 0 20px;
@@ -2943,143 +1591,22 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   box-sizing: border-box;
 }
 
-.c13 {
+.c2 {
   width: 600px;
 }
 
-.c7 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c2 {
-  font-size: 0.8rem;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c3 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c4:hover {
-  color: #000;
-  background-color: #fff;
-  border-color: #888;
-}
-
-.c5::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #0066cd;
-  color: #000;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c6:active {
-  color: #000;
-  background-color: #f7f7f7;
-  border-color: #888;
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   background-color: white;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
 
-.c14 {
+.c3 {
   cursor: pointer;
   position: relative;
 }
 
-.c16 {
+.c5 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3094,17 +1621,17 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   text-overflow: ellipsis;
 }
 
-.c15 {
+.c4 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   white-space: nowrap;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -3114,7 +1641,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   font-size: 14px;
 }
 
-.c19 {
+.c8 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -3127,7 +1654,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -3135,7 +1662,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -3145,15 +1672,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21::before {
+.c10::before {
   display: block;
   position: absolute;
   top: -3px;
@@ -3165,53 +1684,13 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   content: "";
 }
 
-@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
 <section>
-  <div>
-    <div
-      className="yoast-help c0"
-    >
-      <button
-        aria-controls={null}
-        aria-expanded={false}
-        aria-label="Help on the Snippet Preview"
-        className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-          fill="#646464"
-          focusable="false"
-          role="img"
-          size="16px"
-          viewBox="0 0 1792 1792"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-          />
-        </svg>
-      </button>
-      <div
-        className="c10"
-      />
-    </div>
-  </div>
   <div
-    className="c11 c12"
+    className="c0 c1"
     width={640}
   >
     <div
-      className="c13"
+      className="c2"
       width={600}
     >
       <div
@@ -3232,16 +1711,16 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
           SEO title preview:
         </span>
         <div
-          className="c14"
+          className="c3"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c15 c16"
+            className="c4 c5"
           >
             <span
-              className="c17"
+              className="c6"
             >
               Title
             </span>
@@ -3262,10 +1741,10 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
           Url preview:
         </span>
         <div
-          className="c18"
+          className="c7"
         >
           <div
-            className="c19"
+            className="c8"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -3274,7 +1753,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
           </div>
         </div>
         <div
-          className="c20"
+          className="c9"
         />
       </div>
       <div
@@ -3295,7 +1774,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
           Meta description preview:
         </span>
         <div
-          className="c21 c22"
+          className="c10 c11"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
@@ -3309,7 +1788,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
 `;
 
 exports[`SnippetPreview renders a caret on activation 3`] = `
-.c12 {
+.c1 {
   overflow: auto;
   width: 640px;
   padding: 0 20px;
@@ -3317,143 +1796,22 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   box-sizing: border-box;
 }
 
-.c13 {
+.c2 {
   width: 600px;
 }
 
-.c7 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c2 {
-  font-size: 0.8rem;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c3 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c4:hover {
-  color: #000;
-  background-color: #fff;
-  border-color: #888;
-}
-
-.c5::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #0066cd;
-  color: #000;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c6:active {
-  color: #000;
-  background-color: #f7f7f7;
-  border-color: #888;
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   background-color: white;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
 
-.c14 {
+.c3 {
   cursor: pointer;
   position: relative;
 }
 
-.c16 {
+.c5 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3468,17 +1826,17 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   text-overflow: ellipsis;
 }
 
-.c15 {
+.c4 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   white-space: nowrap;
 }
 
-.c19 {
+.c8 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -3488,7 +1846,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   font-size: 14px;
 }
 
-.c20 {
+.c9 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -3501,7 +1859,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -3509,7 +1867,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   font-size: 13px;
 }
 
-.c21 {
+.c10 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -3519,15 +1877,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c18::before {
+.c7::before {
   display: block;
   position: absolute;
   top: -3px;
@@ -3539,53 +1889,13 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   content: "";
 }
 
-@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
 <section>
-  <div>
-    <div
-      className="yoast-help c0"
-    >
-      <button
-        aria-controls={null}
-        aria-expanded={false}
-        aria-label="Help on the Snippet Preview"
-        className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-          fill="#646464"
-          focusable="false"
-          role="img"
-          size="16px"
-          viewBox="0 0 1792 1792"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-          />
-        </svg>
-      </button>
-      <div
-        className="c10"
-      />
-    </div>
-  </div>
   <div
-    className="c11 c12"
+    className="c0 c1"
     width={640}
   >
     <div
-      className="c13"
+      className="c2"
       width={600}
     >
       <div
@@ -3606,16 +1916,16 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
           SEO title preview:
         </span>
         <div
-          className="c14"
+          className="c3"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c15 c16"
+            className="c4 c5"
           >
             <span
-              className="c17"
+              className="c6"
             >
               Title
             </span>
@@ -3636,10 +1946,10 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
           Url preview:
         </span>
         <div
-          className="c18 c19"
+          className="c7 c8"
         >
           <div
-            className="c20"
+            className="c9"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -3648,7 +1958,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
           </div>
         </div>
         <div
-          className="c21"
+          className="c10"
         />
       </div>
       <div
@@ -3669,7 +1979,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
           Meta description preview:
         </span>
         <div
-          className="c22"
+          className="c11"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
@@ -3683,7 +1993,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
 `;
 
 exports[`SnippetPreview renders a caret on hover 1`] = `
-.c12 {
+.c1 {
   overflow: auto;
   width: 640px;
   padding: 0 20px;
@@ -3691,143 +2001,22 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   box-sizing: border-box;
 }
 
-.c13 {
+.c2 {
   width: 600px;
 }
 
-.c7 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c2 {
-  font-size: 0.8rem;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c3 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c4:hover {
-  color: #000;
-  background-color: #fff;
-  border-color: #888;
-}
-
-.c5::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #0066cd;
-  color: #000;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c6:active {
-  color: #000;
-  background-color: #f7f7f7;
-  border-color: #888;
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   background-color: white;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
 
-.c15 {
+.c4 {
   cursor: pointer;
   position: relative;
 }
 
-.c17 {
+.c6 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3842,17 +2031,17 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   text-overflow: ellipsis;
 }
 
-.c16 {
+.c5 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c18 {
+.c7 {
   white-space: nowrap;
 }
 
-.c19 {
+.c8 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -3862,7 +2051,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   font-size: 14px;
 }
 
-.c20 {
+.c9 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -3875,7 +2064,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -3883,7 +2072,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   font-size: 13px;
 }
 
-.c21 {
+.c10 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -3893,15 +2082,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c14::before {
+.c3::before {
   display: block;
   position: absolute;
   top: -3px;
@@ -3913,53 +2094,13 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   content: "";
 }
 
-@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
 <section>
-  <div>
-    <div
-      className="yoast-help c0"
-    >
-      <button
-        aria-controls={null}
-        aria-expanded={false}
-        aria-label="Help on the Snippet Preview"
-        className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-          fill="#646464"
-          focusable="false"
-          role="img"
-          size="16px"
-          viewBox="0 0 1792 1792"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-          />
-        </svg>
-      </button>
-      <div
-        className="c10"
-      />
-    </div>
-  </div>
   <div
-    className="c11 c12"
+    className="c0 c1"
     width={640}
   >
     <div
-      className="c13"
+      className="c2"
       width={600}
     >
       <div
@@ -3980,16 +2121,16 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
           SEO title preview:
         </span>
         <div
-          className="c14 c15"
+          className="c3 c4"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c16 c17"
+            className="c5 c6"
           >
             <span
-              className="c18"
+              className="c7"
             >
               Title
             </span>
@@ -4010,10 +2151,10 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
           Url preview:
         </span>
         <div
-          className="c19"
+          className="c8"
         >
           <div
-            className="c20"
+            className="c9"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -4022,7 +2163,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
           </div>
         </div>
         <div
-          className="c21"
+          className="c10"
         />
       </div>
       <div
@@ -4043,7 +2184,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c22"
+          className="c11"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
@@ -4057,7 +2198,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
 `;
 
 exports[`SnippetPreview renders a caret on hover 2`] = `
-.c12 {
+.c1 {
   overflow: auto;
   width: 640px;
   padding: 0 20px;
@@ -4065,143 +2206,22 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   box-sizing: border-box;
 }
 
-.c13 {
+.c2 {
   width: 600px;
 }
 
-.c7 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c2 {
-  font-size: 0.8rem;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c3 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c4:hover {
-  color: #000;
-  background-color: #fff;
-  border-color: #888;
-}
-
-.c5::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #0066cd;
-  color: #000;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c6:active {
-  color: #000;
-  background-color: #f7f7f7;
-  border-color: #888;
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   background-color: white;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
 
-.c14 {
+.c3 {
   cursor: pointer;
   position: relative;
 }
 
-.c16 {
+.c5 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4216,17 +2236,17 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   text-overflow: ellipsis;
 }
 
-.c15 {
+.c4 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   white-space: nowrap;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -4236,7 +2256,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   font-size: 14px;
 }
 
-.c19 {
+.c8 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -4249,7 +2269,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -4257,7 +2277,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -4267,15 +2287,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c21::before {
+.c10::before {
   display: block;
   position: absolute;
   top: -3px;
@@ -4287,53 +2299,13 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   content: "";
 }
 
-@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
 <section>
-  <div>
-    <div
-      className="yoast-help c0"
-    >
-      <button
-        aria-controls={null}
-        aria-expanded={false}
-        aria-label="Help on the Snippet Preview"
-        className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-          fill="#646464"
-          focusable="false"
-          role="img"
-          size="16px"
-          viewBox="0 0 1792 1792"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-          />
-        </svg>
-      </button>
-      <div
-        className="c10"
-      />
-    </div>
-  </div>
   <div
-    className="c11 c12"
+    className="c0 c1"
     width={640}
   >
     <div
-      className="c13"
+      className="c2"
       width={600}
     >
       <div
@@ -4354,16 +2326,16 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
           SEO title preview:
         </span>
         <div
-          className="c14"
+          className="c3"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c15 c16"
+            className="c4 c5"
           >
             <span
-              className="c17"
+              className="c6"
             >
               Title
             </span>
@@ -4384,10 +2356,10 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
           Url preview:
         </span>
         <div
-          className="c18"
+          className="c7"
         >
           <div
-            className="c19"
+            className="c8"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -4396,7 +2368,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
           </div>
         </div>
         <div
-          className="c20"
+          className="c9"
         />
       </div>
       <div
@@ -4417,7 +2389,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
           Meta description preview:
         </span>
         <div
-          className="c21 c22"
+          className="c10 c11"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
@@ -4431,7 +2403,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
 `;
 
 exports[`SnippetPreview renders a caret on hover 3`] = `
-.c12 {
+.c1 {
   overflow: auto;
   width: 640px;
   padding: 0 20px;
@@ -4439,143 +2411,22 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   box-sizing: border-box;
 }
 
-.c13 {
+.c2 {
   width: 600px;
 }
 
-.c7 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c2 {
-  font-size: 0.8rem;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c3 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c4:hover {
-  color: #000;
-  background-color: #fff;
-  border-color: #888;
-}
-
-.c5::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #0066cd;
-  color: #000;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c6:active {
-  color: #000;
-  background-color: #f7f7f7;
-  border-color: #888;
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   background-color: white;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
 
-.c14 {
+.c3 {
   cursor: pointer;
   position: relative;
 }
 
-.c16 {
+.c5 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4590,17 +2441,17 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   text-overflow: ellipsis;
 }
 
-.c15 {
+.c4 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   white-space: nowrap;
 }
 
-.c19 {
+.c8 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -4610,7 +2461,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   font-size: 14px;
 }
 
-.c20 {
+.c9 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -4623,7 +2474,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   max-width: 100%;
 }
 
-.c22 {
+.c11 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -4631,7 +2482,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   font-size: 13px;
 }
 
-.c21 {
+.c10 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -4641,15 +2492,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   vertical-align: top;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c18::before {
+.c7::before {
   display: block;
   position: absolute;
   top: -3px;
@@ -4661,53 +2504,13 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   content: "";
 }
 
-@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
 <section>
-  <div>
-    <div
-      className="yoast-help c0"
-    >
-      <button
-        aria-controls={null}
-        aria-expanded={false}
-        aria-label="Help on the Snippet Preview"
-        className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-          fill="#646464"
-          focusable="false"
-          role="img"
-          size="16px"
-          viewBox="0 0 1792 1792"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-          />
-        </svg>
-      </button>
-      <div
-        className="c10"
-      />
-    </div>
-  </div>
   <div
-    className="c11 c12"
+    className="c0 c1"
     width={640}
   >
     <div
-      className="c13"
+      className="c2"
       width={600}
     >
       <div
@@ -4728,16 +2531,16 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
           SEO title preview:
         </span>
         <div
-          className="c14"
+          className="c3"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c15 c16"
+            className="c4 c5"
           >
             <span
-              className="c17"
+              className="c6"
             >
               Title
             </span>
@@ -4758,10 +2561,10 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
           Url preview:
         </span>
         <div
-          className="c18 c19"
+          className="c7 c8"
         >
           <div
-            className="c20"
+            className="c9"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -4770,7 +2573,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
           </div>
         </div>
         <div
-          className="c21"
+          className="c10"
         />
       </div>
       <div
@@ -4791,7 +2594,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
           Meta description preview:
         </span>
         <div
-          className="c22"
+          className="c11"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
@@ -4805,7 +2608,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
 `;
 
 exports[`SnippetPreview shows the date if a date is passed 1`] = `
-.c12 {
+.c1 {
   overflow: auto;
   width: 640px;
   padding: 0 20px;
@@ -4813,143 +2616,22 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   box-sizing: border-box;
 }
 
-.c13 {
+.c2 {
   width: 600px;
 }
 
-.c7 {
-  color: #555;
-  border-color: #ccc;
-  background: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,1 );
-}
-
-.c2 {
-  font-size: 0.8rem;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  vertical-align: middle;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 4px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  text-align: left;
-  overflow: visible;
-  min-height: 32px;
-}
-
-.c3 svg {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-}
-
-.c4:hover {
-  color: #000;
-  background-color: #fff;
-  border-color: #888;
-}
-
-.c5::-moz-focus-inner {
-  border-width: 0;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #0066cd;
-  color: #000;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c6:active {
-  color: #000;
-  background-color: #f7f7f7;
-  border-color: #888;
-  box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
-}
-
-.c10 >:first-child {
-  overflow: hidden;
-  -webkit-transition: height 300ms ease-out;
-  transition: height 300ms ease-out;
-}
-
 .c0 {
-  max-width: 600px;
-  font-weight: normal;
-  margin: 0 20px 0 25px;
-}
-
-.c1 {
-  min-width: 14px;
-  min-height: 14px;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  box-shadow: none;
-  display: block;
-  margin: -44px -10px 10px 0;
-  background-color: transparent;
-  float: right;
-  padding: 3px 0 0 6px;
-}
-
-.c1:hover {
-  color: #0066cd;
-}
-
-.c1:focus {
-  border: 1px solid #0066cd;
-  outline: none;
-  box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
-}
-
-.c1:focus svg {
-  fill: #0066cd;
-  color: #0066cd;
-}
-
-.c1:active {
-  box-shadow: none;
-}
-
-.c8:hover {
-  fill: #0066cd;
-}
-
-.c11 {
   background-color: white;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
 
-.c14 {
+.c3 {
   cursor: pointer;
   position: relative;
 }
 
-.c16 {
+.c5 {
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4964,17 +2646,17 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   text-overflow: ellipsis;
 }
 
-.c15 {
+.c4 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c6 {
   white-space: nowrap;
 }
 
-.c18 {
+.c7 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -4984,7 +2666,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   font-size: 14px;
 }
 
-.c19 {
+.c8 {
   display: inline-block;
   color: #006621;
   cursor: pointer;
@@ -4997,7 +2679,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   max-width: 100%;
 }
 
-.c21 {
+.c10 {
   color: #545454;
   cursor: pointer;
   position: relative;
@@ -5005,7 +2687,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   font-size: 13px;
 }
 
-.c20 {
+.c9 {
   display: inline-block;
   margin-top: 6px;
   margin-left: 6px;
@@ -5015,65 +2697,17 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   vertical-align: top;
 }
 
-.c22 {
+.c11 {
   color: #808080;
 }
 
-.c9 {
-  width: 16px;
-  height: 16px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-@media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
-    display: inline-block;
-    content: "";
-    min-height: 22px;
-  }
-}
-
 <section>
-  <div>
-    <div
-      className="yoast-help c0"
-    >
-      <button
-        aria-controls={null}
-        aria-expanded={false}
-        aria-label="Help on the Snippet Preview"
-        className="yoast-help__button c1 c2 Button-kDSBcD c3 Button-kDSBcD c4 Button-kDSBcD c5 Button-kDSBcD c6 c7"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="yoast-svg-icon yoast-svg-icon-question-circle c8 c9"
-          fill="#646464"
-          focusable="false"
-          role="img"
-          size="16px"
-          viewBox="0 0 1792 1792"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1024 1376v-192q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v192q0 14 9 23t23 9h192q14 0 23-9t9-23zm256-672q0-88-55.5-163t-138.5-116-170-41q-243 0-371 213-15 24 8 42l132 100q7 6 19 6 16 0 25-12 53-68 86-92 34-24 86-24 48 0 85.5 26t37.5 59q0 38-20 61t-68 45q-63 28-115.5 86.5t-52.5 125.5v36q0 14 9 23t23 9h192q14 0 23-9t9-23q0-19 21.5-49.5t54.5-49.5q32-18 49-28.5t46-35 44.5-48 28-60.5 12.5-81zm384 192q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"
-          />
-        </svg>
-      </button>
-      <div
-        className="c10"
-      />
-    </div>
-  </div>
   <div
-    className="c11 c12"
+    className="c0 c1"
     width={640}
   >
     <div
-      className="c13"
+      className="c2"
       width={600}
     >
       <div
@@ -5094,16 +2728,16 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
           SEO title preview:
         </span>
         <div
-          className="c14"
+          className="c3"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <div
-            className="c15 c16"
+            className="c4 c5"
           >
             <span
-              className="c17"
+              className="c6"
             >
               Title
             </span>
@@ -5124,10 +2758,10 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
           Url preview:
         </span>
         <div
-          className="c18"
+          className="c7"
         >
           <div
-            className="c19"
+            className="c8"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
@@ -5136,7 +2770,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
           </div>
         </div>
         <div
-          className="c20"
+          className="c9"
         />
       </div>
       <div
@@ -5157,13 +2791,13 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
           Meta description preview:
         </span>
         <div
-          className="c21"
+          className="c10"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
           <span
-            className="c22"
+            className="c11"
           >
             Today
              - 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes help button from SnippetPreview

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Test in combination with https://github.com/Yoast/wordpress-seo/pull/10542

Fixes Yoast/wordpress-seo#10527
