### PR TITLE
Simplify replacement variable editor logic to set id and ref.

### DIFF
--- a/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
+++ b/composites/Plugin/SnippetEditor/components/ReplacementVariableEditorStandalone.js
@@ -346,12 +346,6 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	 * @returns {void}
 	 */
 	setEditorRef( editorRef ) {
-		try {
-			editorRef.editor.editorContainer.firstChild.id = this.props.fieldId;
-		} catch ( error ) {
-			console.trace( error );
-		}
-
 		this.editor = editorRef;
 	}
 
@@ -361,8 +355,7 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	 * @returns {void}
 	 */
 	setEditorFieldId() {
-		const editorContainer = get( this.editor, "editor.editorContainer" );
-		const editorField     = editorContainer.querySelector( "div[contenteditable]" );
+		const editorField = get( this.editor, "editor.editor" );
 
 		editorField.id = this.props.fieldId;
 	}
@@ -521,7 +514,6 @@ class ReplacementVariableEditorStandalone extends React.Component {
 		return (
 			<React.Fragment>
 				<Editor
-					id={ this.props.fieldId }
 					textDirectionality={ theme.isRtl ? "RTL" : "LTR" }
 					editorState={ editorState }
 					onChange={ this.onChange }


### PR DESCRIPTION
Fixes https://github.com/Yoast/wordpress-seo/issues/11482
See https://github.com/Yoast/yoast-components/pull/749

## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

- removes the `id` prop from the draft.js `Editor` as it's not an allowed prop and it doesn't do anything
- removes a try/catch statement from the `setEditorRef()` function: this statement tried to set an `id` to the draft.js editable field using DOM methods:
  - not sure why we should try to set the `id` here, as it's already set by `setEditorFieldId()` when the component mounts. The whole statement seems safe to remove to me, unless I'm missing something.
  - worth noting when a component gets unmounted, React runs something called `safelyDetachRef` which calls the ref callback and the DOM method used there failed, triggering the `console.trace()` message
- simplifies `setEditorFieldId()`: seems to me the draft.js editor ref already has a `editor.editor` property which is the field DOM element so seems to me there's no need to use DOM methods to get the parent and the child again with `editorContainer.querySelector( "div[contenteditable]" )`

## Test instructions

- in the standalone app > Snippet preview tab
- click "Edit snippet" to open and close the editor
- verify there are no JS errors or console output (note: I get an unrelated `Error: Domain `yoast-components` was not found.`
- verify the title and description field have correct IDs:
  - `snippet-editor-field-title`
  - `snippet-editor-field-description`
- in the snippet preview, click on the title and the description, test it when the editor is closed and also when it's already open and verify the related field get focused
