### PR TITLE
Update SynonymsInput to use a help link.

### DIFF
--- a/composites/Plugin/Shared/components/KeywordInput.js
+++ b/composites/Plugin/Shared/components/KeywordInput.js
@@ -173,14 +173,14 @@ class KeywordInput extends React.Component {
 		const {
 			id,
 			label,
-			labelSiblingElement,
+			helpLink,
 		} = this.props;
 		return (
 			<KeywordFieldLabelContainer>
 				<KeywordFieldLabel htmlFor={ id }>
 					{ label }
 				</KeywordFieldLabel>
-				{ labelSiblingElement }
+				{ helpLink }
 			</KeywordFieldLabelContainer>
 		);
 	}
@@ -238,7 +238,7 @@ KeywordInput.propTypes = {
 	onRemoveKeyword: PropTypes.func,
 	onBlurKeyword: PropTypes.func,
 	label: PropTypes.string.isRequired,
-	labelSiblingElement: PropTypes.node,
+	helpLink: PropTypes.node,
 };
 
 KeywordInput.defaultProps = {
@@ -247,7 +247,7 @@ KeywordInput.defaultProps = {
 	keyword: "",
 	onRemoveKeyword: noop,
 	onBlurKeyword: noop,
-	labelSiblingElement: null,
+	helpLink: null,
 };
 
 export default KeywordInput;

--- a/composites/Plugin/Shared/components/SynonymsInput.js
+++ b/composites/Plugin/Shared/components/SynonymsInput.js
@@ -1,21 +1,30 @@
 import React from "react";
 import PropTypes from "prop-types";
 import uniqueId from "lodash/uniqueId";
+import styled from "styled-components";
 
 import { YoastInputContainer, YoastInputField, YoastInputLabel } from "./YoastInput";
-import HelpText from "../../Shared/components/HelpText";
+import { getRtlStyle } from "../../../../utils/helpers/styled-components";
 
-const SynonymsInput = ( { id, label, value, onChange, explanationText } ) => {
+const SynonymsFieldLabelContainer = styled.span`
+	margin-bottom: 0.5em;
+`;
+
+const StyledYoastInputLabel = styled( YoastInputLabel )`
+	display: inline-block;
+	margin-bottom: 0;
+	${ getRtlStyle( "margin-right: 4px", "margin-left: 4px" ) };
+`;
+
+const SynonymsInput = ( { id, label, labelSiblingElement, value, onChange } ) => {
 	return (
 		<YoastInputContainer>
-			<YoastInputLabel htmlFor={ id }>
-				{ label }
-			</YoastInputLabel>
-			{ explanationText && (
-				<HelpText>
-					{ explanationText }
-				</HelpText>
-			) }
+			<SynonymsFieldLabelContainer>
+				<StyledYoastInputLabel htmlFor={ id }>
+					{ label }
+				</StyledYoastInputLabel>
+				{ labelSiblingElement }
+			</SynonymsFieldLabelContainer>
 			<YoastInputField
 				type="text"
 				id={ id }
@@ -31,14 +40,14 @@ SynonymsInput.propTypes = {
 	label: PropTypes.string,
 	value: PropTypes.string,
 	onChange: PropTypes.func.isRequired,
-	explanationText: PropTypes.node,
+	labelSiblingElement: PropTypes.node,
 };
 
 SynonymsInput.defaultProps = {
 	id: uniqueId( "synonyms-input-" ),
 	label: "",
 	value: "",
-	explanationText: null,
+	labelSiblingElement: null,
 };
 
 export default SynonymsInput;

--- a/composites/Plugin/Shared/components/SynonymsInput.js
+++ b/composites/Plugin/Shared/components/SynonymsInput.js
@@ -16,14 +16,14 @@ const StyledYoastInputLabel = styled( YoastInputLabel )`
 	${ getRtlStyle( "margin-right: 4px", "margin-left: 4px" ) };
 `;
 
-const SynonymsInput = ( { id, label, labelSiblingElement, value, onChange } ) => {
+const SynonymsInput = ( { id, label, helpLink, value, onChange } ) => {
 	return (
 		<YoastInputContainer>
 			<SynonymsFieldLabelContainer>
 				<StyledYoastInputLabel htmlFor={ id }>
 					{ label }
 				</StyledYoastInputLabel>
-				{ labelSiblingElement }
+				{ helpLink }
 			</SynonymsFieldLabelContainer>
 			<YoastInputField
 				type="text"
@@ -40,14 +40,14 @@ SynonymsInput.propTypes = {
 	label: PropTypes.string,
 	value: PropTypes.string,
 	onChange: PropTypes.func.isRequired,
-	labelSiblingElement: PropTypes.node,
+	helpLink: PropTypes.node,
 };
 
 SynonymsInput.defaultProps = {
 	id: uniqueId( "synonyms-input-" ),
 	label: "",
 	value: "",
-	labelSiblingElement: null,
+	helpLink: null,
 };
 
 export default SynonymsInput;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

Updates the SynonymsInput to not use an help text any longer and use a help link icon instead.

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/2058
