### PR TITLE
Fix Edit Snippet button margin in RTL.

### DIFF
--- a/composites/Plugin/SnippetEditor/components/SnippetEditor.js
+++ b/composites/Plugin/SnippetEditor/components/SnippetEditor.js
@@ -40,7 +40,7 @@ const SnippetEditorButton = Button.extend`
 `;
 
 const EditSnippetButton = SnippetEditorButton.extend`
-	margin: 10px 0 0 4px;
+	margin: ${ getRtlStyle( "10px 0 0 4px", "10px 4px 0 0" ) };
 	fill: ${ colors.$color_grey_dark };
 	padding-left: 8px;
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the Edit Snippet button margin with Right To Left languages.

## Relevant technical choices:
A very small patch that uses `getRtlStyle()` to properly set the margin.

## Test instructions
- go in the standalone app (`yarn start` and go to http://localhost:3333/ )
- in the "Snippet preview" tab, see the Edit Snippet button has a small margin on the left
- click "Change language direction" at the top of the page
- verify the Edit Snippet button has a right margin

LTR:

<img width="624" alt="screenshot 2018-11-29 at 17 39 36" src="https://user-images.githubusercontent.com/1682452/49238244-4cc5aa00-f400-11e8-95ac-3f6aa7e21afc.png">

RTL:

<img width="605" alt="screenshot 2018-11-29 at 17 39 49" src="https://user-images.githubusercontent.com/1682452/49238246-518a5e00-f400-11e8-8be5-c41772071d54.png">


Fixes https://github.com/Yoast/wordpress-seo/issues/10610
