### PR TITLE
Refactor ContentAnalysis to expose AnalysisList

### DIFF
--- a/composites/Plugin/ContentAnalysis/components/AnalysisList.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisList.js
@@ -1,0 +1,99 @@
+/* External dependencies */
+import { __ } from "@wordpress/i18n";
+import React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import noop from "lodash/noop";
+
+/* Internal dependencies */
+import AnalysisResult from "./AnalysisResult";
+import colors from "../../../../style-guide/colors";
+
+/**
+ * Renders a styled list of analyses.
+ *
+ * @returns {React.Element} The rendered tree.
+ */
+const AnalysisList = styled.ul`
+	margin: 8px 0;
+	padding: 0;
+	list-style: none;
+`;
+
+/**
+ * Converts a result rating to a color.
+ *
+ * @param {string} rating The rating to convert.
+ *
+ * @returns {string} The color for the rating.
+ */
+export function renderRatingToColor( rating ) {
+	switch ( rating ) {
+		case "good":
+			return colors.$color_good;
+		case "OK":
+			return colors.$color_ok;
+		case "bad":
+			return colors.$color_bad;
+		default:
+			return colors.$color_score_icon;
+	}
+}
+
+/**
+ * Renders a list of results based on the array of results.
+ *
+ * @param {AssessmentResult[]} results                    The results from YoastSEO.js
+ * @param {string}             marksButtonActivatedResult The currently activated result.
+ * @param {string}             marksButtonStatus          The overal status of the mark buttons.
+ * @param {string}             marksButtonClassName       A class name to set on the mark buttons.
+ * @param {Function}           onMarksButtonClick         Function that is called when the user
+ *                                                        clicks one of the mark buttons.
+ *
+ * @returns {React.Element} The rendered list.
+ */
+export default function ResultsList( { results, marksButtonActivatedResult, marksButtonStatus, marksButtonClassName, onMarksButtonClick } ) {
+	return <AnalysisList role="list">
+		{ results.map( ( result ) => {
+			let color = renderRatingToColor( result.rating );
+			let isMarkButtonPressed = result.id === marksButtonActivatedResult;
+
+			let ariaLabel = "";
+			if ( marksButtonStatus === "disabled" ) {
+				ariaLabel = __( "Marks are disabled in current view", "yoast-components" );
+			} else if ( isMarkButtonPressed ) {
+				ariaLabel = __( "Remove highlight from the text", "yoast-components" );
+			} else {
+				ariaLabel = __( "Highlight this result in the text", "yoast-components" );
+			}
+
+			return <AnalysisResult
+				key={ result.id }
+				text={ result.text }
+				bulletColor={ color }
+				hasMarksButton={ result.hasMarks }
+				ariaLabel={ ariaLabel }
+				pressed={ isMarkButtonPressed }
+				buttonId={ result.id }
+				onButtonClick={ () => onMarksButtonClick( result.id, result.marker ) }
+				marksButtonClassName={ marksButtonClassName }
+				marksButtonStatus={ marksButtonStatus }
+			/>;
+		} ) }
+	</AnalysisList>;
+}
+
+ResultsList.propTypes = {
+	results: PropTypes.array.isRequired,
+	marksButtonActivatedResult: PropTypes.string,
+	marksButtonStatus: PropTypes.string,
+	marksButtonClassName: PropTypes.string,
+	onMarksButtonClick: PropTypes.func,
+};
+
+ResultsList.defaultProps = {
+	marksButtonActivatedResult: "",
+	marksButtonStatus: "enabled",
+	marksButtonClassName: "",
+	onMarksButtonClick: noop,
+};

--- a/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
+++ b/composites/Plugin/ContentAnalysis/components/ContentAnalysis.js
@@ -6,7 +6,7 @@ import { __ } from "@wordpress/i18n";
 
 /* Internal dependencies */
 import colors from "../../../../style-guide/colors.json";
