### PR TITLE
Add step-specific hashes to the URL in the OnboardingWizard

### DIFF
--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -39,6 +39,8 @@ class OnboardingWizard extends React.Component {
 
 		this.setNextStep = this.setNextStep.bind( this );
 		this.setPreviousStep = this.setPreviousStep.bind( this );
+		this.listenToHashChange = this.listenToHashChange.bind( this );
+		window.addEventListener( "hashchange", this.listenToHashChange, false );
 	}
 
 	/**
@@ -292,6 +294,16 @@ class OnboardingWizard extends React.Component {
 	handleOnClick( stepName, evt ) {
 		this.postStep( stepName, evt );
 		this.changeBrowserHistory( stepName );
+	}
+
+	/**
+	 * Updates the currentStepId in the state when the hash in the URL changes.
+	 *
+	 * @returns {void}
+	 */
+	listenToHashChange() {
+		// Because the hash starts with a hashtag, we need to do `.substring( 1 )`.
+		this.setState( { currentStepId: window.location.hash.substring( 1 ) } );
 	}
 
 	/**

--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -151,7 +151,7 @@ class OnboardingWizard extends React.Component {
 		if ( firstStep !== "" ) {
 			return firstStep;
 		}
-		// When no startingStep is set, use the first step of the wizard as default.
+		// When window.location doesn't have a hash, use the first step of the wizard as default.
 		return Object.getOwnPropertyNames( steps )[ 0 ];
 	}
 
@@ -433,13 +433,11 @@ OnboardingWizard.propTypes = {
 	finishUrl: PropTypes.string,
 	translate: PropTypes.any,
 	headerIcon: PropTypes.func,
-	startingStep: PropTypes.string,
 };
 
 OnboardingWizard.defaultProps = {
 	customComponents: {},
 	finishUrl: "",
-	startingStep: "",
 };
 
 export default localize( OnboardingWizard );

--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -13,7 +13,7 @@ import interpolateComponents from "interpolate-components";
 import ArrowForwardIcon from "material-ui/svg-icons/navigation/arrow-forward";
 import ArrowBackwardIcon from "material-ui/svg-icons/navigation/arrow-back";
 import CloseIcon from "material-ui/svg-icons/navigation/close";
-
+import isUndefined from "lodash/isUndefined";
 
 /**
  * The OnboardingWizard class.
@@ -37,6 +37,7 @@ class OnboardingWizard extends React.Component {
 			wizardUrl: props.wizardUrl,
 		};
 
+		this.handleOnClick = this.handleOnClick.bind( this );
 		this.setNextStep = this.setNextStep.bind( this );
 		this.setPreviousStep = this.setPreviousStep.bind( this );
 		this.listenToHashChange = this.listenToHashChange.bind( this );
@@ -212,7 +213,14 @@ class OnboardingWizard extends React.Component {
 	 * @returns {Object} The current step.
 	 */
 	getCurrentStep() {
-		return this.state.steps[ this.state.currentStepId ];
+		const currentStep = this.state.steps[ this.state.currentStepId ];
+
+		// If the currentStep is undefined because the stepId is invalid, return the first step of the Wizard.
+		if ( isUndefined( currentStep ) ) {
+			const firstStepId = Object.keys( this.state.steps )[ 0 ];
+			return this.state.steps[ firstStepId ];
+		}
+		return currentStep;
 	}
 
 	/**
@@ -349,7 +357,7 @@ class OnboardingWizard extends React.Component {
 					<Header headerTitle={ headerTitle } icon={ this.props.headerIcon } />
 					<StepIndicator
 						steps={ this.props.steps } stepIndex={ this.getCurrentStepNumber() - 1 }
-						onClick={ ( stepName, evt ) => this.handleOnClick( stepName, evt ) }
+						onClick={ this.handleOnClick }
 					/>
 					<main className="yoast-wizard-container">
 						<div className="yoast-wizard">

--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -287,30 +287,47 @@ class OnboardingWizard extends React.Component {
 	}
 
 	/**
-	 * When the currentStepId in the state changes, push the new hash to the history if differs from the current hash.
-	 *
-	 * If we wouldn't check against the current hash, it would lead to double hashes when using the browser's previous
-	 * and next buttons.
+	 * When the currentStepId in the state changes, return a snapshot with the new currentStepId.
 	 *
 	 * @param {Object} prevProps The previous props.
 	 * @param {Object} prevState The previous state.
 	 *
-	 * @returns {void}
+	 * @returns {string|null} The currentStepId from after the update.
 	 */
 	getSnapshotBeforeUpdate( prevProps, prevState ) {
 		const currentStepIdAfterUpdate = this.state.currentStepId;
 		// If there is no change in the currentStepId in the state, do nothing.
 		if ( prevState.currentStepId === currentStepIdAfterUpdate ) {
-			return;
+			return null;
 		}
 
 		// If the new currentStepId is the same as the current location hash, do nothing.
 		if ( window.location.hash.substring( 1 ) === currentStepIdAfterUpdate ) {
-			return;
+			return null;
 		}
 
-		window.history.pushState( null, null, "#" + currentStepIdAfterUpdate );
+		return currentStepIdAfterUpdate;
 	}
