### PR TITLE
Bump YoastSEO.js to 1.39.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "striptags": "^3.1.0",
     "styled-components": "^2.1.2",
     "whatwg-fetch": "^1.0.0",
-    "yoastseo": "^1.39.0"
+    "yoastseo": "^1.39.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "striptags": "^3.1.0",
     "styled-components": "^2.1.2",
     "whatwg-fetch": "^1.0.0",
-    "yoastseo": "^1.39.1"
+    "yoastseo": "^1.39.2"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9138,9 +9138,9 @@ yeoman-generator@^2.0.4:
     through2 "^2.0.0"
     yeoman-environment "^2.0.5"
 
-yoastseo@^1.39.1:
-  version "1.39.1"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.39.1.tgz#cf8ba01fb2cbf90e94229a72b9d81169073641ec"
+yoastseo@^1.39.2:
+  version "1.39.2"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.39.2.tgz#c8cbf62d744f735a197da0a21d38a4d850dc8be2"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9138,9 +9138,9 @@ yeoman-generator@^2.0.4:
     through2 "^2.0.0"
     yeoman-environment "^2.0.5"
 
-yoastseo@^1.39.0:
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.39.0.tgz#e21f9e6caccf5f9b211bab645f0f648c6700e7b3"
+yoastseo@^1.39.1:
+  version "1.39.1"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.39.1.tgz#cf8ba01fb2cbf90e94229a72b9d81169073641ec"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Bumps YoastSEO.js to v. 1.39.2

## Test instructions

This PR can be tested by following these steps:

*Check whether nothing breaks.