### PR TITLE
Implement onblur event

### DIFF
--- a/composites/Plugin/Shared/components/KeywordInput.js
+++ b/composites/Plugin/Shared/components/KeywordInput.js
@@ -119,7 +119,7 @@ class KeywordInput extends React.Component {
 	 * @returns {ReactElement} The KeywordField react component including its label and eventual error message.
 	 */
 	render() {
-		const { id, showLabel, keyword, onRemoveKeyword } = this.props;
+		const { id, showLabel, keyword, onRemoveKeyword, onBlurKeyword } = this.props;
 		const showErrorMessage = this.checkKeywordInput( keyword );
 
 		const label = __( "Focus keyword:", "yoast-components" );
@@ -139,6 +139,7 @@ class KeywordInput extends React.Component {
 						id={ id }
 						className={ showErrorMessage ? "hasError" : null }
 						onChange={ this.handleChange }
+						onBlur={ onBlurKeyword }
 						value={ keyword }
 					/>
 					{ onRemoveKeyword !== noop && (
@@ -163,6 +164,7 @@ KeywordInput.propTypes = {
 	keyword: PropTypes.string,
 	onChange: PropTypes.func.isRequired,
 	onRemoveKeyword: PropTypes.func,
+	onBlurKeyword: PropTypes.func,
 };
 
 KeywordInput.defaultProps = {
@@ -170,6 +172,7 @@ KeywordInput.defaultProps = {
 	showLabel: true,
 	keyword: "",
 	onRemoveKeyword: noop,
+	onBlurKeyword: noop,
 };
 
 export default KeywordInput;

--- a/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
@@ -83,6 +83,7 @@ exports[`KeywordInput matches the snapshot by default 1`] = `
       aria-label={null}
       className="c3 c4"
       id="test-id"
+      onBlur={[Function]}
       onChange={[Function]}
       type="text"
       value=""


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added support for onblur event on an additional keyword input field.

## Test instructions

This PR can be tested by following these steps:

* Follow the steps in https://github.com/Yoast/wordpress-seo-premium/pull/1922

Fixes #[1921](https://github.com/Yoast/wordpress-seo-premium/issues/1921)