-import AnalysisResult from "../components/AnalysisResult.js";
+import AnalysisList from "./AnalysisList";
 import Collapsible, { StyledIconsButton } from "../../../../composites/Plugin/Shared/components/Collapsible";
 
 export const ContentAnalysisContainer = styled.div`
@@ -27,12 +27,6 @@ const StyledCollapsible = styled( Collapsible )`
 		padding: 8px 0;
 		color: ${ colors.$color_blue }
 	}
-`;
-
-const AnalysisList = styled.ul`
-	margin: 8px 0;
-	padding: 0;
-	list-style: none;
 `;
 
 /**
@@ -81,60 +75,6 @@ class ContentAnalysis extends React.Component {
 	}
 
 	/**
-	 * Gets the color for the bullet, based on the rating.
-	 *
-	 * @param {string} rating The rating of the result.
-	 *
-	 * @returns {string} The color for the bullet.
-	 */
-	getColor( rating ) {
-		switch ( rating ) {
-			case "good":
-				return colors.$color_good;
-			case "OK":
-				return colors.$color_ok;
-			case "bad":
-				return colors.$color_bad;
-			default:
-				return colors.$color_score_icon;
-		}
-	}
-
-	/**
-	 * Returns an AnalysisResult component for each result.
-	 *
-	 * @param {array} results The analysis results.
-	 *
-	 * @returns {array} A list of AnalysisResult components.
-	 */
-	getResults( results ) {
-		return results.map( ( result ) => {
-			let color = this.getColor( result.rating );
-			let isPressed = result.id === this.state.checked;
-			let ariaLabel = "";
-			if ( this.props.marksButtonStatus === "disabled" ) {
-				ariaLabel = __( "Marks are disabled in current view", "yoast-components" );
-			} else if ( isPressed ) {
-				ariaLabel = __( "Remove highlight from the text", "yoast-components" );
-			} else {
-				ariaLabel = __( "Highlight this result in the text", "yoast-components" );
-			}
-			return <AnalysisResult
-				key={ result.id }
-				text={ result.text }
-				bulletColor={ color }
-				hasMarksButton={ result.hasMarks }
-				ariaLabel={ ariaLabel }
-				pressed={ isPressed }
-				buttonId={ result.id }
-				onButtonClick={ this.handleClick.bind( this, result.id, result.marker ) }
-				marksButtonClassName={ this.props.marksButtonClassName }
-				marksButtonStatus={ this.props.marksButtonStatus }
-			/>;
-		} );
-	}
-
-	/**
 	 * Renders a Collapsible component with a liset of Analysis results.
 	 *
 	 * @param {string} title        The title of the collapsible section.
@@ -154,7 +94,13 @@ class ContentAnalysis extends React.Component {
 				suffixIconCollapsed={ null }
 				headingProps={ { level: headingLevel, fontSize: "13px", fontWeight: "bold" } }
 			>
-				<AnalysisList role="list">{ this.getResults( results ) }</AnalysisList>
+				<AnalysisList
+					results={ results }
+					marksButtonActivatedResult={ this.state.checked }
+					marksButtonStatus={ this.props.marksButtonStatus }
+					marksButtonClassName={ this.props.marksButtonClassName }
+					onMarksButtonClick={ this.handleClick.bind( this ) }
+				/>
 			</StyledCollapsible>
 		);
 	}

--- a/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/composites/Plugin/ContentAnalysis/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -49,6 +49,12 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
   flex: 1 1 auto;
 }
 
+.c15 {
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
 .c11 {
   color: #555;
   border-color: #ccc;
@@ -197,12 +203,6 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
 .c1 .c4 {
   padding: 8px 0;
   color: #0066cd;
-}
-
-.c15 {
-  margin: 8px 0;
-  padding: 0;
-  list-style: none;
 }
 
 .c12 {
@@ -679,6 +679,12 @@ exports[`ContentAnalysis the ContentAnalysis component with hidden buttons match
   flex: 1 1 auto;
 }
 
