### PR TITLE
Remove getI18n from mock because it will be removed from the i18n api

### DIFF
--- a/jest/__mocks__/@wordpress/i18n.js
+++ b/jest/__mocks__/@wordpress/i18n.js
@@ -1,6 +1,6 @@
 /* eslint-disable require-jsdoc */
 
-import { sprintf, getI18n, setLocaleData } from "@wordpress/i18n";
+import { sprintf, setLocaleData } from "@wordpress/i18n";
 
 function __( string ) {
 	return string;
@@ -30,5 +30,4 @@ export {
 	_nx,
 	setLocaleData,
 	sprintf,
-	getI18n,
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Because the getI18n fucntion will be removed from the `@wordpress/i18n` API, we no longer want to mock it in the tests. 

## Test instructions

This PR can be tested by following these steps:

*`yarn test` should succeed.

Related https://github.com/Yoast/wordpress-seo/issues/10945#issuecomment-424284744
