### PR TITLE
780 build structured url api

### DIFF
--- a/utils/buildStructuredUrl.js
+++ b/utils/buildStructuredUrl.js
@@ -6,8 +6,10 @@ import { isArray } from "lodash";
  *
  * https://www.example.com/%category%/%postname%/
  *
- * The variables should correspond to a key in the urlParts object. The variable is then
- * replaced by the url part's content.
+ * The variables should correspond to a key in the urlParts object. The urlParts
+ * key values can be either a string or an array. In case of an array, the parts
+ * will be joined together using a slash. The variable is then replaced by the
+ * url part's content. Example:
  *
  * urlParts: { category: [ "transportation", "flying" ], postname: "the-cost-of-flying" }
  * urlStructure = "https://www.example.com/%category%/%postname%"/
@@ -20,9 +22,7 @@ import { isArray } from "lodash";
  * @returns {string} The structured URL.
  */
 export default function buildStructuredUrl( urlStructure, urlParts = {} ) {
-	/*
-	 * [ "category", "postname" ]
-	 */
+	// Get the URL parts keys.
 	const partIds = Object.keys( urlParts );
 
 	let url = urlStructure;
@@ -30,10 +30,13 @@ export default function buildStructuredUrl( urlStructure, urlParts = {} ) {
 	partIds.forEach( partId => {
 		const part = urlParts[ partId ];
 
+		// Get the replacement string: if it's an array, join the values with a slash.
 		const replacement = isArray( part ) ? part.join( "/" ) : part;
 
+		// Build a string representing the URL structure variable to be replaced.
 		const variable = `%${ partId }%`;
 
+		// Replace the URL structure variable with the replacement string.
 		url = url.replace( new RegExp( variable, "g" ), replacement );
 	} );
 

--- a/utils/buildStructuredUrl.js
+++ b/utils/buildStructuredUrl.js
@@ -1,0 +1,41 @@
+/* External dependencies */
+import { isArray } from "lodash";
+
+/**
+ * Builds a URL based on a string that has parts marked with % characters, like so:
+ *
+ * https://www.example.com/%category%/%postname%/
+ *
+ * The marked parts should correspond to a key in the urlParts object. The marked part is then
+ * replaced by the url part's content.
+ *
+ * urlParts: { category: [ "transportation", "flying" ], postname: "the-cost-of-flying" }
+ * urlStructure = "https://www.example.com/%category%/%postname%"/
+ *
+ * Outputs: https://www.example.com/transportation/flying/the-cost-of-flying
+ *
+ * @param {string} urlStructure The URL structure.
+ * @param {object} urlParts     The URL parts.
+ *
+ * @returns {string} The structured URL.
+ */
+export default function buildStructuredUrl( urlStructure, urlParts = {} ) {
+	/*
+	 * [ "category", "postname" ]
+	 */
+	const partIds = Object.keys( urlParts );
+
+	let url = urlStructure;
+
+	partIds.forEach( partId => {
+		const part = urlParts[ partId ];
+
+		const replacement = isArray( part ) ? part.join( "/" ) : part;
+
+		const marker = `%${ partId }%`;
+
+		url = url.replace( new RegExp( marker, "g" ), replacement );
+	} );
+
+	return url;
+}

--- a/utils/buildStructuredUrl.js
+++ b/utils/buildStructuredUrl.js
@@ -2,11 +2,11 @@
 import { isArray } from "lodash";
 
 /**
- * Builds a URL based on a string that has parts marked with % characters, like so:
+ * Builds a URL based on a string that has variables surrounded by % characters, like so:
  *
  * https://www.example.com/%category%/%postname%/
  *
- * The marked parts should correspond to a key in the urlParts object. The marked part is then
+ * The variables should correspond to a key in the urlParts object. The variable is then
  * replaced by the url part's content.
  *
  * urlParts: { category: [ "transportation", "flying" ], postname: "the-cost-of-flying" }
@@ -32,9 +32,9 @@ export default function buildStructuredUrl( urlStructure, urlParts = {} ) {
 
 		const replacement = isArray( part ) ? part.join( "/" ) : part;
 
-		const marker = `%${ partId }%`;
+		const variable = `%${ partId }%`;
 
-		url = url.replace( new RegExp( marker, "g" ), replacement );
+		url = url.replace( new RegExp( variable, "g" ), replacement );
 	} );
 
 	return url;

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,7 +1,9 @@
 import { makeOutboundLink } from "./makeOutboundLink";
 import getFeed from "./getFeed";
+import buildStructuredUrl from "./buildStructuredUrl";
 
 export default {
 	getFeed,
 	makeOutboundLink,
+	buildStructuredUrl,
 };

--- a/utils/tests/buildStructuredUrlTest.js
+++ b/utils/tests/buildStructuredUrlTest.js
@@ -1,0 +1,30 @@
+import buildStructuredUrl from "../buildStructuredUrl";
+
+describe( "buildStructuredUrl", () => {
+	it( "correctly replaces multiple URL parts", () => {
+		const expected = "https://www.example.com/transportation/flying/the-cost-of-flying/";
+
+		const actual = buildStructuredUrl(
+			"https://www.example.com/%category%/%postname%/",
+			{
+				category: [ "transportation", "flying" ],
+				postname: "the-cost-of-flying",
+			}
+		);
+
+		expect( actual ).toEqual( expected );
+	} );
+
+	it( "replaces markers that are present in the urlStructure multiple times", () => {
+		const expected = "https://www.example.com/transportation/flying/transportation/flying/";
+
+		const actual = buildStructuredUrl(
+			"https://www.example.com/%category%/%category%/",
+			{
+				category: [ "transportation", "flying" ],
+			}
+		);
+
+		expect( actual ).toEqual( expected );
+	} );
+} );

--- a/utils/tests/buildStructuredUrlTest.js
+++ b/utils/tests/buildStructuredUrlTest.js
@@ -15,7 +15,7 @@ describe( "buildStructuredUrl", () => {
 		expect( actual ).toEqual( expected );
 	} );
 
-	it( "replaces markers that are present in the urlStructure multiple times", () => {
+	it( "replaces variables that are present in the urlStructure multiple times", () => {
 		const expected = "https://www.example.com/transportation/flying/transportation/flying/";
 
 		const actual = buildStructuredUrl(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds `buildStructuredUrl` function.

## Relevant technical choices:

* This is the first step towards fixing Yoast/wordpress-seo#3514. It introduces a function that later on will be used to built the permalink in the snippet editor.

## Test instructions

This PR can be tested by following these steps:

* Link `yoast-components` with this PR to `wordpress-seo` and build the project.
* In your browsers console go to any admin page where `window.yoast.components` is loaded, like the Dashboard.
* In the console, you can test the function, for example like this:
```
window.yoast.components.utils.buildStructuredUrl( "http://www.example.com/%category%/%postname%", {
    category: [ "transportation", "flying" ],
    postname: "the-cost-of-flying",
} );
```

Fixes #780 

[Edit by Andrea]
Changed `"http://www.example.com/%category%/%postname%, {` to `"http://www.example.com/%category%/%postname%", {`