+.c15 {
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
 .c11 {
   color: #555;
   border-color: #ccc;
@@ -827,12 +833,6 @@ exports[`ContentAnalysis the ContentAnalysis component with hidden buttons match
 .c1 .c4 {
   padding: 8px 0;
   color: #0066cd;
-}
-
-.c15 {
-  margin: 8px 0;
-  padding: 0;
-  list-style: none;
 }
 
 .c12 {
@@ -1285,6 +1285,12 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
   flex: 1 1 auto;
 }
 
+.c15 {
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
 .c11 {
   color: #555;
   border-color: #ccc;
@@ -1433,12 +1439,6 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
 .c1 .c4 {
   padding: 8px 0;
   color: #0066cd;
-}
-
-.c15 {
-  margin: 8px 0;
-  padding: 0;
-  list-style: none;
 }
 
 .c12 {
@@ -1939,6 +1939,12 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
   flex: 1 1 auto;
 }
 
+.c15 {
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
 .c11 {
   color: #555;
   border-color: #ccc;
@@ -2087,12 +2093,6 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
 .c1 .c4 {
   padding: 8px 0;
   color: #0066cd;
-}
-
-.c15 {
-  margin: 8px 0;
-  padding: 0;
-  list-style: none;
 }
 
 .c12 {
@@ -2593,6 +2593,12 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and cons
   flex: 1 1 auto;
 }
 
+.c15 {
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
 .c11 {
   color: #555;
   border-color: #ccc;
@@ -2741,12 +2747,6 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and cons
 .c1 .c4 {
   padding: 8px 0;
   color: #0066cd;
-}
-
-.c15 {
-  margin: 8px 0;
-  padding: 0;
-  list-style: none;
 }
 
 .c12 {
@@ -3085,6 +3085,12 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and impr
   flex: 1 1 auto;
 }
 
+.c15 {
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
 .c11 {
   color: #555;
   border-color: #ccc;
@@ -3233,12 +3239,6 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and impr
 .c1 .c4 {
   padding: 8px 0;
   color: #0066cd;
-}
-
-.c15 {
-  margin: 8px 0;
-  padding: 0;
-  list-style: none;
 }
 
 .c12 {
@@ -3577,6 +3577,12 @@ exports[`ContentAnalysis the ContentAnalysis component without problems matches 
   flex: 1 1 auto;
 }
 
+.c15 {
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
 .c11 {
   color: #555;
   border-color: #ccc;
@@ -3725,12 +3731,6 @@ exports[`ContentAnalysis the ContentAnalysis component without problems matches 
 .c1 .c4 {
   padding: 8px 0;
   color: #0066cd;
-}
-
-.c15 {
-  margin: 8px 0;
-  padding: 0;
-  list-style: none;
 }
 
 .c12 {
@@ -4138,6 +4138,12 @@ exports[`ContentAnalysis the ContentAnalysis component without problems, improve
   flex: 1 1 auto;
 }
 
+.c15 {
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
 .c11 {
   color: #555;
   border-color: #ccc;
@@ -4286,12 +4292,6 @@ exports[`ContentAnalysis the ContentAnalysis component without problems, improve
 .c1 .c4 {
   padding: 8px 0;
   color: #0066cd;
-}
-
-.c15 {
-  margin: 8px 0;
-  padding: 0;
-  list-style: none;
 }
 
 .c12 {

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ export { default as SynonymsInput } from "./composites/Plugin/Shared/components/
 export * from "./composites/Plugin/SnippetPreview";
 export * from "./composites/Plugin/SnippetEditor";
 export * from "./forms";
+export * from "./composites/Plugin/ContentAnalysis";
 export { default as colors } from "./style-guide/colors.json";
 export { default as utils } from "./utils";
 export { getRtlStyle } from "./utils/helpers/styled-components";


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Exposes `AnalysisList` to render a plain list of content analysis results.
* Exposes `renderRatingToColor` which renders a rating received from YoastSEO.js to a color that can be used in CSS.

## Relevant technical choices:

* This makes it possible to use the plain list without the headings in different project. I specifically needed it for the YoastSEO.js dev tool.

## Test instructions

This PR can be tested by following these steps:

* Open the standalone test tool of yoast-components.
* Verify that the content analysis looks and works the same as before.
* Run the unit tests.
* Verify they pass.