### PR TITLE
Fix invalid icon warning when no icon is provided to IconsButton

### DIFF
--- a/composites/Plugin/Shared/components/Button.js
+++ b/composites/Plugin/Shared/components/Button.js
@@ -279,7 +279,7 @@ export const IconsButton = ( props ) => {
 
 	return (
 		<Button className={ className } { ...buttonProps }>
-			{ prefixIcon &&
+			{ prefixIcon && prefixIcon.icon &&
 				<SvgIcon
 					icon={ prefixIcon.icon }
 					color={ prefixIcon.color }
@@ -287,7 +287,7 @@ export const IconsButton = ( props ) => {
 				/>
 			}
 			{ children }
-			{ suffixIcon &&
+			{ suffixIcon && suffixIcon.icon &&
 				<SvgIcon
 					icon={ suffixIcon.icon }
 					color={ suffixIcon.color }
@@ -315,17 +315,4 @@ IconsButton.propTypes = {
 		PropTypes.node,
 		PropTypes.string,
 	] ),
-};
-
-IconsButton.defaultProps = {
-	prefixIcon: {
-		icon: "",
-		color: colors.$black,
-		size: "16px",
-	},
-	suffixIcon: {
-		icon: "",
-		color: colors.$black,
-		size: "16px",
-	},
 };

--- a/composites/Plugin/Shared/components/SvgIcon.js
+++ b/composites/Plugin/Shared/components/SvgIcon.js
@@ -61,7 +61,7 @@ export default class SvgIcon extends React.Component {
 		let iconName = icons[ icon ];
 
 		if ( ! iconName ) {
-			console.warn( "Invalid icon name passed to the SvgIcon component." );
+			console.warn( `Invalid icon name ("${ icon }") passed to the SvgIcon component.` );
 			return null;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Link `yoast-components` to `wordpress-seo` and build the project.
* Open a post in gutenberg in the plugin, open the Yoast SEO sidebar and make sure the warning is no longer given.

Fixes Yoast/wordpress-seo#10672
