### PR TITLE
Add Underline and outboundlink to header. 

### DIFF
--- a/app/ComponentsExample.js
+++ b/app/ComponentsExample.js
@@ -1,14 +1,32 @@
 import React from "react";
 import styled from "styled-components";
+import { __ } from "@wordpress/i18n";
 
 import YoastWarning from "../composites/Plugin/Shared/components/YoastWarning";
-
+import { FullHeightCard } from "../composites/CoursesOverview/Card";
+import CardDetails from "../composites/CoursesOverview/CardDetails";
+import getCourseFeed from "../utils/getCourseFeed";
 
 const Container = styled.div`
 	max-width: 1024px;
 	margin: 0 auto;
 	padding: 24px 24px 50em;
 	box-sizing: border-box;
+`;
+
+const CoursesList = styled.ul`
+	display: grid;
+	grid-template-columns: repeat(auto-fill, 288px);
+	grid-column-gap: 16px;
+	grid-row-gap: 16px;
+	align-items: flex-start;
+	padding: 0;
+`;
+
+const CourseListItem = styled.li`
+	list-style-type: none;
+	height: 100%;
+	width: 100%;
 `;
 
 /**
@@ -18,11 +36,76 @@ const Container = styled.div`
  */
 export default class ComponentsExample extends React.Component {
 	/**
+	 * Creates the components and initializes its state.
+	 */
+	constructor() {
+		super();
+
+		this.state = {
+			courses: null,
+		};
+
+		this.getFeed( "free" );
+	}
+
+	/**
+	 * Fetches data from the yoast.com feed, parses it and sets it to the state.
+	 *
+	 * @param {String} version Active Yoast SEO version.
+	 *
+	 * @returns {void}
+	 */
+	getFeed( version ) {
+		// Developer note: this link should -not- be converted to a shortlink.
+		getCourseFeed( "https://yoast.com/?feed=courses&license=" + version )
+			.then( ( feed ) => {
+				feed.items = feed.items.map( ( item ) => {
+					return item;
+				} );
+				this.setState( { courses: feed.items } );
+			} )
+			/* eslint-disable-next-line no-console */
+			.catch( error => console.log( error ) );
+	}
+
+	/**
+	 * Converts the relevant data in a course to a header object.
+	 *
+	 * @param {Object} course The course to create a header for.
+	 *
+	 * @returns {Object} The header object.
+	 */
+	getHeaderData( course ) {
+		return {
+			image: course.image,
+			title: course.title,
+			link: course.link,
+		};
+	}
+
+	/**
+	 * Converts the relevant data from a course for the ctaButton to an object.
+	 *
+	 * @param {string} course The course to create a ctaButton for.
+	 *
+	 * @returns {Object} The data object for the ctaButton.
+	 */
+	getButtonData( course ) {
+		return {
+			ctaButtonCopy: course.ctaButtonCopy,
+			ctaButtonType: course.ctaButtonType,
+			ctaButtonUrl: course.ctaButtonUrl,
+		};
+	}
+
+	/**
 	 * Renders all the Component examples.
 	 *
 	 * @returns {ReactElement} The rendered list of the Component examples.
 	 */
 	render() {
+		const courses = this.state.courses;
+
 		/* eslint-disable react/jsx-no-target-blank */
 		return (
 			<Container>
@@ -39,6 +122,27 @@ export default class ComponentsExample extends React.Component {
 						<p key="2">This spans to multiple lines.</p>,
 					] }
 				/>
+
+				<h2>Courses overview cards</h2>
+				{ courses && <CoursesList>
+					{ courses.map( course =>
+						<CourseListItem key={ course.id }>
+							<FullHeightCard
+								className={ "CourseCard" }
+								id={ course.id }
+								header={ this.getHeaderData( course ) }
+								banner={ course.isFree === "true" ? { text: __( "Free", "yoast-components" ) } : null }
+							>
+								<CardDetails
+									description={ course.content }
+									courseUrl={ course.link }
+									readMoreLinkText={ course.readMoreLinkText }
+									ctaButtonData={ this.getButtonData( course ) }
+								/>
+							</FullHeightCard>
+						</CourseListItem>
+					) }
+				</CoursesList> }
 			</Container>
 		);
 		/* eslint-enable react/jsx-no-target-blank */

--- a/app/ComponentsExample.js
+++ b/app/ComponentsExample.js
@@ -10,8 +10,20 @@ import getCourseFeed from "../utils/getCourseFeed";
 const Container = styled.div`
 	max-width: 1024px;
 	margin: 0 auto;
-	padding: 24px 24px 50em;
+	padding: 24px;
 	box-sizing: border-box;
+`;
+
+// Use this only for testing purposes in the standalone examples.
+const WordPressStylesEmulator = styled.div`
+	/* Emulate WordPress font metrics. */
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 13px;
+	line-height: 1.4em;
+	/* Emulate WordPress list styles. */
+	li {
+		margin-bottom: 6px;
+	}
 `;
 
 const CoursesList = styled.ul`
@@ -124,25 +136,27 @@ export default class ComponentsExample extends React.Component {
 				/>
 
 				<h2>Courses overview cards</h2>
-				{ courses && <CoursesList>
-					{ courses.map( course =>
-						<CourseListItem key={ course.id }>
-							<FullHeightCard
-								className={ "CourseCard" }
-								id={ course.id }
-								header={ this.getHeaderData( course ) }
-								banner={ course.isFree === "true" ? { text: __( "Free", "yoast-components" ) } : null }
-							>
-								<CardDetails
-									description={ course.content }
-									courseUrl={ course.link }
-									readMoreLinkText={ course.readMoreLinkText }
-									ctaButtonData={ this.getButtonData( course ) }
-								/>
-							</FullHeightCard>
-						</CourseListItem>
-					) }
-				</CoursesList> }
+				<WordPressStylesEmulator>
+					{ courses && <CoursesList>
+						{ courses.map( course =>
+							<CourseListItem key={ course.id }>
+								<FullHeightCard
+									className={ "CourseCard" }
+									id={ course.id }
+									header={ this.getHeaderData( course ) }
+									banner={ course.isFree === "true" ? { text: __( "Free", "yoast-components" ) } : null }
+								>
+									<CardDetails
+										description={ course.content }
+										courseUrl={ course.link }
+										readMoreLinkText={ course.readMoreLinkText }
+										ctaButtonData={ this.getButtonData( course ) }
+									/>
+								</FullHeightCard>
+							</CourseListItem>
+						) }
+					</CoursesList> }
+				</WordPressStylesEmulator>
 			</Container>
 		);
 		/* eslint-enable react/jsx-no-target-blank */

--- a/composites/CoursesOverview/Card.js
+++ b/composites/CoursesOverview/Card.js
@@ -37,6 +37,7 @@ const HeaderLink = styled.a`
 		color: ${ colors.$color_pink_dark };
 	}
 
