### PR TITLE
Don't show empty read more button for course bundles

### DIFF
--- a/composites/CoursesOverview/CardDetails.js
+++ b/composites/CoursesOverview/CardDetails.js
@@ -123,7 +123,6 @@ class CardDetails extends React.Component {
 	 */
 	render() {
 		const buttonType = this.props.ctaButtonData.ctaButtonType === "regular" ? CardRegularButton : CardUpsellButton;
-		const OutboundLinkButton = makeOutboundLink( buttonType );
 
 		return (
 			<Fragment>
@@ -132,16 +131,30 @@ class CardDetails extends React.Component {
 						dangerouslySetInnerHTML={ { __html: this.props.description } }
 					/>
 				</Details>
-				<ActionBlock>
-					<OutboundLinkButton href={ this.props.ctaButtonData.ctaButtonUrl } rel={ null }>
-						{ this.props.ctaButtonData.ctaButtonCopy }
-					</OutboundLinkButton>
-					<OutboundInfoLink href={ this.props.courseUrl } rel={ null }>
-						{ this.props.readMoreLinkText }
-					</OutboundInfoLink>
-				</ActionBlock>
+				{ this.getActionBlock( buttonType, this.props.isBundle ) }
 			</Fragment>
 		);
+	}
+
+	getActionBlock( buttonType, isBundle ) {
+		const OutboundLinkButton = makeOutboundLink( buttonType );
+
+		// Bundles don't have an OutboundInfoLink and use a different property from the feed for the OutboundLinkButton.
+		if ( isBundle === "true" ) {
+			return <ActionBlock>
+				<OutboundLinkButton href={ this.props.courseUrl } rel={ null }>
+					{ this.props.ctaButtonData.ctaButtonCopy }
+				</OutboundLinkButton>
+			</ActionBlock>;
+		}
+		return <ActionBlock>
+			<OutboundLinkButton href={ this.props.ctaButtonData.ctaButtonUrl } rel={ null }>
+				{ this.props.ctaButtonData.ctaButtonCopy }
+			</OutboundLinkButton>
+			<OutboundInfoLink href={ this.props.courseUrl } rel={ null }>
+				{ this.props.readMoreLinkText }
+			</OutboundInfoLink>
+		</ActionBlock>;
 	}
 }
 
@@ -152,6 +165,7 @@ CardDetails.propTypes = {
 	courseUrl: PropTypes.string,
 	ctaButtonData: PropTypes.object,
 	readMoreLinkText: PropTypes.string,
+	isBundle: PropTypes.bool,
 };
 
 CardDetails.defaultProps = {
@@ -159,4 +173,5 @@ CardDetails.defaultProps = {
 	courseUrl: "",
 	ctaButtonData: {},
 	readMoreLinkText: "",
+	isBundle: false,
 };

--- a/composites/CoursesOverview/CardDetails.js
+++ b/composites/CoursesOverview/CardDetails.js
@@ -136,6 +136,14 @@ class CardDetails extends React.Component {
 		);
 	}
 
+	/**
+	 * Returns the correct Action Block based on whether an item is a bundle or a single course.
+	 *
+	 * @param {string} buttonType The type of the button. Either regular or sale.
+	 * @param {boolean} isBundle True when the it's a bundle.
+	 *
+	 * @returns {ReactElement} The ActionBlock component.
+	 */
 	getActionBlock( buttonType, isBundle ) {
 		const OutboundLinkButton = makeOutboundLink( buttonType );
 

--- a/utils/getCourseFeed.js
+++ b/utils/getCourseFeed.js
@@ -33,6 +33,7 @@ function parseCourseFeedItem( parsed, snapshot, nsResolver ) {
 	item.ctaButtonUrl        = getXPathText( "child::content:cta_button_url", parsed, snapshot, nsResolver );
 	item.readMoreLinkText    = getXPathText( "child::content:read_more_link_text", parsed, snapshot, nsResolver );
 	item.isFree              = getXPathText( "child::content:is_free", parsed, snapshot, nsResolver );
+	item.isBundle            = getXPathText( "child::content:is_bundle", parsed, snapshot, nsResolver );
 
 	return item;
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

*

Fixes https://github.com/Yoast/wordpress-seo/issues/12030
