### PR TITLE
Add onBlurSynonym to SynonymsInput component

### DIFF
--- a/composites/Plugin/Shared/components/KeywordInput.js
+++ b/composites/Plugin/Shared/components/KeywordInput.js
@@ -191,7 +191,7 @@ class KeywordInput extends React.Component {
 	 * @returns {ReactElement} The KeywordField react component including its label and eventual error message.
 	 */
 	render() {
-		const { id, showLabel, keyword, onRemoveKeyword, onBlurKeyword } = this.props;
+		const { id, showLabel, keyword, onRemoveKeyword, onBlurKeyword, onFocusKeyword } = this.props;
 		const showErrorMessage = this.checkKeywordInput( keyword );
 
 		// The aria label should not be shown if there is a visible label.
@@ -211,6 +211,7 @@ class KeywordInput extends React.Component {
 						id={ id }
 						className={ showErrorMessage ? "has-error" : null }
 						onChange={ this.handleChange }
+						onFocus={ onFocusKeyword }
 						onBlur={ onBlurKeyword }
 						value={ keyword }
 					/>
@@ -237,6 +238,7 @@ KeywordInput.propTypes = {
 	onChange: PropTypes.func.isRequired,
 	onRemoveKeyword: PropTypes.func,
 	onBlurKeyword: PropTypes.func,
+	onFocusKeyword: PropTypes.func,
 	label: PropTypes.string.isRequired,
 	helpLink: PropTypes.node,
 };
@@ -247,6 +249,7 @@ KeywordInput.defaultProps = {
 	keyword: "",
 	onRemoveKeyword: noop,
 	onBlurKeyword: noop,
+	onFocusKeyword: noop,
 	helpLink: null,
 };
 

--- a/composites/Plugin/Shared/components/SynonymsInput.js
+++ b/composites/Plugin/Shared/components/SynonymsInput.js
@@ -17,7 +17,7 @@ const StyledYoastInputLabel = styled( YoastInputLabel )`
 	${ getRtlStyle( "margin-right: 4px", "margin-left: 4px" ) };
 `;
 
-const SynonymsInput = ( { id, label, helpLink, value, onChange, onBlurSynonym } ) => {
+const SynonymsInput = ( { id, label, helpLink, value, onChange, onBlurSynonym, onFocusSynonym } ) => {
 	return (
 		<YoastInputContainer>
 			<SynonymsFieldLabelContainer>
@@ -31,6 +31,7 @@ const SynonymsInput = ( { id, label, helpLink, value, onChange, onBlurSynonym } 
 				id={ id }
 				onChange={ onChange }
 				onBlur={ onBlurSynonym }
+				onFocus={ onFocusSynonym }
 				value={ value }
 			/>
 		</YoastInputContainer>
@@ -43,6 +44,7 @@ SynonymsInput.propTypes = {
 	value: PropTypes.string,
 	onChange: PropTypes.func.isRequired,
 	onBlurSynonym: PropTypes.func,
+	onFocusSynonym: PropTypes.func,
 	helpLink: PropTypes.node,
 };
 
@@ -51,6 +53,7 @@ SynonymsInput.defaultProps = {
 	label: "",
 	value: "",
 	onBlurSynonym: noop,
+	onFocusSynonym: noop,
 	helpLink: null,
 };
 

--- a/composites/Plugin/Shared/components/SynonymsInput.js
+++ b/composites/Plugin/Shared/components/SynonymsInput.js
@@ -17,7 +17,7 @@ const StyledYoastInputLabel = styled( YoastInputLabel )`
 	${ getRtlStyle( "margin-right: 4px", "margin-left: 4px" ) };
 `;
 
-const SynonymsInput = ( { id, label, helpLink, value, onChange, onBlurSynonym, onFocusSynonym } ) => {
+const SynonymsInput = ( { id, label, helpLink, value, onChange, onBlur, onFocus } ) => {
 	return (
 		<YoastInputContainer>
 			<SynonymsFieldLabelContainer>
@@ -30,8 +30,8 @@ const SynonymsInput = ( { id, label, helpLink, value, onChange, onBlurSynonym, o
 				type="text"
 				id={ id }
 				onChange={ onChange }
-				onBlur={ onBlurSynonym }
-				onFocus={ onFocusSynonym }
+				onBlur={ onBlur }
+				onFocus={ onFocus }
 				value={ value }
 			/>
 		</YoastInputContainer>
@@ -43,8 +43,8 @@ SynonymsInput.propTypes = {
 	label: PropTypes.string,
 	value: PropTypes.string,
 	onChange: PropTypes.func.isRequired,
-	onBlurSynonym: PropTypes.func,
-	onFocusSynonym: PropTypes.func,
+	onBlur: PropTypes.func,
+	onFocus: PropTypes.func,
 	helpLink: PropTypes.node,
 };
 
@@ -52,8 +52,8 @@ SynonymsInput.defaultProps = {
 	id: uniqueId( "synonyms-input-" ),
 	label: "",
 	value: "",
-	onBlurSynonym: noop,
-	onFocusSynonym: noop,
+	onBlur: noop,
+	onFocus: noop,
 	helpLink: null,
 };
 

--- a/composites/Plugin/Shared/components/SynonymsInput.js
+++ b/composites/Plugin/Shared/components/SynonymsInput.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import uniqueId from "lodash/uniqueId";
 import styled from "styled-components";
-import noop from "lodash/noop";
 
 import { YoastInputContainer, YoastInputField, YoastInputLabel } from "./YoastInput";
 import { getRtlStyle } from "../../../../utils/helpers/styled-components";
@@ -17,43 +16,48 @@ const StyledYoastInputLabel = styled( YoastInputLabel )`
 	${ getRtlStyle( "margin-right: 4px", "margin-left: 4px" ) };
 `;
 
-const SynonymsInput = ( { id, label, helpLink, value, onChange, onBlur, onFocus } ) => {
+/**
+ * Renders the input for synonyms.
+ *
+ * All props that are not specific to this element are passed to the input element.
+ *
+ * @param {object} props The component props.
+ *
+ * @returns {ReactElement} The rendered synonyms input element.
+ */
+const SynonymsInput = ( props ) => {
+	const {
+		label,
+		helpLink,
+		...inputProps
+	} = props;
+
 	return (
 		<YoastInputContainer>
 			<SynonymsFieldLabelContainer>
-				<StyledYoastInputLabel htmlFor={ id }>
+				<StyledYoastInputLabel htmlFor={ inputProps.id }>
 					{ label }
 				</StyledYoastInputLabel>
 				{ helpLink }
 			</SynonymsFieldLabelContainer>
 			<YoastInputField
-				type="text"
-				id={ id }
-				onChange={ onChange }
-				onBlur={ onBlur }
-				onFocus={ onFocus }
-				value={ value }
+				{ ...inputProps }
 			/>
 		</YoastInputContainer>
 	);
 };
 
 SynonymsInput.propTypes = {
+	type: PropTypes.string,
 	id: PropTypes.string,
 	label: PropTypes.string,
-	value: PropTypes.string,
-	onChange: PropTypes.func.isRequired,
-	onBlur: PropTypes.func,
-	onFocus: PropTypes.func,
 	helpLink: PropTypes.node,
 };
 
 SynonymsInput.defaultProps = {
+	type: "text",
 	id: uniqueId( "synonyms-input-" ),
 	label: "",
-	value: "",
-	onBlur: noop,
-	onFocus: noop,
 	helpLink: null,
 };
 

--- a/composites/Plugin/Shared/components/SynonymsInput.js
+++ b/composites/Plugin/Shared/components/SynonymsInput.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import uniqueId from "lodash/uniqueId";
 import styled from "styled-components";
+import noop from "lodash/noop";
 
 import { YoastInputContainer, YoastInputField, YoastInputLabel } from "./YoastInput";
 import { getRtlStyle } from "../../../../utils/helpers/styled-components";
@@ -16,7 +17,7 @@ const StyledYoastInputLabel = styled( YoastInputLabel )`
 	${ getRtlStyle( "margin-right: 4px", "margin-left: 4px" ) };
 `;
 
-const SynonymsInput = ( { id, label, helpLink, value, onChange } ) => {
+const SynonymsInput = ( { id, label, helpLink, value, onChange, onBlurSynonym } ) => {
 	return (
 		<YoastInputContainer>
 			<SynonymsFieldLabelContainer>
@@ -29,6 +30,7 @@ const SynonymsInput = ( { id, label, helpLink, value, onChange } ) => {
 				type="text"
 				id={ id }
 				onChange={ onChange }
+				onBlur={ onBlurSynonym }
 				value={ value }
 			/>
 		</YoastInputContainer>
@@ -40,6 +42,7 @@ SynonymsInput.propTypes = {
 	label: PropTypes.string,
 	value: PropTypes.string,
 	onChange: PropTypes.func.isRequired,
+	onBlurSynonym: PropTypes.func,
 	helpLink: PropTypes.node,
 };
 
@@ -47,6 +50,7 @@ SynonymsInput.defaultProps = {
 	id: uniqueId( "synonyms-input-" ),
 	label: "",
 	value: "",
+	onBlurSynonym: noop,
 	helpLink: null,
 };
 

--- a/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
@@ -134,6 +134,7 @@ exports[`KeywordInput matches the snapshot by default 1`] = `
       id="test-id"
       onBlur={[Function]}
       onChange={[Function]}
+      onFocus={[Function]}
       type="text"
       value=""
     />


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add onBlur and onFocus prop to SynonymsInput component.

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Test in combination with https://github.com/Yoast/wordpress-seo/pull/11728

Fixes Yoast/wordpress-seo/issues/11710
