### PR TITLE
Make getFeed work in IE11 and Edge

### DIFF
--- a/app/ComponentsExample.js
+++ b/app/ComponentsExample.js
@@ -77,7 +77,7 @@ export default class ComponentsExample extends React.Component {
 				this.setState( { courses: feed.items } );
 			} )
 			/* eslint-disable-next-line no-console */
-			.catch( error => console.log( error ) );
+			.catch( error => console.error( error ) );
 	}
 
 	/**

--- a/app/DashboardWidgetWrapper.js
+++ b/app/DashboardWidgetWrapper.js
@@ -1,6 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 
+import getPostFeed from "../utils/getPostFeed";
+
 import {
 	DashboardWidgetSeoAssessment,
 	DashboardWidgetWordpressFeed,
@@ -18,58 +20,88 @@ export const DashboardContainer = styled.div`
 `;
 
 /**
- * Returns the ContentAnalysis component.
+ * Returns the DashboardWidget component.
  *
- * @returns {ReactElement} The ContentAnalysis component.
+ * @returns {ReactElement} The DashboardWidget component.
  */
-export default function DashboardWidget() {
-	const seoAssessmentItems = [
-		{
-			value: 33,
-			color: "#F00",
-			html: "Posts with a <b>bad</b> score",
-		},
-		{
-			value: 20,
-			color: "#FF0",
-			html: "Posts with a <b>decent</b> score",
-		},
-		{
-			value: 47,
-			color: "#0F0",
-			html: "Posts with a <b>good</b> score",
-		},
-	];
+export default class DashboardWidget extends React.Component {
+	/**
+	 * Creates the components and initializes its state.
+	 */
+	constructor() {
+		super();
 
-	const feed = {
-		link: "https://www.yoast.com",
-		title: "Feed title",
-		items: [
-			{
-				title: "Wordpress SEO",
-				link: "https://www.yoast.com/1",
-				description: "Some arbitrary description any blog post could have",
-			},
-			{
-				title: "Wordpress SEO",
-				link: "https://www.yoast.com/2",
-				description: "Some arbitrary description any blog post could have",
-			},
-		],
-	};
+		this.state = {
+			seoAssessmentItems: [
+				{
+					value: 33,
+					color: "#F00",
+					html: "Posts with a <b>bad</b> score",
+				},
+				{
+					value: 20,
+					color: "#FF0",
+					html: "Posts with a <b>decent</b> score",
+				},
+				{
+					value: 47,
+					color: "#0F0",
+					html: "Posts with a <b>good</b> score",
+				},
+			],
+			feed: null,
+		};
 
-	return (
-		<DashboardWidgetContainer>
-			<DashboardContainer>
-				<DashboardWidgetSeoAssessment
-					seoAssessmentText="Your SEO score is decent overall, but can be improved! Get to work!"
-					seoAssessmentItems={ seoAssessmentItems }
-				/>
-				<DashboardWidgetWordpressFeed
-					feed={ feed }
-					footerHtml="View our blog on yoast.com!"
-				/>
-			</DashboardContainer>
-		</DashboardWidgetContainer>
-	);
+		this.getFeed( "free" );
+	}
+
+	/**
+	 * Fetches data from the yoast.com feed, parses it and sets it to the state.
+	 *
+	 * @returns {void}
+	 */
+	getFeed() {
+		// Developer note: this link should -not- be converted to a shortlink.
+		getPostFeed( "https://yoast.com/feed/widget/", 3 )
+			.then( ( feed ) => {
+				feed.title = "Feed title";
+				feed.link  = "https://www.yoast.com";
+
+				feed.items = feed.items.map( ( item ) => {
+					item.description = item.description;
+					item.description = item.description.replace( `The post ${ item.title } appeared first on Yoast.`, "" ).trim();
+					item.content = item.content;
+
+					return item;
+				} );
+
+				this.setState( { feed } );
+			} )
+			/* eslint-disable-next-line no-console */
+			.catch( error => console.log( error ) );
+	}
+
+	/**
+	 * Renders all the Dashboard widget example.
+	 *
+	 * @returns {ReactElement} The rendered Dashboard widget example.
+	 */
+	render() {
+		const feed = this.state.feed;
+
+		return (
+			<DashboardWidgetContainer>
+				<DashboardContainer>
+					<DashboardWidgetSeoAssessment
+						seoAssessmentText="Your SEO score is decent overall, but can be improved! Get to work!"
+						seoAssessmentItems={ this.state.seoAssessmentItems }
+					/>
+					{ feed && <DashboardWidgetWordpressFeed
+						feed={ feed }
+						footerHtml="View our blog on yoast.com!"
+					/> }
+				</DashboardContainer>
+			</DashboardWidgetContainer>
+		);
+	}
 }

--- a/app/DashboardWidgetWrapper.js
+++ b/app/DashboardWidgetWrapper.js
@@ -52,7 +52,7 @@ export default class DashboardWidget extends React.Component {
 			feed: null,
 		};
 
-		this.getFeed( "free" );
+		this.getFeed();
 	}
 
 	/**
@@ -64,13 +64,10 @@ export default class DashboardWidget extends React.Component {
 		// Developer note: this link should -not- be converted to a shortlink.
 		getPostFeed( "https://yoast.com/feed/widget/", 3 )
 			.then( ( feed ) => {
-				feed.title = "Feed title";
-				feed.link  = "https://www.yoast.com";
-
 				feed.items = feed.items.map( ( item ) => {
+					// The implementation on wordpress-seo makes use of jQuery for escaping.
 					item.description = item.description;
 					item.description = item.description.replace( `The post ${ item.title } appeared first on Yoast.`, "" ).trim();
-					item.content = item.content;
 
 					return item;
 				} );
@@ -98,7 +95,7 @@ export default class DashboardWidget extends React.Component {
 					/>
 					{ feed && <DashboardWidgetWordpressFeed
 						feed={ feed }
-						footerHtml="View our blog on yoast.com!"
+						footerLinkText="View our blog on yoast.com!"
 					/> }
 				</DashboardContainer>
 			</DashboardWidgetContainer>

--- a/app/DashboardWidgetWrapper.js
+++ b/app/DashboardWidgetWrapper.js
@@ -75,7 +75,7 @@ export default class DashboardWidget extends React.Component {
 				this.setState( { feed } );
 			} )
 			/* eslint-disable-next-line no-console */
