### PR TITLE
Avoid Collapsible headers vertical scrollbar in IE 11.

### DIFF
--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -162,6 +162,7 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c14 {
@@ -791,6 +792,7 @@ exports[`ContentAnalysis the ContentAnalysis component with hidden buttons match
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c14 {
@@ -1396,6 +1398,7 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c14 {
@@ -2049,6 +2052,7 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c14 {
@@ -2702,6 +2706,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and cons
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c14 {
@@ -3193,6 +3198,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and impr
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c14 {
@@ -3684,6 +3690,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems matches 
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c14 {
@@ -4244,6 +4251,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems, improve
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c14 {

--- a/composites/Plugin/Shared/components/Collapsible.js
+++ b/composites/Plugin/Shared/components/Collapsible.js
@@ -57,6 +57,7 @@ export const StyledIconsButton = styled( IconsButton )`
 const StyledTitleContainer = styled.span`
 	flex-grow: 1;
 	overflow-x: hidden;
+	line-height: normal; // Avoid vertical scrollbar in IE 11 when rendered in the WP sidebar.
 `;
 
 const StyledTitle = styled.span`

--- a/composites/Plugin/Shared/tests/__snapshots__/CollapsibleTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/CollapsibleTest.js.snap
@@ -114,6 +114,7 @@ exports[`Collapsible matches the snapshot by default 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c10 {
@@ -300,6 +301,7 @@ exports[`Collapsible matches the snapshot by default 2`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c10 {
@@ -498,6 +500,7 @@ exports[`Collapsible matches the snapshot when it is closed 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c10 {
@@ -684,6 +687,7 @@ exports[`Collapsible matches the snapshot when it is closed 2`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c10 {
@@ -882,6 +886,7 @@ exports[`Collapsible matches the snapshot when it is open 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c10 {
@@ -1080,6 +1085,7 @@ exports[`Collapsible matches the snapshot when it is open 2`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c10 {
@@ -1266,6 +1272,7 @@ exports[`CollapsibleStateless matches the snapshot by default 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c10 {
@@ -1442,6 +1449,7 @@ exports[`CollapsibleStateless matches the snapshot when it is opened and closed 
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c10 {
@@ -1618,6 +1626,7 @@ exports[`CollapsibleStateless matches the snapshot when it is opened and closed 
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c10 {
@@ -1794,6 +1803,7 @@ exports[`CollapsibleStateless matches the snapshot with prefix seo icon and scre
   -ms-flex-positive: 1;
   flex-grow: 1;
   overflow-x: hidden;
+  line-height: normal;
 }
 
 .c11 {


### PR DESCRIPTION
## Summary

* Avoid Collapsible headers to show a vertical scrollbar in IE 11.

In IE 11, when rendered in the sidebar, the collapsibles show a vertical scrollbar:

![screenshot 49 2](https://user-images.githubusercontent.com/1682452/43832551-1d4dd320-9b08-11e8-8393-c9b50c50458e.png)

Slightly increasing the line-height on the title container fixes it. 

## Test instructions

- needs to be tested in IE 11
- this would require to yarn-link the components, built the JS, etc. and follow the whole process to test on IE 11
- since it's a minor one, I'd suggest to just test there are no regressions on mac browsers and do a final test on IE 11 when a zip will be ready

Fixes https://github.com/Yoast/wordpress-seo/issues/10585
