### PR TITLE
Let makeOutboundLink handle rel attribute automatically.

### DIFF
--- a/app/ComponentsExample.js
+++ b/app/ComponentsExample.js
@@ -49,6 +49,7 @@ const CourseListItem = styled.li`
 	}
 `;
 
+const CornerstoneLink    = makeOutboundLink();
 const NonYoastLink       = makeOutboundLink();
 const YoastLink          = makeOutboundLink();
 const YoastShortLink     = makeOutboundLink();
@@ -139,11 +140,10 @@ export default class ComponentsExample extends React.Component {
 					<YoastWarning
 						message={ [
 							"This is a warning message that also accepts arrays, so you can pass links such as ",
-							<a
+							<CornerstoneLink
 								key="1"
 								href="https://yoa.st/metabox-help-cornerstone"
-								target="_blank"
-							>cornerstone content</a>,
+							>cornerstone content</CornerstoneLink>,
 							", for example.",
 							<p key="2">This spans to multiple lines.</p>,
 						] }

--- a/app/ComponentsExample.js
+++ b/app/ComponentsExample.js
@@ -7,6 +7,7 @@ import { FullHeightCard } from "../composites/CoursesOverview/Card";
 import CardDetails from "../composites/CoursesOverview/CardDetails";
 import getCourseFeed from "../utils/getCourseFeed";
 import { getRtlStyle } from "../utils/helpers/styled-components";
+import { makeOutboundLink } from "../utils/makeOutboundLink";
 
 const Container = styled.div`
 	max-width: 1024px;
@@ -47,6 +48,11 @@ const CourseListItem = styled.li`
 		margin: ${ getRtlStyle( "0 16px 16px 0", "0 0 16px 16px" ) };
 	}
 `;
+
+const NonYoastLink       = makeOutboundLink();
+const YoastLink          = makeOutboundLink();
+const YoastShortLink     = makeOutboundLink();
+const YoastLinkCustomRel = makeOutboundLink();
 
 /**
  * Renders the yoast-component Components Examples.
@@ -142,6 +148,23 @@ export default class ComponentsExample extends React.Component {
 							<p key="2">This spans to multiple lines.</p>,
 						] }
 					/>
+					<h2>Outbound links</h2>
+					<p>
+						<NonYoastLink href="http://www.example.org">example.org</NonYoastLink>
+						<br /><small>expected: target=&quot;_blank&quot; rel=&quot;noopener&quot; and visually hidden message</small>
+					</p>
+					<p>
+						<YoastLink href="https://yoast.com">yoast.com</YoastLink>
+						<br /><small>expected: target=&quot;_blank&quot; and visually hidden message</small>
+					</p>
+					<p>
+						<YoastShortLink href="https://yoa.st/why-permalinks/">yoa.st/why-permalinks</YoastShortLink>
+						<br /><small>expected: target=&quot;_blank&quot; and visually hidden message</small>
+					</p>
+					<p>
+						<YoastLinkCustomRel href="https://yoast.com/" rel="bookmark nofollow">yoast.com (custom rel attribute)</YoastLinkCustomRel>
+						<br /><small>expected: target=&quot;_blank&quot; rel=&quot;bookmark nofollow&quot; and visually hidden message</small>
+					</p>
 				</Container>
 				<h2>Courses overview cards</h2>
 				<p>Full width example to test the cards wrapping.</p>
@@ -160,6 +183,7 @@ export default class ComponentsExample extends React.Component {
 										courseUrl={ course.link }
 										readMoreLinkText={ course.readMoreLinkText }
 										ctaButtonData={ this.getButtonData( course ) }
+										isBundle={ course.isBundle }
 									/>
 								</FullHeightCard>
 							</CourseListItem>

--- a/app/SidebarCollapsibleWrapper.js
+++ b/app/SidebarCollapsibleWrapper.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import Collapsible, { StyledIconsButton } from "../composites/Plugin/Shared/components/Collapsible";
 import colors from "../style-guide/colors.json";
+import { makeOutboundLink } from "../utils/makeOutboundLink";
 
 const FullWidthContaniner = styled.div`
 	max-width: 1024px;
