### PR TITLE
Rename keyword to keyphrase in the KeywordInput component

### DIFF
--- a/composites/Plugin/Shared/components/KeywordInput.js
+++ b/composites/Plugin/Shared/components/KeywordInput.js
@@ -140,7 +140,7 @@ class KeywordInput extends React.Component {
 		if ( showErrorMessage && this.props.keyword !== "" ) {
 			return (
 				<ErrorText role="alert">
-					{ __( "Are you trying to use multiple keywords? You should add them separately below.", "yoast-components" ) }
+					{ __( "Are you trying to use multiple keyphrases? You should add them separately below.", "yoast-components" ) }
 				</ErrorText>
 			);
 		}
@@ -166,7 +166,7 @@ class KeywordInput extends React.Component {
 		const { id, showLabel, keyword, onRemoveKeyword, onBlurKeyword } = this.props;
 		const showErrorMessage = this.checkKeywordInput( keyword );
 
-		const label = __( "Focus keyword:", "yoast-components" );
+		const label = __( "Focus keyphrase:", "yoast-components" );
 
 		// The aria label should not be shown if there is a visible label.
 		const showAriaLabel = ! showLabel;

--- a/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
@@ -108,7 +108,7 @@ exports[`KeywordInput matches the snapshot by default 1`] = `
     className="c1"
     htmlFor="test-id"
   >
-    Focus keyword:
+    Focus keyphrase:
   </label>
   <div
     className="has-remove-keyword-button c2"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Renamed 'Focus keyword' to 'Focus keyphrase' in the `KeywordInput` component.

## Relevant technical choices:

* After discussing with Joost, I didn't change the following string: "Read our %1$sultimate guide to keyword research%2$s to learn more about keyword research and keyword strategy."

## Test instructions

This PR can be tested by following these steps:

* Link this branch to Free using `yarn link` (the components example is currently broken).
* Check in both the metabox and the sidebar that the keyword input label has changed to 'focus keyphrase'

Fixes #738 
