### PR TITLE
Related keyphrase marking

### DIFF
--- a/composites/Plugin/ContentAnalysis/components/AnalysisList.js
+++ b/composites/Plugin/ContentAnalysis/components/AnalysisList.js
@@ -45,7 +45,7 @@ export function renderRatingToColor( rating ) {
  *
  * @param {AssessmentResult[]} results                    The results from YoastSEO.js
  * @param {string}             marksButtonActivatedResult The currently activated result.
- * @param {string}             marksButtonStatus          The overal status of the mark buttons.
+ * @param {string}             marksButtonStatus          The overall status of the mark buttons.
  * @param {string}             marksButtonClassName       A class name to set on the mark buttons.
  * @param {Function}           onMarksButtonClick         Function that is called when the user
  *                                                        clicks one of the mark buttons.
@@ -56,7 +56,7 @@ export default function AnalysisList( { results, marksButtonActivatedResult, mar
 	return <AnalysisListBase role="list">
 		{ results.map( ( result ) => {
 			const color = renderRatingToColor( result.rating );
-			const isMarkButtonPressed = result.id === marksButtonActivatedResult;
+			const isMarkButtonPressed = result.markerId === marksButtonActivatedResult;
 
 			let ariaLabel = "";
 			if ( marksButtonStatus === "disabled" ) {


### PR DESCRIPTION
Related keyphrases and the focus keyphrase can apply the same assessments. The active marker needs differentiating between the analysis results. Therefore, this PR changes the pressed check to a freshly introduced `markerId`.

## Summary

This PR can be summarized in the following changelog entry:

* Change AnalysisList pressed status check to listen to `result.markerId` instead of `result.id`.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* See related PR: https://github.com/Yoast/wordpress-seo-premium/pull/2181

Fixes https://github.com/Yoast/YoastSEO.js/issues/2011
