### PR TITLE
Add autocomplete prop to Step, Textfield, and Input.

### DIFF
--- a/composites/OnboardingWizard/Step.js
+++ b/composites/OnboardingWizard/Step.js
@@ -227,6 +227,7 @@ class Step extends React.Component {
 				label: currentField.properties.label,
 				"label-className": `${this.props.classPrefix}-text-input-label`,
 				"field-className": `${this.props.classPrefix}-text-input-field`,
+				autoComplete: currentField.properties.autoComplete,
 				optionalAttributes: {
 					"class": `${this.props.classPrefix}-text-input`,
 				},

--- a/forms/Input.js
+++ b/forms/Input.js
@@ -59,6 +59,7 @@ class Input extends React.Component {
 				name={ this.props.name }
 				defaultValue={ this.props.value }
 				onChange={ this.props.onChange }
+				autoComplete={ this.props.autoComplete }
 				{ ...this.props.optionalAttributes }
 			/>
 		);

--- a/forms/composites/Textfield.js
+++ b/forms/composites/Textfield.js
@@ -72,6 +72,7 @@ class Textfield extends React.Component {
 					onChange={ this.props.onChange }
 					value={ this.props.value }
 					hasFocus={ this.props.hasFocus }
+					autoComplete={ this.props.autoComplete }
 					optionalAttributes={ this.optionalAttributes.field }
 				/>
 				<Explanation text={ this.props.explanation } />


### PR DESCRIPTION
Required for https://github.com/Yoast/wordpress-seo/issues/12171

Fixes https://github.com/Yoast/wordpress-seo/issues/12171