### PR TITLE
Babelify YoastSEO.js in the standalone

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,7 @@ module.exports = {
 		rules: [
 			{
 				test: /\.js$/,
-				exclude: /node_modules/,
+				exclude: /node_modules[/\\](?!(yoastseo)[/\\]).*/,
 				use: [ {
 					loader: "babel-loader",
 					options: {


### PR DESCRIPTION
IE11 does not support destructuring of assignments (or any destructuring https://kangax.github.io/compat-table/es6/#ie11).
Use Babel to transpile this to IE11 understandable code.

## Summary

This PR can be summarized in the following changelog entry:

* [non-user-facing] Fixes the standalone in IE11.

## Relevant technical choices:

* Adds an exception for `node_modules/yoastseo` in the babel exclusion of the webpack config.

## Test instructions

This PR can be tested by following these steps:

* use IE11
* on `yoast-components`, run `yarn` to make sure everything is updated
* run `yarn start` and go to the standalone demos on [http://localhost:3333](http://localhost:3333/)
* open the IE11 console (press F12)
* note that the IE11 console needs to be open, this is a pre-existing issue: without opening the console you won't see anything

Ensure you no longer get the following:
* even with the console open, you will get a blank page
* see a couple of cryptic JS errors in the console: one of them seems related to the relevant words

## UI changes
* [ ] ~This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.~

Fixes https://github.com/Yoast/YoastSEO.js/issues/2086