+	&:focus,
 	&:active {
 		box-shadow: none;
 	}

--- a/composites/CoursesOverview/Card.js
+++ b/composites/CoursesOverview/Card.js
@@ -61,7 +61,7 @@ class Card extends React.Component {
 
 		if ( this.props.header.link ) {
 			return (
-				<OutboundHeaderLink href={ this.props.header.link }>
+				<OutboundHeaderLink href={ this.props.header.link } rel={ null }>
 					<HeaderImage src={ this.props.header.image } alt="" />
 					<HeaderTitle>{ this.props.header.title }</HeaderTitle>
 				</OutboundHeaderLink>

--- a/composites/CoursesOverview/Card.js
+++ b/composites/CoursesOverview/Card.js
@@ -38,9 +38,9 @@ const HeaderTitle = styled.h2`
 
 const HeaderLink = styled.a`
 	text-decoration: none;
-	
+
 	&:hover {
-		text-decoration: underline; 
+		text-decoration: underline;
 		color: ${ colors.$color_pink_dark };
 
 	}
@@ -65,16 +65,16 @@ class Card extends React.Component {
 		if ( this.props.header.link ) {
 			return (
 				<OutboundHeaderLink href={ this.props.header.link }>
-					<HeaderImage src={ this.props.header.image } alt={ this.props.header.title || "" } />
-					<HeaderTitle> { this.props.header.title } </HeaderTitle>
+					<HeaderImage src={ this.props.header.image } alt="" />
+					<HeaderTitle>{ this.props.header.title }</HeaderTitle>
 				</OutboundHeaderLink>
 			);
 		}
 
 		return (
 			<Fragment>
-				<HeaderImage src={ this.props.header.image } alt={ this.props.header.title || "" } />;
-				<HeaderTitle> { this.props.header.title } </HeaderTitle>
+				<HeaderImage src={ this.props.header.image } alt="" />;
+				<HeaderTitle>{ this.props.header.title }</HeaderTitle>
 			</Fragment>
 		);
 	}
@@ -143,4 +143,3 @@ Card.defaultProps = {
 	banner: null,
 	children: null,
 };
-

--- a/composites/CoursesOverview/Card.js
+++ b/composites/CoursesOverview/Card.js
@@ -20,7 +20,6 @@ const HeaderImage = styled.img`
 `;
 
 const Content = styled.div`
-	margin: 0;
 	padding: 12px 16px;
 	display: flex;
 	flex-direction: column;
@@ -28,8 +27,7 @@ const Content = styled.div`
 `;
 
 const HeaderTitle = styled.h2`
-	margin: 16px 8px 0px 16px;
-	display: block;
+	margin: 16px 16px 0 16px;
 	font-weight: 400;
 	font-size: 1.5em;
 	line-height: 1.2;
@@ -38,11 +36,10 @@ const HeaderTitle = styled.h2`
 
 const HeaderLink = styled.a`
 	text-decoration: none;
+	color: ${ colors.$color_pink_dark };
 
 	&:hover {
 		text-decoration: underline;
-		color: ${ colors.$color_pink_dark };
-
 	}
 `;
 

--- a/composites/CoursesOverview/Card.js
+++ b/composites/CoursesOverview/Card.js
@@ -36,10 +36,10 @@ const HeaderTitle = styled.h2`
 
 const HeaderLink = styled.a`
 	text-decoration: none;
-	color: ${ colors.$color_pink_dark };
 
 	&:hover {
 		text-decoration: underline;
+		color: ${ colors.$color_pink_dark };
 	}
 `;
 

--- a/composites/CoursesOverview/Card.js
+++ b/composites/CoursesOverview/Card.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import colors from "../../style-guide/colors.json";
 import Banner from "./CardBanner";
+import { makeOutboundLink } from "../../utils/makeOutboundLink";
 
 const Container = styled.div`
 	position: relative;
@@ -37,7 +38,15 @@ const HeaderTitle = styled.h2`
 
 const HeaderLink = styled.a`
 	text-decoration: none;
+	
+	&:hover {
+		text-decoration: underline; 
+		color: ${ colors.$color_pink_dark };
+
+	}
 `;
+
+const OutboundHeaderLink = makeOutboundLink( HeaderLink );
 
 /**
  * Card component.
@@ -55,10 +64,10 @@ class Card extends React.Component {
 
 		if ( this.props.header.link ) {
 			return (
-				<HeaderLink href={ this.props.header.link }>
+				<OutboundHeaderLink href={ this.props.header.link }>
 					<HeaderImage src={ this.props.header.image } alt={ this.props.header.title || "" } />
 					<HeaderTitle> { this.props.header.title } </HeaderTitle>
-				</HeaderLink>
+				</OutboundHeaderLink>
 			);
 		}
 

--- a/composites/CoursesOverview/Card.js
+++ b/composites/CoursesOverview/Card.js
@@ -26,21 +26,28 @@ const Content = styled.div`
 	flex-grow: 1;
 `;
 
+const HeaderLink = styled.a`
+	text-decoration: none;
+	color: ${ colors.$color_pink_dark };
+
+	&:hover,
+	&:focus,
+	&:active {
+		text-decoration: underline;
+		color: ${ colors.$color_pink_dark };
+	}
+
+	&:active {
+		box-shadow: none;
+	}
+`;
+
 const HeaderTitle = styled.h2`
 	margin: 16px 16px 0 16px;
 	font-weight: 400;
 	font-size: 1.5em;
 	line-height: 1.2;
-	color: ${ colors.$color_pink_dark };
-`;
-
-const HeaderLink = styled.a`
-	text-decoration: none;
-
-	&:hover {
-		text-decoration: underline;
-		color: ${ colors.$color_pink_dark };
-	}
+	color: currentColor;
 `;
 
 const OutboundHeaderLink = makeOutboundLink( HeaderLink );

--- a/composites/CoursesOverview/CardDetails.js
+++ b/composites/CoursesOverview/CardDetails.js
@@ -122,7 +122,7 @@ class CardDetails extends React.Component {
 	 * @returns {ReactElement} The rendered component.
 	 */
 	render() {
-		const buttonType =  this.props.ctaButtonData.ctaButtonType === "regular" ? CardRegularButton : CardUpsellButton;
+		const buttonType = this.props.ctaButtonData.ctaButtonType === "regular" ? CardRegularButton : CardUpsellButton;
 		const OutboundLinkButton = makeOutboundLink( buttonType );
 
 		return (
@@ -133,10 +133,10 @@ class CardDetails extends React.Component {
 					/>
 				</Details>
 				<ActionBlock>
-					<OutboundLinkButton href={ this.props.ctaButtonData.ctaButtonUrl }>
+					<OutboundLinkButton href={ this.props.ctaButtonData.ctaButtonUrl } rel={ null }>
 						{ this.props.ctaButtonData.ctaButtonCopy }
 					</OutboundLinkButton>
-					<OutboundInfoLink href={ this.props.courseUrl }>
+					<OutboundInfoLink href={ this.props.courseUrl } rel={ null }>
 						{ this.props.readMoreLinkText }
 					</OutboundInfoLink>
 				</ActionBlock>

--- a/composites/CoursesOverview/CardDetails.js
+++ b/composites/CoursesOverview/CardDetails.js
@@ -3,9 +3,9 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import colors from "../../style-guide/colors.json";
 import { makeOutboundLink } from "../../utils/makeOutboundLink";
+import { getRtlStyle } from "../../utils/helpers/styled-components";
 
 const CardRegularButton = styled.a`
-	cursor: pointer;
 	color: ${ colors.$color_black };
 	white-space: nowrap;
 	display: block;
@@ -17,7 +17,6 @@ const CardRegularButton = styled.a`
 	text-decoration: none;
 	font-weight: bold;
 	font-size: inherit;
-	margin-top: 0;
 	margin-bottom: 8px;
 
 	&:hover,
@@ -25,13 +24,11 @@ const CardRegularButton = styled.a`
 	&:active {
 		color: ${ colors.$color_black };
 		background-color: ${ colors.$color_grey_hover };
-		text-decoration: none;
 	}
 
-	:active {
-		position: relative;
-		top: 2px
+	&:active {
 		background-color: ${ colors.$color_grey_hover };
+		transform: translateY( 1px );
 		box-shadow: none;
 		filter: none;
 	}
@@ -60,10 +57,9 @@ const CardUpsellButton = styled.a`
 		background: ${ colors.$color_button_upsell_hover };
 	}
 
-	:active {
-		position: relative;
-		top: 2px;
+	&:active {
 		background-color: ${ colors.$color_button_hover_upsell };
+		transform: translateY( 1px );
 		box-shadow: none;
 		filter: none;
 	}
@@ -80,9 +76,15 @@ const ActionBlock = styled.div`
 `;
 
 const CourseFeatureList = styled.div`
+	ul {
+		list-style-type: none;
+		margin: 0;
+		padding: 0;
+	}
+
 	li {
 		position: relative;
-		margin-left: 16px;
+		${ getRtlStyle( "margin-left", "margin-right" ) }: 16px;
 
 		&:before {
 			content: "✓";
@@ -90,7 +92,7 @@ const CourseFeatureList = styled.div`
 			position: absolute;
 			font-weight: bold;
 			display: inline-block;
-			left: -16px;
+			${ getRtlStyle( "left", "right" ) }: -16px;
 		}
 	}
 `;

--- a/composites/CoursesOverview/tests/__snapshots__/CardDetailsTest.js.snap
+++ b/composites/CoursesOverview/tests/__snapshots__/CardDetailsTest.js.snap
@@ -2,7 +2,13 @@
 
 exports[`The CardDetails component matches the snapshot when given specific props 1`] = `
 Array [
-  .c1 li {
+  .c1 ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c1 li {
   position: relative;
   margin-left: 16px;
 }
@@ -57,7 +63,6 @@ you’ll learn how to research and select the keywords that will guide searchers
 }
 
 .c1 {
-  cursor: pointer;
   color: #000;
   white-space: nowrap;
   display: block;
@@ -70,7 +75,6 @@ you’ll learn how to research and select the keywords that will guide searchers
   text-decoration: none;
   font-weight: bold;
   font-size: inherit;
-  margin-top: 0;
   margin-bottom: 8px;
 }
 
@@ -79,13 +83,13 @@ you’ll learn how to research and select the keywords that will guide searchers
 .c1:active {
   color: #000;
   background-color: #cecece;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c1:active {
-  position: relative;
-  top: 2px background-color:#cecece;
+  background-color: #cecece;
+  -webkit-transform: translateY( 1px );
+  -ms-transform: translateY( 1px );
+  transform: translateY( 1px );
   box-shadow: none;
   -webkit-filter: none;
   filter: none;
@@ -134,7 +138,13 @@ you’ll learn how to research and select the keywords that will guide searchers
 
 exports[`The empty CardDetails component matches the snapshot 1`] = `
 Array [
-  .c1 li {
+  .c1 ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c1 li {
   position: relative;
   margin-left: 16px;
 }
@@ -213,8 +223,9 @@ Array [
 }
 
 .c1:active {
-  position: relative;
-  top: 2px;
+  -webkit-transform: translateY( 1px );
+  -ms-transform: translateY( 1px );
+  transform: translateY( 1px );
   box-shadow: none;
   -webkit-filter: none;
   filter: none;

--- a/composites/CoursesOverview/tests/__snapshots__/CardDetailsTest.js.snap
+++ b/composites/CoursesOverview/tests/__snapshots__/CardDetailsTest.js.snap
@@ -109,7 +109,7 @@ you’ll learn how to research and select the keywords that will guide searchers
     <a
       className="c1"
       href="https://yoast.com/cart/?add-to-cart=1311259"
-      rel="noopener noreferrer"
+      rel={null}
       target="_blank"
     >
       Start your free trail
@@ -122,7 +122,7 @@ you’ll learn how to research and select the keywords that will guide searchers
     <a
       className="c3"
       href="https://yoast.com/academy/keyword-research-training/"
-      rel="noopener noreferrer"
+      rel={null}
       target="_blank"
     >
       Read more about this training »
@@ -245,7 +245,7 @@ Array [
     <a
       className="c1"
       href={undefined}
-      rel="noopener noreferrer"
+      rel={null}
       target="_blank"
     >
       <span
@@ -257,7 +257,7 @@ Array [
     <a
       className="c3"
       href=""
-      rel="noopener noreferrer"
+      rel={null}
       target="_blank"
     >
       

--- a/composites/CoursesOverview/tests/__snapshots__/CardTest.js.snap
+++ b/composites/CoursesOverview/tests/__snapshots__/CardTest.js.snap
@@ -128,12 +128,12 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
 .c2 {
   -webkit-text-decoration: none;
   text-decoration: none;
-  color: #a4286a;
 }
 
 .c2:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  color: #a4286a;
 }
 
 .c0 {

--- a/composites/CoursesOverview/tests/__snapshots__/CardTest.js.snap
+++ b/composites/CoursesOverview/tests/__snapshots__/CardTest.js.snap
@@ -217,7 +217,7 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
   <a
     className="c2"
     href="https://yoast.com/academy/keyword-research-training/"
-    rel="noopener noreferrer"
+    rel={null}
     target="_blank"
   >
     <img
@@ -266,7 +266,7 @@ you’ll learn how to research and select the keywords that will guide searchers
       <a
         className="c12"
         href="https://yoast.com/cart/?add-to-cart=1311259"
-        rel="noopener noreferrer"
+        rel={null}
         target="_blank"
       >
         Start your free trail
@@ -279,7 +279,7 @@ you’ll learn how to research and select the keywords that will guide searchers
       <a
         className="c13"
         href="https://yoast.com/academy/keyword-research-training/"
-        rel="noopener noreferrer"
+        rel={null}
         target="_blank"
       >
         Read more about this training »

--- a/composites/CoursesOverview/tests/__snapshots__/CardTest.js.snap
+++ b/composites/CoursesOverview/tests/__snapshots__/CardTest.js.snap
@@ -131,6 +131,7 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
   color: #a4286a;
 }
 
+.c2:focus,
 .c2:active {
   box-shadow: none;
 }

--- a/composites/CoursesOverview/tests/__snapshots__/CardTest.js.snap
+++ b/composites/CoursesOverview/tests/__snapshots__/CardTest.js.snap
@@ -46,7 +46,7 @@ exports[`The FullHeightCard is rendered including some props 1`] = `
 `;
 
 exports[`The FullHeightCard is rendered including the CardBanner and CardDetails components 1`] = `
-.c5 {
+.c6 {
   position: absolute;
   top: 8px;
   left: -8px;
@@ -58,12 +58,30 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.2);
 }
 
-.c6 {
+.c7 {
   position: absolute;
   top: 40px;
   left: -8px;
   border-top: 8px solid #6c2548;
   border-left: 8px solid transparent;
+}
+
+.c5 {
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute !important;
+  width: 1px;
+  word-wrap: normal !important;
+  -webkit-transform: translateY(1em);
+  -ms-transform: translateY(1em);
+  transform: translateY(1em);
 }
 
 .c1 {
@@ -85,7 +103,7 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
   vertical-align: bottom;
 }
 
-.c7 {
+.c8 {
   margin: 0;
   padding: 12px 16px;
   display: -webkit-box;
@@ -115,29 +133,17 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
   text-decoration: none;
 }
 
+.c2:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #a4286a;
+}
+
 .c0 {
   height: 100%;
 }
 
 .c12 {
-  border: 0;
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute !important;
-  width: 1px;
-  word-wrap: normal !important;
-  -webkit-transform: translateY(1em);
-  -ms-transform: translateY(1em);
-  transform: translateY(1em);
-}
-
-.c11 {
   cursor: pointer;
   color: #000;
   white-space: nowrap;
@@ -155,16 +161,16 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
   margin-bottom: 8px;
 }
 
-.c11:hover,
-.c11:focus,
-.c11:active {
+.c12:hover,
+.c12:focus,
+.c12:active {
   color: #000;
   background-color: #cecece;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c11:active {
+.c12:active {
   position: relative;
   top: 2px background-color:#cecece;
   box-shadow: none;
@@ -176,16 +182,16 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
   font-weight: bold;
 }
 
-.c10 {
+.c11 {
   text-align: center;
 }
 
-.c9 li {
+.c10 li {
   position: relative;
   margin-left: 16px;
 }
 
-.c9 li:before {
+.c10 li:before {
   content: "✓";
   color: #77b227;
   position: absolute;
@@ -194,7 +200,7 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
   left: -16px;
 }
 
-.c8 {
+.c9 {
   margin-bottom: 12px;
   border-bottom: 1px #ddd solid;
   -webkit-box-flex: 1;
@@ -210,6 +216,8 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
   <a
     className="c2"
     href="https://yoast.com/academy/keyword-research-training/"
+    rel="noopener noreferrer"
+    target="_blank"
   >
     <img
       alt="Keyword Research"
@@ -223,23 +231,28 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
       Keyword Research
        
     </h2>
+    <span
+      className="c5"
+    >
+      (Opens in a new browser tab)
+    </span>
   </a>
   <span
-    className="c5"
+    className="c6"
   >
     Free
   </span>
   <span
-    className="c6"
+    className="c7"
   />
   <div
-    className="c7"
+    className="c8"
   >
     <div
-      className="c8"
+      className="c9"
     >
       <div
-        className="c9"
+        className="c10"
         dangerouslySetInnerHTML={
           Object {
             "__html": "Do you know the essential first step of good SEO? It’s keyword research. In this training, 
@@ -249,17 +262,17 @@ you’ll learn how to research and select the keywords that will guide searchers
       />
     </div>
     <div
-      className="c10"
+      className="c11"
     >
       <a
-        className="c11"
+        className="c12"
         href="https://yoast.com/cart/?add-to-cart=1311259"
         rel="noopener noreferrer"
         target="_blank"
       >
         Start your free trail
         <span
-          className="c12"
+          className="c5"
         >
           (Opens in a new browser tab)
         </span>
@@ -272,7 +285,7 @@ you’ll learn how to research and select the keywords that will guide searchers
       >
         Read more about this training »
         <span
-          className="c12"
+          className="c5"
         >
           (Opens in a new browser tab)
         </span>

--- a/composites/CoursesOverview/tests/__snapshots__/CardTest.js.snap
+++ b/composites/CoursesOverview/tests/__snapshots__/CardTest.js.snap
@@ -16,7 +16,6 @@ exports[`The FullHeightCard is rendered including some props 1`] = `
 }
 
 .c2 {
-  margin: 0;
   padding: 12px 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -104,7 +103,6 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
 }
 
 .c8 {
-  margin: 0;
   padding: 12px 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -120,8 +118,7 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
 }
 
 .c4 {
-  margin: 16px 8px 0px 16px;
-  display: block;
+  margin: 16px 16px 0 16px;
   font-weight: 400;
   font-size: 1.5em;
   line-height: 1.2;
@@ -131,12 +128,12 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
 .c2 {
   -webkit-text-decoration: none;
   text-decoration: none;
+  color: #a4286a;
 }
 
 .c2:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
-  color: #a4286a;
 }
 
 .c0 {
@@ -144,7 +141,6 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
 }
 
 .c12 {
-  cursor: pointer;
   color: #000;
   white-space: nowrap;
   display: block;
@@ -157,7 +153,6 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
   text-decoration: none;
   font-weight: bold;
   font-size: inherit;
-  margin-top: 0;
   margin-bottom: 8px;
 }
 
@@ -166,13 +161,13 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
 .c12:active {
   color: #000;
   background-color: #cecece;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c12:active {
-  position: relative;
-  top: 2px background-color:#cecece;
+  background-color: #cecece;
+  -webkit-transform: translateY( 1px );
+  -ms-transform: translateY( 1px );
+  transform: translateY( 1px );
   box-shadow: none;
   -webkit-filter: none;
   filter: none;
@@ -184,6 +179,12 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
 
 .c11 {
   text-align: center;
+}
+
+.c10 ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
 }
 
 .c10 li {
@@ -309,7 +310,6 @@ exports[`The empty Card component matches the snapshot 1`] = `
 }
 
 .c1 {
-  margin: 0;
   padding: 12px 16px;
   display: -webkit-box;
   display: -webkit-flex;

--- a/composites/CoursesOverview/tests/__snapshots__/CardTest.js.snap
+++ b/composites/CoursesOverview/tests/__snapshots__/CardTest.js.snap
@@ -117,23 +117,30 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
   flex-grow: 1;
 }
 
+.c2 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #a4286a;
+}
+
+.c2:hover,
+.c2:focus,
+.c2:active {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #a4286a;
+}
+
+.c2:active {
+  box-shadow: none;
+}
+
 .c4 {
   margin: 16px 16px 0 16px;
   font-weight: 400;
   font-size: 1.5em;
   line-height: 1.2;
-  color: #a4286a;
-}
-
-.c2 {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c2:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  color: #a4286a;
+  color: currentColor;
 }
 
 .c0 {

--- a/composites/CoursesOverview/tests/__snapshots__/CardTest.js.snap
+++ b/composites/CoursesOverview/tests/__snapshots__/CardTest.js.snap
@@ -220,16 +220,14 @@ exports[`The FullHeightCard is rendered including the CardBanner and CardDetails
     target="_blank"
   >
     <img
-      alt="Keyword Research"
+      alt=""
       className="c3"
       src="../wp-content/plugins/wordpress-seo/images/sample_course_card_header.png"
     />
     <h2
       className="c4"
     >
-       
       Keyword Research
-       
     </h2>
     <span
       className="c5"

--- a/composites/Plugin/Shared/components/UpsellLinkButton.js
+++ b/composites/Plugin/Shared/components/UpsellLinkButton.js
@@ -8,7 +8,6 @@ export const UpsellLinkButton = styled.a`
 	align-items: center;
 	justify-content: center;
 	vertical-align: middle;
-	cursor: pointer;
 	color: ${ colors.$color_black };
 	white-space: nowrap;
 	display: inline-flex;
@@ -27,10 +26,9 @@ export const UpsellLinkButton = styled.a`
 		background: ${ colors.$color_button_upsell_hover };
 	}
 
-	:active {
-		position: relative;
-		top: 2px;
+	&:active {
 		background-color: ${ colors.$color_button_hover_upsell };
+		transform: translateY( 1px );
 		box-shadow: none;
 		filter: none;
 	}

--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -1,6 +1,6 @@
 module.exports = {
 	target: [ "<%= files.components %>" ],
 	options: {
-		maxWarnings: 384,
+		maxWarnings: 380,
 	},
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Made link on Courses card header outbound and added underline on header title. 

## Test instructions

This PR can be tested by following these steps:

* Yarn link yoast-components in this branch and build yoastseo. 
* Go to the courses page click on the header (image or title) and see the link opens in a new tab.
* Hover over the header and see the title gets an underline. 

Fixes #[11906](https://github.com/Yoast/wordpress-seo/issues/11906)