+
+	/**
+	 * Push the new hash to the history.
+	 *
+	 * Only do this when the new hash differs from the current hash. If we wouldn't check against
+	 * the current hash, it would lead to double hashes when using the browser's previous and next
+	 * buttons.
+	 *
+	 * @param {Object} prevProps The previous props.
+	 * @param {Object} prevState The previous state.
+	 * @param {string} snapshot The currentStepId from after the update.
+	 *
+	 * @returns {void}
+	 */
+	componentDidUpdate( prevProps, prevState, snapshot ) {
+		if ( snapshot !== null ) {
+			window.history.pushState( null, null, "#" + snapshot );
+		}
+	}
+
 
 	/**
 	 * Renders the wizard.

--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -403,11 +403,13 @@ OnboardingWizard.propTypes = {
 	finishUrl: PropTypes.string,
 	translate: PropTypes.any,
 	headerIcon: PropTypes.func,
+	startingStep: PropTypes.string,
 };
 
 OnboardingWizard.defaultProps = {
 	customComponents: {},
 	finishUrl: "",
+	startingStep: "",
 };
 
 export default localize( OnboardingWizard );

--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -44,6 +44,17 @@ class OnboardingWizard extends React.Component {
 	}
 
 	/**
+	 * Remove the prepended hashtag from the passed string.
+	 *
+	 * @param {string} stringWithHashtag The string to remove the prepended hashtag from.
+	 *
+	 * @returns {string} The string without prepended hashtag.
+	 */
+	removePrependedHashtag( stringWithHashtag ) {
+		return stringWithHashtag.substring( 1 );
+	}
+
+	/**
 	 * Sets the previous and next stepId for each step.
 	 *
 	 * @param {Object} steps The object containing the steps.
@@ -134,7 +145,9 @@ class OnboardingWizard extends React.Component {
 	 * @returns {Object}  The first step object
 	 */
 	getFirstStep( steps ) {
-		const firstStep = this.props.startingStep;
+		// Use the hash from the url without the hashtag.
+		const firstStep = this.removePrependedHashtag( window.location.hash );
+
 		if ( firstStep !== "" ) {
 			return firstStep;
 		}
@@ -282,8 +295,8 @@ class OnboardingWizard extends React.Component {
 	 * @returns {void}
 	 */
 	listenToHashChange() {
-		// Because the hash starts with a hashtag, we need to do `.substring( 1 )`.
-		this.setState( { currentStepId: window.location.hash.substring( 1 ) } );
+		// Because the hash starts with a hashtag, we need to do remove the hastag before using it.
+		this.setState( { currentStepId: this.removePrependedHashtag( window.location.hash ) } );
 	}
 
 	/**
@@ -302,7 +315,7 @@ class OnboardingWizard extends React.Component {
 		}
 
 		// If the new currentStepId is the same as the current location hash, do nothing.
-		if ( window.location.hash.substring( 1 ) === currentStepIdAfterUpdate ) {
+		if ( this.removePrependedHashtag( window.location.hash ) === currentStepIdAfterUpdate ) {
 			return null;
 		}
 

--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -34,6 +34,7 @@ class OnboardingWizard extends React.Component {
 			steps: this.parseSteps( this.props.steps ),
 			currentStepId: this.getFirstStep( props.steps ),
 			errorMessage: "",
+			wizardUrl: props.wizardUrl,
 		};
 
 		this.setNextStep = this.setNextStep.bind( this );
@@ -131,11 +132,11 @@ class OnboardingWizard extends React.Component {
 	 * @returns {Object}  The first step object
 	 */
 	getFirstStep( steps ) {
-		const firstStep = this.props.firstStep;
+		const firstStep = this.props.startingStep;
 		if ( firstStep !== "" ) {
 			return firstStep;
 		}
-		// When no firstStep is set, use the first step of the wizard as default.
+		// When no startingStep is set, use the first step of the wizard as default.
 		return Object.getOwnPropertyNames( steps )[ 0 ];
 	}
 
@@ -265,6 +266,35 @@ class OnboardingWizard extends React.Component {
 	}
 
 	/**
+	 * Appends the name of the step that is navigated to as a fragment to the end of the URL.
+	 *
+	 * As a result, the URL changes for every step, and the user can use their browser's back and
+	 * next to navigate between steps.
+	 *
+	 * @param {string} stepName The name of the step that has been navigated to.
+	 *
+	 * @returns {void}
+	 */
+	changeBrowserHistory( stepName ) {
+		window.history.pushState( null, null, this.state.wizardUrl + "#" + stepName );
+	}
+
+	/**
+	 * Handles the onClick event.
+	 *
+	 * Posts the step to the endpoint and appends the step name as a hash to the URL.
+	 *
+	 * @param {string} stepName The name of the step that is clicked on.
+	 * @param {event} evt The onClick event.
+	 *
+	 * @returns {void}
+	 */
+	handleOnClick( stepName, evt ) {
+		this.postStep( stepName, evt );
+		this.changeBrowserHistory( stepName );
+	}
+
+	/**
 	 * Renders the wizard.
 	 *
 	 * @returns {JSX.Element} The rendered step in the wizard.
@@ -307,7 +337,7 @@ class OnboardingWizard extends React.Component {
 					<Header headerTitle={ headerTitle } icon={ this.props.headerIcon } />
 					<StepIndicator
 						steps={ this.props.steps } stepIndex={ this.getCurrentStepNumber() - 1 }
-						onClick={ ( stepNumber, evt ) => this.postStep( stepNumber, evt ) }
+						onClick={ ( stepName, evt ) => this.handleOnClick( stepName, evt ) }
 					/>
 					<main className="yoast-wizard-container">
 						<div className="yoast-wizard">

--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -131,6 +131,11 @@ class OnboardingWizard extends React.Component {
 	 * @returns {Object}  The first step object
 	 */
 	getFirstStep( steps ) {
+		const firstStep = this.props.firstStep;
+		if ( firstStep !== "" ) {
+			return firstStep;
+		}
+		// When no firstStep is set, use the first step of the wizard as default.
 		return Object.getOwnPropertyNames( steps )[ 0 ];
 	}
 

--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -1,6 +1,6 @@
 module.exports = {
 	target: [ "<%= files.components %>" ],
 	options: {
-		maxWarnings: 380,
+		maxWarnings: 379,
 	},
 };


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add step-specific hashes to the URL in the OnboardingWizard to make navigation easier.

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* See https://github.com/Yoast/wordpress-seo/pull/12162

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

Fixes #[12158](https://github.com/Yoast/wordpress-seo/issues/12158)
