### PR TITLE
Add autocomplete directive to keyphrase fields

### DIFF
--- a/app/ComponentsExample.js
+++ b/app/ComponentsExample.js
@@ -23,6 +23,7 @@ export default class ComponentsExample extends React.Component {
 	 * @returns {ReactElement} The rendered list of the Component examples.
 	 */
 	render() {
+		/* eslint-disable react/jsx-no-target-blank */
 		return (
 			<Container>
 				<h2>Yoast warning</h2>
@@ -40,5 +41,6 @@ export default class ComponentsExample extends React.Component {
 				/>
 			</Container>
 		);
+		/* eslint-enable react/jsx-no-target-blank */
 	}
 }

--- a/composites/Plugin/Shared/components/KeywordInput.js
+++ b/composites/Plugin/Shared/components/KeywordInput.js
@@ -214,6 +214,7 @@ class KeywordInput extends React.Component {
 						onFocus={ onFocusKeyword }
 						onBlur={ onBlurKeyword }
 						value={ keyword }
+						autoComplete="off"
 					/>
 					{ showRemoveKeywordButton && (
 						<BorderlessButton onClick={ onRemoveKeyword }>

--- a/composites/Plugin/Shared/components/SynonymsInput.js
+++ b/composites/Plugin/Shared/components/SynonymsInput.js
@@ -42,6 +42,7 @@ const SynonymsInput = ( props ) => {
 			</SynonymsFieldLabelContainer>
 			<YoastInputField
 				{ ...inputProps }
+				autoComplete="off"
 			/>
 		</YoastInputContainer>
 	);

--- a/composites/Plugin/Shared/tests/YoastWarningTest.js
+++ b/composites/Plugin/Shared/tests/YoastWarningTest.js
@@ -4,6 +4,7 @@ import YoastWarning from "../components/YoastWarning";
 import { ThemeProvider } from "styled-components";
 
 test( "YoastWarning matches the snapshot", () => {
+	/* eslint-disable react/jsx-no-target-blank */
 	const component = renderer.create(
 		<YoastWarning
 			message={ [
@@ -13,6 +14,7 @@ test( "YoastWarning matches the snapshot", () => {
 			] }
 		/>
 	);
+	/* eslint-enable react/jsx-no-target-blank */
 
 	const tree = component.toJSON();
 	expect( tree ).toMatchSnapshot();
@@ -29,6 +31,7 @@ test( "YoastWarning does not render without a message", () => {
 } );
 
 test( "YoastWarning with a right to left language matches the snapshot", () => {
+	/* eslint-disable react/jsx-no-target-blank */
 	const component = renderer.create(
 		<ThemeProvider theme={ { isRtl: true } }>
 			<YoastWarning
@@ -40,6 +43,7 @@ test( "YoastWarning with a right to left language matches the snapshot", () => {
 			/>
 		</ThemeProvider>
 	);
+	/* eslint-enable react/jsx-no-target-blank */
 
 	const tree = component.toJSON();
 	expect( tree ).toMatchSnapshot();

--- a/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
@@ -130,6 +130,7 @@ exports[`KeywordInput matches the snapshot by default 1`] = `
   >
     <input
       aria-label={null}
+      autoComplete="off"
       className="c4 c5 c6"
       id="test-id"
       onBlur={[Function]}

--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -1,6 +1,6 @@
 module.exports = {
 	target: [ "<%= files.components %>" ],
 	options: {
-		maxWarnings: 384,
+		maxWarnings: 383,
 	},
 };


### PR DESCRIPTION
Keyphrase and Synonyms input fields

## Summary

This PR can be summarized in the following changelog entry:

* Removes autocomplete functionality from the Keyphrase and Synonyms input fields.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Inspect the Keyphrase and Synonyms input fields and see the `autocomplete="off"` being added as HTML attributes
* See issue for other test step

Fixes #792 
