### PR TITLE
Use the Gutenberg chevrons

### DIFF
--- a/composites/Plugin/Shared/components/Collapsible.js
+++ b/composites/Plugin/Shared/components/Collapsible.js
@@ -325,14 +325,14 @@ Collapsible.defaultProps = {
 	prefixIcon: null,
 	prefixIconCollapsed: null,
 	suffixIcon: {
-		icon: "arrow-up",
+		icon: "chevron-up",
 		color: colors.$black,
-		size: "9px",
+		size: "24px",
 	},
 	suffixIconCollapsed: {
-		icon: "arrow-down",
+		icon: "chevron-down",
 		color: colors.$black,
-		size: "9px",
+		size: "24px",
 	},
 	headingProps: {
 		level: 2,

--- a/composites/Plugin/Shared/components/SvgIcon.js
+++ b/composites/Plugin/Shared/components/SvgIcon.js
@@ -6,6 +6,14 @@ import isArray from "lodash/isArray";
 const DEFAULT_VIEWBOX = "0 0 1792 1792";
 /* eslint-disable max-len, quote-props */
 export const icons = {
+	"chevron-down": { viewbox: "0 0 24 24", width: "24px", path: [
+		<g key="1"><path fill="none" d="M0,0h24v24H0V0z" /></g>,
+		<g key="2"><path d="M7.41,8.59L12,13.17l4.59-4.58L18,10l-6,6l-6-6L7.41,8.59z" /></g>,
+	] },
+	"chevron-up": { viewbox: "0 0 24 24", width: "24px", path: [
+		<g key="1"><path fill="none" d="M0,0h24v24H0V0z" /></g>,
+		<g key="2"><path d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z" /></g>,
+	] },
 	"angle-down": { viewbox: DEFAULT_VIEWBOX, path: "M1395 736q0 13-10 23l-466 466q-10 10-23 10t-23-10l-466-466q-10-10-10-23t10-23l50-50q10-10 23-10t23 10l393 393 393-393q10-10 23-10t23 10l50 50q10 10 10 23z" },
 	"angle-left": { viewbox: DEFAULT_VIEWBOX, path: "M1203 544q0 13-10 23l-393 393 393 393q10 10 10 23t-10 23l-50 50q-10 10-23 10t-23-10l-466-466q-10-10-10-23t10-23l466-466q10-10 23-10t23 10l50 50q10 10 10 23z" },
 	"angle-right": { viewbox: DEFAULT_VIEWBOX, path: "M1171 960q0 13-10 23l-466 466q-10 10-23 10t-23-10l-50-50q-10-10-10-23t10-23l393-393-393-393q-10-10-10-23t10-23l50-50q10-10 23-10t23 10l466 466q10 10 10 23z" },

--- a/composites/Plugin/Shared/tests/__snapshots__/CollapsibleTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/CollapsibleTest.js.snap
@@ -134,8 +134,8 @@ exports[`Collapsible matches the snapshot by default 1`] = `
 }
 
 .c11 {
-  width: 9px;
-  height: 9px;
+  width: 24px;
+  height: 24px;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -173,17 +173,25 @@ exports[`Collapsible matches the snapshot by default 1`] = `
       </span>
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-arrow-down c11"
+        className="yoast-svg-icon yoast-svg-icon-chevron-down c11"
         fill="currentColor"
         focusable="false"
         role="img"
-        size="9px"
-        viewBox="0 0 1792 1792"
+        size="24px"
+        viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M896 1791L120.91 448.5L1671.09 448.5z"
-        />
+        <g>
+          <path
+            d="M0,0h24v24H0V0z"
+            fill="none"
+          />
+        </g>
+        <g>
+          <path
+            d="M7.41,8.59L12,13.17l4.59-4.58L18,10l-6,6l-6-6L7.41,8.59z"
+          />
+        </g>
       </svg>
     </button>
   </h2>
@@ -324,8 +332,8 @@ exports[`Collapsible matches the snapshot by default 2`] = `
 }
 
 .c11 {
-  width: 9px;
-  height: 9px;
+  width: 24px;
+  height: 24px;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -363,17 +371,25 @@ exports[`Collapsible matches the snapshot by default 2`] = `
       </span>
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-arrow-up c11"
+        className="yoast-svg-icon yoast-svg-icon-chevron-up c11"
         fill="currentColor"
         focusable="false"
         role="img"
-        size="9px"
-        viewBox="0 0 1792 1792"
+        size="24px"
+        viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M1671.09 1343.5L120.91 1343.5L896 1z"
-        />
+        <g>
+          <path
+            d="M0,0h24v24H0V0z"
+            fill="none"
+          />
+        </g>
+        <g>
+          <path
+            d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z"
+          />
+        </g>
       </svg>
     </button>
   </h2>
@@ -526,8 +542,8 @@ exports[`Collapsible matches the snapshot by default when the collapsible has an
 }
 
 .c11 {
-  width: 9px;
-  height: 9px;
+  width: 24px;
+  height: 24px;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -565,17 +581,25 @@ exports[`Collapsible matches the snapshot by default when the collapsible has an
       </span>
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-arrow-down c11"
+        className="yoast-svg-icon yoast-svg-icon-chevron-down c11"
         fill="currentColor"
         focusable="false"
         role="img"
-        size="9px"
-        viewBox="0 0 1792 1792"
+        size="24px"
+        viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M896 1791L120.91 448.5L1671.09 448.5z"
-        />
+        <g>
+          <path
+            d="M0,0h24v24H0V0z"
+            fill="none"
+          />
+        </g>
+        <g>
+          <path
+            d="M7.41,8.59L12,13.17l4.59-4.58L18,10l-6,6l-6-6L7.41,8.59z"
+          />
+        </g>
       </svg>
     </button>
   </h2>
@@ -716,8 +740,8 @@ exports[`Collapsible matches the snapshot by default when the collapsible has an
 }
 
 .c11 {
-  width: 9px;
-  height: 9px;
+  width: 24px;
+  height: 24px;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -755,17 +779,25 @@ exports[`Collapsible matches the snapshot by default when the collapsible has an
       </span>
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-arrow-up c11"
+        className="yoast-svg-icon yoast-svg-icon-chevron-up c11"
         fill="currentColor"
         focusable="false"
         role="img"
-        size="9px"
-        viewBox="0 0 1792 1792"
+        size="24px"
+        viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M1671.09 1343.5L120.91 1343.5L896 1z"
-        />
+        <g>
+          <path
+            d="M0,0h24v24H0V0z"
+            fill="none"
+          />
+        </g>
+        <g>
+          <path
+            d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z"
+          />
+        </g>
       </svg>
     </button>
   </h2>
@@ -918,8 +950,8 @@ exports[`Collapsible matches the snapshot when it is closed 1`] = `
 }
 
 .c11 {
-  width: 9px;
-  height: 9px;
+  width: 24px;
+  height: 24px;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -957,17 +989,25 @@ exports[`Collapsible matches the snapshot when it is closed 1`] = `
       </span>
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-arrow-down c11"
+        className="yoast-svg-icon yoast-svg-icon-chevron-down c11"
         fill="currentColor"
         focusable="false"
         role="img"
-        size="9px"
-        viewBox="0 0 1792 1792"
+        size="24px"
+        viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M896 1791L120.91 448.5L1671.09 448.5z"
-        />
+        <g>
+          <path
+            d="M0,0h24v24H0V0z"
+            fill="none"
+          />
+        </g>
+        <g>
+          <path
+            d="M7.41,8.59L12,13.17l4.59-4.58L18,10l-6,6l-6-6L7.41,8.59z"
+          />
+        </g>
       </svg>
     </button>
   </h2>
@@ -1108,8 +1148,8 @@ exports[`Collapsible matches the snapshot when it is closed 2`] = `
 }
 
 .c11 {
-  width: 9px;
-  height: 9px;
+  width: 24px;
+  height: 24px;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -1147,17 +1187,25 @@ exports[`Collapsible matches the snapshot when it is closed 2`] = `
       </span>
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-arrow-up c11"
+        className="yoast-svg-icon yoast-svg-icon-chevron-up c11"
         fill="currentColor"
         focusable="false"
         role="img"
-        size="9px"
-        viewBox="0 0 1792 1792"
+        size="24px"
+        viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M1671.09 1343.5L120.91 1343.5L896 1z"
-        />
+        <g>
+          <path
+            d="M0,0h24v24H0V0z"
+            fill="none"
+          />
+        </g>
+        <g>
+          <path
+            d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z"
+          />
+        </g>
       </svg>
     </button>
   </h2>
@@ -1310,8 +1358,8 @@ exports[`Collapsible matches the snapshot when it is open 1`] = `
 }
 
 .c11 {
-  width: 9px;
-  height: 9px;
+  width: 24px;
+  height: 24px;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -1349,17 +1397,25 @@ exports[`Collapsible matches the snapshot when it is open 1`] = `
       </span>
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-arrow-up c11"
+        className="yoast-svg-icon yoast-svg-icon-chevron-up c11"
         fill="currentColor"
         focusable="false"
         role="img"
-        size="9px"
-        viewBox="0 0 1792 1792"
+        size="24px"
+        viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M1671.09 1343.5L120.91 1343.5L896 1z"
-        />
+        <g>
+          <path
+            d="M0,0h24v24H0V0z"
+            fill="none"
+          />
+        </g>
+        <g>
+          <path
+            d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z"
+          />
+        </g>
       </svg>
     </button>
   </h2>
@@ -1512,8 +1568,8 @@ exports[`Collapsible matches the snapshot when it is open 2`] = `
 }
 
 .c11 {
-  width: 9px;
-  height: 9px;
+  width: 24px;
+  height: 24px;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -1551,17 +1607,25 @@ exports[`Collapsible matches the snapshot when it is open 2`] = `
       </span>
       <svg
         aria-hidden={true}
-        className="yoast-svg-icon yoast-svg-icon-arrow-down c11"
+        className="yoast-svg-icon yoast-svg-icon-chevron-down c11"
         fill="currentColor"
         focusable="false"
         role="img"
-        size="9px"
-        viewBox="0 0 1792 1792"
+        size="24px"
+        viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M896 1791L120.91 448.5L1671.09 448.5z"
-        />
+        <g>
+          <path
+            d="M0,0h24v24H0V0z"
+            fill="none"
+          />
+        </g>
+        <g>
+          <path
+            d="M7.41,8.59L12,13.17l4.59-4.58L18,10l-6,6l-6-6L7.41,8.59z"
+          />
+        </g>
       </svg>
     </button>
   </h2>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Uses the same chevrons as Gutenberg does.

## Relevant technical choices:

* 

## Test instructions

This PR can be tested by following these steps:

* Checkout wordpress-seo/trunk
* Link this branch (`yarn link`)
* Do the grunt building happiness
* Compare the arrows (chevrons) in the Yoast sidebar with the one that Gutenberg uses

* Note: the metabox is using the old style because of this is WordPress internal logic and it's too hard to change that:
![edit_post_ _local_wordpress_dev_ _wordpress](https://user-images.githubusercontent.com/325040/50687747-c87bcd80-1022-11e9-8b60-826f579af795.png)

Fixes https://github.com/Yoast/wordpress-seo/issues/11490