-			.catch( error => console.log( error ) );
+			.catch( error => console.error( error ) );
 	}
 
 	/**

--- a/composites/Plugin/DashboardWidget/components/WordpressFeed.js
+++ b/composites/Plugin/DashboardWidget/components/WordpressFeed.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
+import { makeOutboundLink } from "../../../../utils/makeOutboundLink";
 
 /**
  * @typedef  {Object}     Feed
@@ -23,9 +24,9 @@ import styled from "styled-components";
 const WordpressFeedContainer = styled.div`
 	box-sizing: border-box;
 
-	p, a {
-		font-size: 14px;
+	p {
 		margin: 0;
+		font-size: 14px;
 	}
 `;
 
@@ -40,27 +41,14 @@ const WordpressFeedList = styled.ul`
 	padding: 0;
 `;
 
-const WordpressFeedLink = styled.a`
+const WordpressFeedLink = makeOutboundLink( styled.a`
 	display: inline-block;
-	padding-bottom: 4px;
-`;
-
-const A11yNotice = styled.span`
-	border: 0;
-	clip: rect(1px, 1px, 1px, 1px);
-	clip-path: inset(50%);
-	height: 1px;
-	margin: -1px;
-	overflow: hidden;
-	padding: 0;
-	position: absolute !important;
-	width: 1px;
-	word-wrap: normal !important;
-`;
+	margin-bottom: 4px;
+	font-size: 14px;
+` );
 
 const WordpressFeedListItemContainer = styled.li`
 	margin: 8px 0;
-	overflow: hidden;
 `;
 
 const WordpressFeedFooter = styled.div`
@@ -77,13 +65,9 @@ const WordpressFeedListItem = ( props ) => {
 			<WordpressFeedLink
 				className={ `${ props.className }-link` }
 				href={ props.link }
-				target="_blank"
-				rel="noopener noreferrer"
+				rel={ null }
 			>
 				{ props.title }
-				<A11yNotice>
-					( Opens in a new browser tab )
-				</A11yNotice>
 			</WordpressFeedLink>
 			<p className={ `${ props.className }-description` }>
 				{ props.description }
@@ -102,11 +86,11 @@ WordpressFeedListItem.propTypes = {
 /**
  * Displays a parsed wordpress feed.
  *
- * @param {Object} props            The component props.
- * @param {Feed} props.feed         The feed object.
- * @param {string} props.title      The title. Defaults to feed title.
- * @param {string} props.footerHtml The footer HTML contents.
- * @param {string} props.feedLink   The footer link. Defaults to feed link.
+ * @param {Object} props                The component props.
+ * @param {Feed}   props.feed           The feed object.
+ * @param {string} props.title          The title. Defaults to feed title.
+ * @param {string} props.footerLinkText The footer link text.
+ * @param {string} props.feedLink       The footer link. Defaults to feed link.
  *
  * @returns {ReactElement} The WordpressFeed component.
  */
@@ -134,17 +118,17 @@ const WordpressFeed = ( props ) => {
 					/>
 				) ) }
 			</WordpressFeedList>
