### PR TITLE
Bump yoastseojs to 1.48

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "styled-components": "^2.1.2",
     "whatwg-fetch": "^1.0.0",
     "wicked-good-xpath": "^1.3.0",
-    "yoastseo": "git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.7"
+    "yoastseo": "^1.48.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10515,9 +10515,10 @@ yeoman-generator@^2.0.4:
     through2 "^2.0.0"
     yeoman-environment "^2.0.5"
 
-"yoastseo@git+https://github.com/Yoast/YoastSEO.js.git#release-yoast-seo/9.7":
-  version "1.46.0"
-  resolved "git+https://github.com/Yoast/YoastSEO.js.git#9f5f0071110b1dae18447512790958f1830ab6e7"
+yoastseo@^1.48.0:
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.48.0.tgz#47f41ae7cd1d1de3ce3823a7bf82b31aeab092fa"
+  integrity sha512-SpoOYK8Yx+3KGZDbV/zJZkN26Q4lX5B+yp8OmyX8mJs7Zzn5Yb5dokvAXPFTcr9NuUS+jiCzv00R9yCKZpTuKw==
   dependencies:
     "@wordpress/autop" "^2.0.2"
     htmlparser2 "^3.9.2"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-user-facing] Version bump for YoastSEO (to 1.48.0)

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* See: https://github.com/Yoast/Wiki/wiki/Testing-YoastSEO.js-version-bumps-on-Yoast-Components

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

Fixes #
