### PR TITLE
Fix import in the Snippet Preview demo.

### DIFF
--- a/app/SnippetEditorExample.js
+++ b/app/SnippetEditorExample.js
@@ -3,7 +3,8 @@ import React, { Component } from "react";
 import styled from "styled-components";
 import debounce from "lodash/debounce";
 
-import MetaDescriptionLengthAssessment from "yoastseo/src/assessments/seo/metaDescriptionLengthAssessment";
+import { assessments } from "yoastseo";
+const { MetaDescriptionLengthAssessment } = assessments.seo;
 
 // Internal dependencies.
 import SnippetEditor from "../composites/Plugin/SnippetEditor/components/SnippetEditor";

--- a/app/SnippetEditorExample.js
+++ b/app/SnippetEditorExample.js
@@ -3,8 +3,7 @@ import React, { Component } from "react";
 import styled from "styled-components";
 import debounce from "lodash/debounce";
 
-import { assessments } from "yoastseo";
-const { MetaDescriptionLengthAssessment } = assessments;
+import MetaDescriptionLengthAssessment from "yoastseo/src/assessments/seo/metaDescriptionLengthAssessment";
 
 // Internal dependencies.
 import SnippetEditor from "../composites/Plugin/SnippetEditor/components/SnippetEditor";

--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -3,13 +3,14 @@ import React from "react";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 
-import MetaDescriptionLengthAssessment from "yoastseo/src/assessments/seo/metaDescriptionLengthAssessment";
-import PageTitleWidthAssesment from "yoastseo/src/assessments/seo/pageTitleWidthAssessment";
+import { assessments } from "yoastseo";
+const { MetaDescriptionLengthAssessment, PageTitleWidthAssessment } = assessments.seo;
 
 import { helpers } from "yoastseo";
 const { measureTextWidth } = helpers;
 
 import stripSpaces from "yoastseo/src/stringProcessing/stripSpaces";
+
 import noop from "lodash/noop";
 
 // Internal dependencies.
@@ -61,7 +62,7 @@ const CloseEditorButton = SnippetEditorButton.extend`
  */
 function getTitleProgress( title ) {
 	const titleWidth = measureTextWidth( title );
-	const pageTitleWidthAssessment = new PageTitleWidthAssesment();
+	const pageTitleWidthAssessment = new PageTitleWidthAssessment();
 	const score = pageTitleWidthAssessment.calculateScore( titleWidth );
 	const maximumLength = pageTitleWidthAssessment.getMaximumLength();
 


### PR DESCRIPTION
Fixes the snippet preview demo in the standalone app.

To test:
- check the standalone app: `yarn start` and go to `localhost:3333`
- go in the Snippet preview tab
- verify there are no errors and the snippet preview / editor work as expected
- edit the meta description and verify the progress bar works as expected (max length is 156 characters)

Note: since the date in the meta description demo is hardcoded (`Jan 8, 2018 -`) you can actually enter only 143 characters before the progress bar turns into orange.

Fixes #740 