-			{ props.footerHtml &&
+			{ props.footerLinkText &&
 				<WordpressFeedFooter
 					className={ `${ props.className }__footer` }
 				>
 					<WordpressFeedLink
 						className={ `${ props.className }__footer-link` }
 						href={ props.feedLink ? props.feedLink : props.feed.link }
-						target="_blank"
-						rel="noopener noreferrer"
-						dangerouslySetInnerHTML={ { __html: props.footerHtml } }
-					/>
+						rel={ null }
+					>
+						{ props.footerLinkText }
+					</WordpressFeedLink>
 				</WordpressFeedFooter>
 			}
 		</WordpressFeedContainer>
@@ -155,7 +139,7 @@ WordpressFeed.propTypes = {
 	className: PropTypes.string,
 	feed: PropTypes.object.isRequired,
 	title: PropTypes.string,
-	footerHtml: PropTypes.string,
+	footerLinkText: PropTypes.string,
 	feedLink: PropTypes.string,
 };
 

--- a/composites/Plugin/DashboardWidget/tests/__snapshots__/WordpressFeedTest.js.snap
+++ b/composites/Plugin/DashboardWidget/tests/__snapshots__/WordpressFeedTest.js.snap
@@ -1,14 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`the WordpressFeed matches the snapshot 1`] = `
+.c5 {
+  border: 0;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute !important;
+  width: 1px;
+  word-wrap: normal !important;
+  -webkit-transform: translateY(1em);
+  -ms-transform: translateY(1em);
+  transform: translateY(1em);
+}
+
 .c0 {
   box-sizing: border-box;
 }
 
-.c0 p,
-.c0 a {
-  font-size: 14px;
+.c0 p {
   margin: 0;
+  font-size: 14px;
 }
 
 .c1 {
@@ -24,27 +41,12 @@ exports[`the WordpressFeed matches the snapshot 1`] = `
 
 .c4 {
   display: inline-block;
-  padding-bottom: 4px;
-}
-
-.c5 {
-  border: 0;
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute !important;
-  width: 1px;
-  word-wrap: normal !important;
+  margin-bottom: 4px;
+  font-size: 14px;
 }
 
 .c3 {
   margin: 8px 0;
-  overflow: hidden;
 }
 
 <div
@@ -65,14 +67,14 @@ exports[`the WordpressFeed matches the snapshot 1`] = `
       <a
         className="wordpress-feed__post-link c4"
         href="https://www.yoast.com/1"
-        rel="noopener noreferrer"
+        rel={null}
         target="_blank"
       >
         Wordpress SEO
         <span
           className="c5"
         >
-          ( Opens in a new browser tab )
+          (Opens in a new browser tab)
         </span>
       </a>
       <p
@@ -87,14 +89,14 @@ exports[`the WordpressFeed matches the snapshot 1`] = `
       <a
         className="wordpress-feed__post-link c4"
         href="https://www.yoast.com/2"
-        rel="noopener noreferrer"
+        rel={null}
         target="_blank"
       >
         Wordpress SEO
         <span
           className="c5"
         >
-          ( Opens in a new browser tab )
+          (Opens in a new browser tab)
         </span>
       </a>
       <p

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "redux": "^3.7.2",
     "styled-components": "^2.1.2",
     "whatwg-fetch": "^1.0.0",
