### PR TITLE
Bump YoastSEO.js to 1.39.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "striptags": "^3.1.0",
     "styled-components": "^2.1.2",
     "whatwg-fetch": "^1.0.0",
-    "yoastseo": "^1.37.0"
+    "yoastseo": "^1.39.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9138,9 +9138,9 @@ yeoman-generator@^2.0.4:
     through2 "^2.0.0"
     yeoman-environment "^2.0.5"
 
-yoastseo@^1.37.0:
-  version "1.37.0"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.37.0.tgz#257b3dfe3e764ccd5e8dd444987eb88d68c4e969"
+yoastseo@^1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.39.0.tgz#e21f9e6caccf5f9b211bab645f0f648c6700e7b3"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* n/a

##Relevant technical choices:

* Bumps YoastSEO.js to 1.36.0

## Test instructions

This PR can be tested by following these steps:

* Check whether nothing breaks.