### PR TITLE
Load translation inside lifecycle function

### DIFF
--- a/composites/Plugin/Shared/components/LanguageNotice.js
+++ b/composites/Plugin/Shared/components/LanguageNotice.js
@@ -46,17 +46,12 @@ export default class LanguageNotice extends PureComponent {
 			return null;
 		}
 
-		const changeLanguageText = __( "Change language", "yoast-components" );
-		/* Translators: %s expands to the actual language. */
-		const canChangeLanguageText = __( "Your site language is set to %s. ", "yoast-components" );
-		/* Translators: %s expands to the actual language. */
-		const canNotChangeLanguageText = __(
-			"Your site language is set to %s. If this is not correct, contact your site administrator.",
-			"yoast-components"
-		);
-
 		// Determine the correct text.
-		let text = canChangeLanguage ? canChangeLanguageText : canNotChangeLanguageText;
+		let text = canChangeLanguage
+			/* Translators: %s expands to the actual language. */
+			? __( "Your site language is set to %s. ", "yoast-components" )
+			/* Translators: %s expands to the actual language. */
+			: __( "Your site language is set to %s. If this is not correct, contact your site administrator.", "yoast-components" );
 
 		// Replace the %s with a strong marked language.
 		text = sprintf( text, `{{strong}}${ language }{{/strong}}` );
@@ -71,7 +66,7 @@ export default class LanguageNotice extends PureComponent {
 			<YoastLanguageNotice>
 				{ text }
 				{ canChangeLanguage && <ChangeLanguageLink href={ changeLanguageLink }>
-					{ changeLanguageText }
+					{ __( "Change language", "yoast-components" ) }
 				</ChangeLanguageLink> }
 			</YoastLanguageNotice>
 		);

--- a/composites/Plugin/Shared/components/LanguageNotice.js
+++ b/composites/Plugin/Shared/components/LanguageNotice.js
@@ -16,15 +16,6 @@ const ChangeLanguageLink = makeOutboundLink( styled.a`
 	margin-left: 4px;
 ` );
 
-const changeLanguageText = __( "Change language", "yoast-components" );
-/* Translators: %s expands to the actual language. */
-const canChangeLanguageText = __( "Your site language is set to %s. ", "yoast-components" );
-/* Translators: %s expands to the actual language. */
-const canNotChangeLanguageText = __(
-	"Your site language is set to %s. If this is not correct, contact your site administrator.",
-	"yoast-components"
-);
-
 /**
  * Returns the LanguageNotice component.
  *
@@ -54,6 +45,15 @@ export default class LanguageNotice extends PureComponent {
 		if ( ! showLanguageNotice ) {
 			return null;
 		}
+
+		const changeLanguageText = __( "Change language", "yoast-components" );
+		/* Translators: %s expands to the actual language. */
+		const canChangeLanguageText = __( "Your site language is set to %s. ", "yoast-components" );
+		/* Translators: %s expands to the actual language. */
+		const canNotChangeLanguageText = __(
+			"Your site language is set to %s. If this is not correct, contact your site administrator.",
+			"yoast-components"
+		);
 
 		// Determine the correct text.
 		let text = canChangeLanguage ? canChangeLanguageText : canNotChangeLanguageText;

--- a/composites/Plugin/Shared/components/LanguageNotice.js
+++ b/composites/Plugin/Shared/components/LanguageNotice.js
@@ -47,11 +47,12 @@ export default class LanguageNotice extends PureComponent {
 		}
 
 		// Determine the correct text.
-		let text = canChangeLanguage
+		/* Translators: %s expands to the actual language. */
+		let text = __( "Your site language is set to %s. ", "yoast-components" );
+		if ( ! canChangeLanguage ) {
 			/* Translators: %s expands to the actual language. */
-			? __( "Your site language is set to %s. ", "yoast-components" )
-			/* Translators: %s expands to the actual language. */
-			: __( "Your site language is set to %s. If this is not correct, contact your site administrator.", "yoast-components" );
+			text = __( "Your site language is set to %s. If this is not correct, contact your site administrator.", "yoast-components" );
+		}
 
 		// Replace the %s with a strong marked language.
 		text = sprintf( text, `{{strong}}${ language }{{/strong}}` );


### PR DESCRIPTION
Otherwise the textdomain is not available yet and the text will not be translated.
Resolves the "textdomain 'yoast-components' not found"

## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Load a post-edit page and see no error about the textdomain appear.
* The text should be translated in the metabox readability analysis section

Fixes #