@@ -57,6 +58,8 @@ const StyledContent = styled.div`
 		margin-bottom: 0;
 	}
 `;
+
+const GoToYoastLink = makeOutboundLink();
 
 /**
  * Returns the SidebarCollapsibleWrapper component.
@@ -126,8 +129,7 @@ export default function SidebarCollapsibleWrapper() {
 					>
 						<StyledContent>
 							<p>
-								Maybe some help text here with a link
-								 <a target="_blank" rel="noopener noreferrer" href="https://yoast.com">Go to Yoast</a>
+								Maybe some help text here with a link <GoToYoastLink href="https://yoast.com">Go to Yoast</GoToYoastLink>
 							</p>
 						</StyledContent>
 					</StyledCollapsible>

--- a/app/UIControlsWrapper.js
+++ b/app/UIControlsWrapper.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import Checkbox from "../composites/Plugin/Shared/components/Checkbox";
 import Toggle from "../composites/Plugin/Shared/components/Toggle";
 import CornerstoneToggle from "../composites/Plugin/CornerstoneContent/components/CornerstoneToggle.js";
+import { makeOutboundLink } from "../utils/makeOutboundLink";
 
 const Container = styled.div`
 	max-width: 1024px;
@@ -15,6 +16,8 @@ const Container = styled.div`
 const Separator = styled.hr`
 	margin: 1em 0;
 `;
+
+const CornerstoneLink = makeOutboundLink();
 
 /**
  * Renders the yoast-component UI Controls.
@@ -74,12 +77,7 @@ export default class UIControlsList extends React.Component {
 					id="example-checkbox"
 					label={ [
 						"This is a label that also accepts arrays, so you can pass links such as ",
-						<a
-							key="1"
-							href="https://yoa.st/metabox-help-cornerstone?utm_content=7.0.3"
-							target="_blank"
-							rel="noopener noreferrer"
-						>cornerstone content</a>,
+						<CornerstoneLink key="1" href="https://yoa.st/metabox-help-cornerstone">cornerstone content</CornerstoneLink>,
 						", for example.",
 					] }
 					// eslint-disable-next-line no-console

--- a/composites/AlgoliaSearch/SearchResultDetail.js
+++ b/composites/AlgoliaSearch/SearchResultDetail.js
@@ -86,8 +86,6 @@ class SearchResultDetail extends React.Component {
 				<RightYoastLinkButton
 					href={ this.props.post.permalink }
 					aria-label={ openButtonLabel }
-					target="_blank"
-					rel="noopener noreferrer"
 				>
 					{ openButtonText }
 					<SvgIcon

--- a/composites/AlgoliaSearch/tests/__snapshots__/SearchResultDetailTest.js.snap
+++ b/composites/AlgoliaSearch/tests/__snapshots__/SearchResultDetailTest.js.snap
@@ -172,7 +172,7 @@ exports[`the SearchResultDetail component matches the snapshot 1`] = `
       aria-label="Open the knowledge base article in a new window or read it in the iframe below"
       className="c5 c2 c6"
       href="https://kb.yoast.com/kb/passive-voice/"
-      rel="noopener noreferrer"
+      rel={null}
       target="_blank"
     >
       View in KB

--- a/composites/CoursesOverview/Card.js
+++ b/composites/CoursesOverview/Card.js
@@ -71,7 +71,7 @@ class Card extends React.Component {
 
 		if ( this.props.header.link ) {
 			return (
-				<OutboundHeaderLink href={ this.props.header.link } rel={ null }>
+				<OutboundHeaderLink href={ this.props.header.link }>
 					<HeaderImage src={ this.props.header.image } alt="" />
 					<HeaderTitle>{ this.props.header.title }</HeaderTitle>
 				</OutboundHeaderLink>

--- a/composites/CoursesOverview/CardDetails.js
+++ b/composites/CoursesOverview/CardDetails.js
@@ -140,7 +140,7 @@ class CardDetails extends React.Component {
 	 * Returns the correct Action Block based on whether an item is a bundle or a single course.
 	 *
 	 * @param {string} buttonType The type of the button. Either regular or sale.
-	 * @param {boolean} isBundle True when the it's a bundle.
+	 * @param {string} isBundle   Whether the item is a bundle. Default: empty string.
 	 *
 	 * @returns {ReactElement} The ActionBlock component.
 	 */
