### PR TITLE
Makes the string translatable

### DIFF
--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -591,7 +591,7 @@ SnippetEditor.defaultProps = {
 	},
 	mapEditorDataToPreview: null,
 	locale: "en",
-	descriptionEditorFieldPlaceholder: "Modify your meta description by editing it right here",
+	descriptionEditorFieldPlaceholder: __( "Modify your meta description by editing it right here", "yoast-components" ),
 	onChangeAnalysisData: noop,
 	hasPaperStyle: true,
 	showCloseButton: true,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the placeholder "Modify your meta description by editing it right here" wasn't translatable.

## Test instructions

This PR can be tested by following these steps:

* The translation is just missing, thus it isn't really testable. If it looks okay, please merge.

