### PR TITLE
Bump YoastSEO.js to 1.44.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "redux": "^3.7.2",
     "styled-components": "^2.1.2",
     "whatwg-fetch": "^1.0.0",
-    "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.3"
+    "yoastseo": "^1.44.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10345,9 +10345,10 @@ yeoman-generator@^2.0.4:
     through2 "^2.0.0"
     yeoman-environment "^2.0.5"
 
-"yoastseo@git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.3":
-  version "1.43.0"
-  resolved "git+https://github.com/Yoast/YoastSEO.js.git#04657b482fa45a19ea290baf224aeb809ae6a8a4"
+yoastseo@^1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.44.0.tgz#4d1b66a96c4d3812b6a2ae403fed7e8cc31fc2ef"
+  integrity sha512-37woRKLULGW0LYtJvXounj1dNTUmURmWYZU2e5OhaQxzk9bZFPwSYwsLIdWm2dE0Svs/2ycTcqnq+jkKnmpKVw==
   dependencies:
     "@wordpress/autop" "^2.0.2"
     htmlparser2 "^3.9.2"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Updates YoastSEO.js to 1.44.0.

## Test instructions

This PR can be tested by following these steps:

* Check whether nothing breaks; see also https://github.com/Yoast/Wiki/wiki/Testing-YoastSEO.js-version-bumps-on-Yoast-Components