@@ -150,16 +150,16 @@ class CardDetails extends React.Component {
 		// Bundles don't have an OutboundInfoLink and use a different property from the feed for the OutboundLinkButton.
 		if ( isBundle === "true" ) {
 			return <ActionBlock>
-				<OutboundLinkButton href={ this.props.courseUrl } rel={ null }>
+				<OutboundLinkButton href={ this.props.courseUrl }>
 					{ this.props.ctaButtonData.ctaButtonCopy }
 				</OutboundLinkButton>
 			</ActionBlock>;
 		}
 		return <ActionBlock>
-			<OutboundLinkButton href={ this.props.ctaButtonData.ctaButtonUrl } rel={ null }>
+			<OutboundLinkButton href={ this.props.ctaButtonData.ctaButtonUrl }>
 				{ this.props.ctaButtonData.ctaButtonCopy }
 			</OutboundLinkButton>
-			<OutboundInfoLink href={ this.props.courseUrl } rel={ null }>
+			<OutboundInfoLink href={ this.props.courseUrl }>
 				{ this.props.readMoreLinkText }
 			</OutboundInfoLink>
 		</ActionBlock>;
@@ -173,7 +173,7 @@ CardDetails.propTypes = {
 	courseUrl: PropTypes.string,
 	ctaButtonData: PropTypes.object,
 	readMoreLinkText: PropTypes.string,
-	isBundle: PropTypes.bool,
+	isBundle: PropTypes.string,
 };
 
 CardDetails.defaultProps = {
@@ -181,5 +181,5 @@ CardDetails.defaultProps = {
 	courseUrl: "",
 	ctaButtonData: {},
 	readMoreLinkText: "",
-	isBundle: false,
+	isBundle: "",
 };

--- a/composites/CoursesOverview/tests/__snapshots__/CardDetailsTest.js.snap
+++ b/composites/CoursesOverview/tests/__snapshots__/CardDetailsTest.js.snap
@@ -179,94 +179,12 @@ Array [
       }
     />
   </div>,
-  .c2 {
-  border: 0;
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute !important;
-  width: 1px;
-  word-wrap: normal !important;
-  -webkit-transform: translateY(1em);
-  -ms-transform: translateY(1em);
-  transform: translateY(1em);
-}
-
-.c1 {
-  cursor: pointer;
-  color: #000;
-  white-space: nowrap;
-  display: block;
-  border-radius: 4px;
-  background-color: #fec228;
-  padding: 12px 16px;
-  box-shadow: inset 0 -4px 0 rgba(0,0,0,0.2);
-  border: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: bold;
-  font-size: inherit;
-  margin-top: 0;
-  margin-bottom: 8px;
-}
-
-.c1:hover,
-.c1:focus,
-.c1:active {
-  color: #000;
-  background: #f2ae01;
-}
-
-.c1:active {
-  -webkit-transform: translateY( 1px );
-  -ms-transform: translateY( 1px );
-  transform: translateY( 1px );
-  box-shadow: none;
-  -webkit-filter: none;
-  filter: none;
-}
-
-.c3 {
-  font-weight: bold;
-}
-
-.c0 {
+  .c0 {
   text-align: center;
 }
 
 <div
     className="c0"
-  >
-    <a
-      className="c1"
-      href={undefined}
-      rel={null}
-      target="_blank"
-    >
-      <span
-        className="c2"
-      >
-        (Opens in a new browser tab)
-      </span>
-    </a>
-    <a
-      className="c3"
-      href=""
-      rel={null}
-      target="_blank"
-    >
-      
-      <span
-        className="c2"
-      >
-        (Opens in a new browser tab)
-      </span>
-    </a>
-  </div>,
+  />,
 ]
 `;

--- a/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
+++ b/composites/HelpCenter/views/tests/__snapshots__/VideoTutorialTest.js.snap
@@ -118,7 +118,7 @@ exports[`the VideoTutorial component matches the snapshot 1`] = `
       <a
         className="c6"
         href="#1"
-        rel="noopener noreferrer"
+        rel="noopener"
         target="_blank"
       >
         Get Yoast SEO Premium now »
@@ -143,7 +143,7 @@ exports[`the VideoTutorial component matches the snapshot 1`] = `
       <a
         className="c6"
         href="#2"
-        rel="noopener noreferrer"
+        rel="noopener"
         target="_blank"
       >
         Get Yoast SEO Premium now »

--- a/composites/LinkSuggestions/composites/LinkSuggestion.js
+++ b/composites/LinkSuggestions/composites/LinkSuggestion.js
@@ -2,6 +2,9 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { localize } from "../../../utils/i18n";
+import { makeOutboundLink } from "../../../utils/makeOutboundLink";
+
+const SingleSuggestionLink = makeOutboundLink();
 
 /**
  * @summary Represents a suggestion component with a copy url to clipboard icon and a text value.
@@ -47,7 +50,7 @@ const LinkSuggestion = ( { value, url, isActive, translate } ) => {
 			>
 				<span className="screen-reader-text">{ label }</span>
 			</button>
-			<a href={ url } className="yoast-link-suggestion__value" target="_blank">{ value }</a>
+			<SingleSuggestionLink href={ url } className="yoast-link-suggestion__value">{ value }</SingleSuggestionLink>
 		</div>
 	);
 };

--- a/composites/OnboardingWizard/OnboardingWizard.js
+++ b/composites/OnboardingWizard/OnboardingWizard.js
@@ -1,19 +1,25 @@
+/* External dependencies */
 import React from "react";
 import PropTypes from "prop-types";
-import Step from "./Step";
-import StepIndicator from "./StepIndicator";
-import LoadingIndicator from "./LoadingIndicator";
-import sendStep from "./helpers/ajaxHelper";
 import RaisedButton from "material-ui/RaisedButton";
-import Header from "./Header";
 import MuiThemeProvider from "material-ui/styles/MuiThemeProvider";
-import { localize } from "../../utils/i18n";
-import muiTheme from "./config/yoast-theme";
 import interpolateComponents from "interpolate-components";
 import ArrowForwardIcon from "material-ui/svg-icons/navigation/arrow-forward";
 import ArrowBackwardIcon from "material-ui/svg-icons/navigation/arrow-back";
 import CloseIcon from "material-ui/svg-icons/navigation/close";
 import isUndefined from "lodash/isUndefined";
+
+/* Internal dependencies */
+import { localize } from "../../utils/i18n";
+import muiTheme from "./config/yoast-theme";
+import Header from "./Header";
+import Step from "./Step";
+import StepIndicator from "./StepIndicator";
+import LoadingIndicator from "./LoadingIndicator";
+import sendStep from "./helpers/ajaxHelper";
+import { makeOutboundLink } from "../../utils/makeOutboundLink";
+
+const BugReportLink = makeOutboundLink();
 
 /**
  * The OnboardingWizard class.
@@ -190,7 +196,7 @@ class OnboardingWizard extends React.Component {
 				),
 				// The anchor does have content (see mixedString above).
 				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				components: { link: <a href="https://yoa.st/bugreport" target="_blank" rel="noopener noreferrer" /> },
+				components: { link: <BugReportLink href="https://yoa.st/bugreport" /> },
 			} ),
 		} );
 	}

--- a/composites/Plugin/DashboardWidget/components/WordpressFeed.js
+++ b/composites/Plugin/DashboardWidget/components/WordpressFeed.js
@@ -72,7 +72,6 @@ const WordpressFeedListItem = ( props ) => {
 			<WordpressFeedLink
 				className={ `${ props.className }-link` }
 				href={ props.link }
-				rel={ null }
 			>
 				{ props.title }
 			</WordpressFeedLink>
@@ -132,7 +131,6 @@ const WordpressFeed = ( props ) => {
 					<WordpressFeedLink
 						className={ `${ props.className }__footer-link` }
 						href={ props.feedLink ? props.feedLink : props.feed.link }
-						rel={ null }
 					>
 						{ props.footerLinkText }
 					</WordpressFeedLink>

--- a/composites/Plugin/Shared/tests/__snapshots__/LanguageNoticeTest.js.snap
+++ b/composites/Plugin/Shared/tests/__snapshots__/LanguageNoticeTest.js.snap
@@ -56,7 +56,7 @@ exports[`LanguageNotice matches the snapshot with a changed language link 1`] = 
   <a
     className="c1"
     href="http://www.example.com"
-    rel="noopener noreferrer"
+    rel="noopener"
     target="_blank"
   >
     Change language
@@ -107,7 +107,7 @@ exports[`LanguageNotice matches the snapshot with another language 1`] = `
   <a
     className="c1"
     href="http://www.example.com"
-    rel="noopener noreferrer"
+    rel="noopener"
     target="_blank"
   >
     Change language

--- a/utils/makeOutboundLink.js
+++ b/utils/makeOutboundLink.js
@@ -19,17 +19,50 @@ export const makeOutboundLink = ( Component = "a" ) => {
 	 */
 	class OutboundLink extends React.Component {
 		/**
+		 * Constructs the OutboundLink component.
+		 *
+		 * @param {Object} props The props for the snippet preview example.
+		 */
+		constructor( props ) {
+			super( props );
+			this.isYoastLink = this.isYoastLink.bind( this );
+		}
+
+		/**
+		 * Determines if a certain URL points to Yoast.
+		 *
+		 * @param {string} url The URL to test.
+		 * @returns {boolean} Whether or not the URL points to Yoast.
+		 */
+		isYoastLink( url ) {
+			return /yoast\.com|yoast\.test|yoa\.st/.test( url );
+		}
+
+		/**
 		 * Renders the component.
 		 *
 		 * @returns {ReactElement} The rendered component.
 		 */
 		render() {
+			if ( ! this.props.href ) {
+				return null;
+			}
+
+			const isYoastLink = this.isYoastLink( this.props.href );
+			/*
+			 * Set the target="_blank" and rel attributes. When a link doesn't point
+			 * to Yoast, we want just a "noopener" rel attribute value.
+			 * Instead, when a link does point to Yoast, we use the rel prop which
+			 * is null by default so it doesn't render. This way, it can be
+			 * overridden setting the prop, if necessary.
+			 */
 			const newProps = Object.assign(
+				{},
+				this.props,
 				{
 					target: "_blank",
-					rel: "noopener noreferrer",
+					rel: isYoastLink ? this.props.rel : "noopener",
 				},
-				this.props
 			);
 			// Use React.createElement instead of JSX because it can accept a string as a component parameter.
 			return React.createElement(
@@ -49,10 +82,14 @@ export const makeOutboundLink = ( Component = "a" ) => {
 		children: PropTypes.oneOfType( [
 			PropTypes.node,
 		] ),
+		href: PropTypes.string,
+		rel: PropTypes.string,
 	};
 
 	OutboundLink.defaultProps = {
 		children: null,
+		href: null,
+		rel: null,
 	};
 
 	return OutboundLink;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improve handling of the `rel` attribute for links that open in a new browser's tab

## Relevant technical choices:
- tests for links that point to Yoast and handles the `rel` attribute automatically
- removes the explicitly passed props `rel={ null }` as they're no longer necessary
- uses `makeOutboundLink` instead of hardcoded links where necessary
- fixes a prop type

As per [Yoast/wordpress-seo#4605 (comment)](https://github.com/Yoast/wordpress-seo/issues/4605#issuecomment-425409923), the desired behavior is:

* use `noopener` for all the non-yoast.com external links
* omit it for the yoast.com links (including shortened links)

## Test instructions

This PR can be tested by following these steps:
- go in the standalone app > "Components" tab
- in the section "Outbound links" there are a few link examples
- check the output is the expected one
- optionally: check links in components that use `makeOutboundLink` e.g.:
  - the links in the Dashboard Widget
  - the change language link in content analysis
  - the link in the Checkbox (UI controls tab)

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

Fixes #828 