+    "wicked-good-xpath": "^1.3.0",
     "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.5"
   },
   "devDependencies": {

--- a/utils/getFeed.js
+++ b/utils/getFeed.js
@@ -22,14 +22,19 @@ import { parseFeedItem as parsePostFeedItem } from "./getPostFeed";
  * @returns {string|undefined} The string result of the xpath query.
  */
 export function getXPathText( xpath, document, context = null, nsResolver = null ) {
+	const elementCount = document.evaluate( "count(" + xpath + ")", ( context || document ), nsResolver, XPathResult.ANY_TYPE, null ).numberValue;
+
+	if ( elementCount === 0 ) {
+		return;
+	}
+
 	const result = document.evaluate( xpath, ( context || document ), nsResolver, XPathResult.STRING_TYPE, null );
 
 	if ( result.stringValue ) {
 		return result.stringValue;
 	}
 
-	// eslint-disable-next-line no-undefined
-	return undefined;
+	return null;
 }
 
 /**

--- a/utils/getFeed.js
+++ b/utils/getFeed.js
@@ -22,13 +22,6 @@ import { parseFeedItem as parsePostFeedItem } from "./getPostFeed";
  * @returns {string|undefined} The string result of the xpath query.
  */
 export function getXPathText( xpath, document, context = null, nsResolver = null ) {
-	const tagname = xpath.replace( "child::", "" );
-	const elementExists = document.getElementsByTagName( tagname );
-
-	if ( typeof elementExists[ 0 ] === "undefined" ) {
-		return;
-	}
-
 	const result = document.evaluate( xpath, ( context || document ), nsResolver, XPathResult.STRING_TYPE, null );
 
 	if ( result.stringValue ) {

--- a/utils/getFeed.js
+++ b/utils/getFeed.js
@@ -1,3 +1,5 @@
+import wgxpath from "wicked-good-xpath";
+
 /* Internal dependencies */
 import { parseFeedItem as parsePostFeedItem } from "./getPostFeed";
 
@@ -107,6 +109,10 @@ function getFeedItems( parsed, nsResolver, maxItems, parseFeedItem ) {
 export function parseFeed( raw, maxItems = 0, parseFeedItem ) {
 	return new Promise( function( resolve, reject ) {
 		try {
+			// Use Wicked Good XPath for browsers that don't support XPath evaluation.
+			if ( "evaluate" in document === false ) {
+				wgxpath.install();
+			}
 			const parser     = new DOMParser();
 			const parsed     = parser.parseFromString( raw, "application/xml" );
 			const nsResolver = parsed.createNSResolver( parsed.documentElement );

--- a/utils/getFeed.js
+++ b/utils/getFeed.js
@@ -22,6 +22,10 @@ import { parseFeedItem as parsePostFeedItem } from "./getPostFeed";
  * @returns {string|undefined} The string result of the xpath query.
  */
 export function getXPathText( xpath, document, context = null, nsResolver = null ) {
+	/*
+	 * Check for the existence of the element referenced by the passed xpath
+	 * and return early if no occurrences are found.
+	 */
 	const elementCount = document.evaluate( "count(" + xpath + ")", ( context || document ), nsResolver, XPathResult.ANY_TYPE, null ).numberValue;
 
 	if ( elementCount === 0 ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10074,6 +10074,11 @@ which@~1.2.1:
   dependencies:
     isexe "^2.0.0"
 
+wicked-good-xpath@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz#81b0e95e8650e49c94b22298fff8686b5553cf6c"
+  integrity sha1-gbDpXoZQ5JyUsiKY//hoa1VTz2w=
+
 wide-align@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes parsing of feeds in Internet Explorer 11

## Relevant technical choices:

- uses [Wicked Good XPath](https://github.com/google/wicked-good-xpath) for browsers that don't support XPath evaluation (IE11), for more details see their documentation. I'm not an expert in XPath parsing in JS, but it works. /Cc @atimmer @herregroen 
- adds a real dashboard widget working example in the demos

## Test instructions

Updated instructions:

- at the moment, this PR can't be tested in the standalone app because of https://github.com/Yoast/YoastSEO.js/issues/2086
- if you want to test it there, you need to downgrade `yoastseo` to `v1.43.0` in the package.json

## Test in the plugin
- first, test on `release-yoast-seo/9.5`
- go to the WP dashboard and observe in IE11 the Yoast dashboard widget doesn't show the posts from the feed
- go in the Courses page and observe in IE11 the page is blank
- in Edge, the Courses page shows the cards with missing content
- see in the IE11 console the error `[object Error]` and expand it for more details: `TypeError: Object doesn't support property or method 'createNSResolver'`

Switch the plugin to the `11935-get-feed-ie11-edge` branch (see https://github.com/Yoast/wordpress-seo/pull/11968) and yarn link this yoast-component PR to the plugin:
- build the JS: `grunt build:js && grunt webpack:buildProd`
- verify the dashboard widget shows the content parsed from the feed
- verify the "Read more like this ..." link at the bottom has a link to yoast.com with tracking code
- you may need to flush the transients, if you're using VVV:
```
vagrant ssh
cd /srv/www/wordpress-develop/public_html/
wp transient delete-all
```

- verify the Courses page shows the content parsed from the feed in IE11 and Edge
- in both the dashboard widget and the Courses page, verify all the links that have `target="_blank"` don't have a `rel="noopener noreferrer" attribute` and do have the a11y message "Opens in a new. browser tab"

Note: the Courses page layout is broken in IE11 because the current CSS grid implementation doesn't work in this browser. Will be addressed separately.

Screenshots from IE11:

![screenshot 160](https://user-images.githubusercontent.com/1682452/50606309-9acd4200-0ec5-11e9-9e0b-4be9ddbbe0c4.png)

![screenshot 161](https://user-images.githubusercontent.com/1682452/50606311-9acd4200-0ec5-11e9-9eee-5e87cadb9c12.png)

(as said, the broken layout will be addressed in https://github.com/Yoast/wordpress-seo/issues/11953 )

Fixes https://github.com/Yoast/wordpress-seo/issues/11935
Fixes https://github.com/Yoast/wordpress-seo/issues/11073
