### PR TITLE
Bumped YoastSEO version to 1.47.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "styled-components": "^2.1.2",
     "whatwg-fetch": "^1.0.0",
     "wicked-good-xpath": "^1.3.0",
-    "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.6"
+    "yoastseo": "^1.47.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10350,10 +10350,10 @@ yeoman-generator@^2.0.4:
     through2 "^2.0.0"
     yeoman-environment "^2.0.5"
 
-yoastseo@^1.46.0:
-  version "1.46.0"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.46.0.tgz#59f23945dc79a0c18124a7be8965f7089b2a3639"
-  integrity sha512-/hp/LQ/BPZtf8o/KFu9HxunnyIa/XpRoETdgCZCQ46mo1OKnGAOz+jiD8D3d+pn/7Wrxdfwz+egV5rhCcEvP3w==
+yoastseo@^1.47.0:
+  version "1.47.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.47.0.tgz#3d9b80317f290187ea0bba7370c2625cf069ec99"
+  integrity sha512-SPDrQ/G6zNpjSz6a1o7qhEJN1eceJUFaSYM9xngDaLLs1YOXYu4tyXge9knlNPiC/dBpxJF5bEuigcuJ9llfyQ==
   dependencies:
     "@wordpress/autop" "^2.0.2"
     htmlparser2 "^3.9.2"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-user-facing] Version bump for YoastSEO (to 1.47.0)

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* See: https://github.com/Yoast/Wiki/wiki/Testing-YoastSEO.js-version-bumps-on-Yoast-Components

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

Fixes #
